### PR TITLE
🔒 Fix Path Traversal vulnerability in sync_folder configuration

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -9,6 +9,7 @@ MCP Interface:
 """
 
 import json
+import os
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -426,6 +427,19 @@ async def config(
                     sys.stderr,
                     level=settings.log_level,
                 )
+            elif key == "sync_folder":
+                # Security check: prevent path traversal
+                if (
+                    os.path.isabs(value)
+                    or value.startswith("/")
+                    or ".." in value.replace("\\", "/").split("/")
+                ):
+                    return _json(
+                        {
+                            "error": "Invalid sync_folder: Must be a relative path and cannot contain .. (parent directory traversal)"
+                        }
+                    )
+                settings.sync_folder = value
             else:
                 setattr(settings, key, value)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -246,6 +246,46 @@ class TestConfigTool:
         )
         assert result["status"] == "updated"
 
+    async def test_set_invalid_sync_folder(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        # Test traversal
+        result = json.loads(
+            await config(
+                action="set",
+                key="sync_folder",
+                value="../../etc",
+                ctx=ctx,
+            )
+        )
+        assert "error" in result
+        assert "Invalid sync_folder" in result["error"]
+
+        # Test absolute path
+        result = json.loads(
+            await config(
+                action="set",
+                key="sync_folder",
+                value="/absolute/path",
+                ctx=ctx,
+            )
+        )
+        assert "error" in result
+        assert "Invalid sync_folder" in result["error"]
+
+    async def test_set_valid_sync_folder_complex(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        # Valid relative path with subfolders
+        result = json.loads(
+            await config(
+                action="set",
+                key="sync_folder",
+                value="backups/mnemo",
+                ctx=ctx,
+            )
+        )
+        assert result["status"] == "updated"
+        assert result["value"] == "backups/mnemo"
+
     async def test_set_invalid_key(self, ctx_with_db):
         ctx, _ = ctx_with_db
         result = json.loads(

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.0b7"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** Fixed a Path Traversal vulnerability in `src/mnemo_mcp/server.py` where the `sync_folder` setting could be set to arbitrary paths (e.g., `../../etc`), potentially allowing unauthorized file access or manipulation via rclone sync operations.

⚠️ **Risk:** If left unfixed, an attacker with access to the MCP server configuration could traverse the directory structure and potentially overwrite or exfiltrate sensitive files on the host system or remote storage.

🛡️ **Solution:**
- Added strict validation logic in `config` tool's `set` action for `sync_folder`.
- The validation rejects:
  - Absolute paths (using `os.path.isabs` and checking for leading `/`).
  - Paths containing `..` components (by splitting path segments).
- Added comprehensive tests in `tests/test_server.py` covering both invalid (traversal, absolute) and valid inputs.
- Verified the fix with a reproduction script and ran the full test suite (`uv run pytest`) with 100% pass rate.

---
*PR created automatically by Jules for task [17212821108770612638](https://jules.google.com/task/17212821108770612638) started by @n24q02m*