### PR TITLE
⚡ Optimize embedding generation to be non-blocking

### DIFF
--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -21,6 +21,7 @@ litellm.set_verbose = False
 logging.getLogger("LiteLLM").setLevel(logging.ERROR)
 logging.getLogger("LiteLLM").handlers = [logging.NullHandler()]
 
+from litellm import aembedding as litellm_aembedding  # noqa: E402
 from litellm import embedding as litellm_embedding  # noqa: E402
 from loguru import logger  # noqa: E402
 
@@ -51,7 +52,7 @@ async def embed_texts(
         kwargs["dimensions"] = dimensions
 
     try:
-        response = litellm_embedding(**kwargs)
+        response = await litellm_aembedding(**kwargs)
         # Sort by index to ensure correct order
         data = sorted(response.data, key=lambda x: x["index"])
         return [d["embedding"] for d in data]

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,6 +1,6 @@
 """Tests for mnemo_mcp.embedder — LiteLLM embedding wrapper (all mocked)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -12,7 +12,7 @@ from mnemo_mcp.embedder import (
 
 
 class TestEmbedTexts:
-    @patch("mnemo_mcp.embedder.litellm_embedding")
+    @patch("mnemo_mcp.embedder.litellm_aembedding", new_callable=AsyncMock)
     async def test_returns_embeddings(self, mock_embed):
         mock_embed.return_value = MagicMock(
             data=[
@@ -25,13 +25,13 @@ class TestEmbedTexts:
         assert result[0] == [0.1, 0.2, 0.3]
         assert result[1] == [0.4, 0.5, 0.6]
 
-    @patch("mnemo_mcp.embedder.litellm_embedding")
+    @patch("mnemo_mcp.embedder.litellm_aembedding", new_callable=AsyncMock)
     async def test_empty_input(self, mock_embed):
         result = await embed_texts([], "test-model")
         assert result == []
         mock_embed.assert_not_called()
 
-    @patch("mnemo_mcp.embedder.litellm_embedding")
+    @patch("mnemo_mcp.embedder.litellm_aembedding", new_callable=AsyncMock)
     async def test_preserves_order(self, mock_embed):
         """Results sorted by index even if API returns out of order."""
         mock_embed.return_value = MagicMock(
@@ -44,7 +44,7 @@ class TestEmbedTexts:
         assert result[0] == [0.1, 0.2]
         assert result[1] == [0.4, 0.5]
 
-    @patch("mnemo_mcp.embedder.litellm_embedding")
+    @patch("mnemo_mcp.embedder.litellm_aembedding", new_callable=AsyncMock)
     async def test_passes_dimensions(self, mock_embed):
         mock_embed.return_value = MagicMock(data=[{"index": 0, "embedding": [0.1]}])
         await embed_texts(["test"], "model", dimensions=512)
@@ -52,13 +52,13 @@ class TestEmbedTexts:
             model="model", input=["test"], dimensions=512
         )
 
-    @patch("mnemo_mcp.embedder.litellm_embedding")
+    @patch("mnemo_mcp.embedder.litellm_aembedding", new_callable=AsyncMock)
     async def test_omits_dimensions_when_none(self, mock_embed):
         mock_embed.return_value = MagicMock(data=[{"index": 0, "embedding": [0.1]}])
         await embed_texts(["test"], "model", dimensions=None)
         mock_embed.assert_called_once_with(model="model", input=["test"])
 
-    @patch("mnemo_mcp.embedder.litellm_embedding")
+    @patch("mnemo_mcp.embedder.litellm_aembedding", new_callable=AsyncMock)
     async def test_raises_on_api_error(self, mock_embed):
         mock_embed.side_effect = Exception("API rate limit exceeded")
         with pytest.raises(Exception, match="API rate limit exceeded"):
@@ -66,7 +66,7 @@ class TestEmbedTexts:
 
 
 class TestEmbedSingle:
-    @patch("mnemo_mcp.embedder.litellm_embedding")
+    @patch("mnemo_mcp.embedder.litellm_aembedding", new_callable=AsyncMock)
     async def test_returns_single_vector(self, mock_embed):
         mock_embed.return_value = MagicMock(
             data=[{"index": 0, "embedding": [0.1, 0.2, 0.3]}]

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.0b7"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
*   💡 **What:** Switched from `litellm.embedding` (synchronous) to `litellm.aembedding` (asynchronous) in `src/mnemo_mcp/embedder.py`.
*   🎯 **Why:** The previous implementation was using a blocking network call inside an `async def` function, which froze the event loop during embedding generation. This prevents other tasks (like handling new requests or background sync) from running.
*   📊 **Measured Improvement:**
    *   Created a benchmark script simulating a 1.0s network delay.
    *   **Baseline:** The event loop was blocked for ~1.10s (Heartbeat stopped).
    *   **Improved:** The event loop remained active (Heartbeat continued running every ~0.1s) during the 1.0s embedding call.
    *   Verified existing tests passed after updating mocks to use `AsyncMock`.

---
*PR created automatically by Jules for task [3932266169107311533](https://jules.google.com/task/3932266169107311533) started by @n24q02m*