### PR TITLE
🧹 Refactor database schema initialization

### DIFF
--- a/src/mnemo_mcp/sql.py
+++ b/src/mnemo_mcp/sql.py
@@ -1,0 +1,66 @@
+"""SQL queries and schema definitions for Mnemo MCP."""
+
+INIT_MEMORIES_TABLE = """
+            CREATE TABLE IF NOT EXISTS memories (
+                id TEXT PRIMARY KEY NOT NULL,
+                content TEXT NOT NULL,
+                category TEXT NOT NULL DEFAULT 'general',
+                tags TEXT NOT NULL DEFAULT '[]',
+                source TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                access_count INTEGER NOT NULL DEFAULT 0,
+                last_accessed TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_memories_category
+                ON memories(category);
+            CREATE INDEX IF NOT EXISTS idx_memories_updated
+                ON memories(updated_at);
+            CREATE INDEX IF NOT EXISTS idx_memories_accessed
+                ON memories(last_accessed);
+"""
+
+INIT_FTS_TABLE = """
+            CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts
+            USING fts5(
+                id UNINDEXED,
+                content,
+                category UNINDEXED,
+                tags,
+                content=memories,
+                content_rowid=rowid,
+                tokenize='porter unicode61'
+            )
+"""
+
+INIT_FTS_TRIGGERS = """
+            CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+                INSERT INTO memories_fts(rowid, id, content, tags)
+                VALUES (new.rowid, new.id, new.content, new.tags);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+                INSERT INTO memories_fts(memories_fts, rowid, id, content, tags)
+                VALUES ('delete', old.rowid, old.id, old.content, old.tags);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+                INSERT INTO memories_fts(memories_fts, rowid, id, content, tags)
+                VALUES ('delete', old.rowid, old.id, old.content, old.tags);
+                INSERT INTO memories_fts(rowid, id, content, tags)
+                VALUES (new.rowid, new.id, new.content, new.tags);
+            END;
+"""
+
+CHECK_VEC_TABLE_EXISTS = (
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='memories_vec'"
+)
+
+INIT_VEC_TABLE_TEMPLATE = """
+                    CREATE VIRTUAL TABLE memories_vec
+                    USING vec0(
+                        id TEXT PRIMARY KEY,
+                        embedding float[{dims}]
+                    )
+"""

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.0b7"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Moved hardcoded SQL queries from `_init_schema` in `src/mnemo_mcp/db.py` to `src/mnemo_mcp/sql.py` constants. This improves readability and maintainability by separating SQL logic from Python code. Verified with `pytest` and `ruff`.

---
*PR created automatically by Jules for task [10993080391091733760](https://jules.google.com/task/10993080391091733760) started by @n24q02m*