### PR TITLE
Refactor memory tool into handler functions

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -181,7 +181,14 @@ async def _embed(text: str, model: str | None, dims: int) -> list[float] | None:
 # --- Tools ---
 
 
-async def _handle_add(db: MemoryDB, embedding_model: str | None, embedding_dims: int, content: str | None, category: str | None, tags: list[str] | None) -> str:
+async def _handle_add(
+    db: MemoryDB,
+    embedding_model: str | None,
+    embedding_dims: int,
+    content: str | None,
+    category: str | None,
+    tags: list[str] | None,
+) -> str:
     if not content:
         return _json({"error": "content is required for add"})
 
@@ -202,7 +209,15 @@ async def _handle_add(db: MemoryDB, embedding_model: str | None, embedding_dims:
     )
 
 
-async def _handle_search(db: MemoryDB, embedding_model: str | None, embedding_dims: int, query: str | None, category: str | None, tags: list[str] | None, limit: int) -> str:
+async def _handle_search(
+    db: MemoryDB,
+    embedding_model: str | None,
+    embedding_dims: int,
+    query: str | None,
+    category: str | None,
+    tags: list[str] | None,
+    limit: int,
+) -> str:
     if not query:
         return _json({"error": "query is required for search"})
 
@@ -236,7 +251,15 @@ async def _handle_list(db: MemoryDB, category: str | None, limit: int) -> str:
     )
 
 
-async def _handle_update(db: MemoryDB, embedding_model: str | None, embedding_dims: int, memory_id: str | None, content: str | None, category: str | None, tags: list[str] | None) -> str:
+async def _handle_update(
+    db: MemoryDB,
+    embedding_model: str | None,
+    embedding_dims: int,
+    memory_id: str | None,
+    content: str | None,
+    category: str | None,
+    tags: list[str] | None,
+) -> str:
     if not memory_id:
         return _json({"error": "memory_id is required for update"})
 
@@ -290,7 +313,9 @@ async def _handle_import(db: MemoryDB, data: str | None, mode: str) -> str:
     )
 
 
-async def _handle_stats(db: MemoryDB, embedding_model: str | None, embedding_dims: int) -> str:
+async def _handle_stats(
+    db: MemoryDB, embedding_model: str | None, embedding_dims: int
+) -> str:
     s = db.stats()
     s["embedding_model"] = embedding_model
     s["embedding_dims"] = embedding_dims
@@ -334,16 +359,22 @@ async def memory(
 
     match action:
         case "add":
-            return await _handle_add(db, embedding_model, embedding_dims, content, category, tags)
+            return await _handle_add(
+                db, embedding_model, embedding_dims, content, category, tags
+            )
 
         case "search":
-            return await _handle_search(db, embedding_model, embedding_dims, query, category, tags, limit)
+            return await _handle_search(
+                db, embedding_model, embedding_dims, query, category, tags, limit
+            )
 
         case "list":
             return await _handle_list(db, category, limit)
 
         case "update":
-            return await _handle_update(db, embedding_model, embedding_dims, memory_id, content, category, tags)
+            return await _handle_update(
+                db, embedding_model, embedding_dims, memory_id, content, category, tags
+            )
 
         case "delete":
             return await _handle_delete(db, memory_id)

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.2"
+version = "0.1.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Refactored the `memory` tool function in `src/mnemo_mcp/server.py` to reduce its cyclomatic complexity.

**What:**
- Extracted the logic for each action (`add`, `search`, `list`, `update`, `delete`, `export`, `import`, `stats`) into separate asynchronous handler functions:
    - `_handle_add`
    - `_handle_search`
    - `_handle_list`
    - `_handle_update`
    - `_handle_delete`
    - `_handle_export`
    - `_handle_import`
    - `_handle_stats`
- Updated the main `memory` function to dispatch calls to these handlers.

**Why:**
- The original `memory` function was becoming too long and complex, making it difficult to maintain and test.
- Breaking it down into smaller functions improves readability and allows for easier testing of individual actions in the future.

**Verification:**
- Ran existing tests using `pytest tests/test_server.py` and `pytest`. All tests passed.
- Verified that no functionality was changed, only the structure of the code.


---
*PR created automatically by Jules for task [908883923152057481](https://jules.google.com/task/908883923152057481) started by @n24q02m*