### PR TITLE
Refactor embedding dimensions to use configurable model map

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -57,6 +57,15 @@ class Settings(BaseSettings):
         return self.get_db_path().parent
 
     # LiteLLM uses different env vars for embeddings vs completions
+    # Known dimensions for common models
+    _MODEL_DIMENSIONS: dict[str, int] = {
+        "gemini/text-embedding-004": 768,
+        "text-embedding-3-small": 1536,
+        "text-embedding-3-large": 3072,
+        "text-embedding-ada-002": 1536,
+        "mistral/mistral-embed": 1024,
+    }
+
     _ENV_ALIASES: dict[str, str] = {
         "GOOGLE_API_KEY": "GEMINI_API_KEY",
     }
@@ -116,6 +125,10 @@ class Settings(BaseSettings):
     def resolve_embedding_dims(self) -> int:
         """Return explicit EMBEDDING_DIMS or 0 for auto-detect."""
         return self.embedding_dims
+
+    def get_model_dims(self, model: str) -> int:
+        """Get known dimensions for a model, or default to 768."""
+        return self._MODEL_DIMENSIONS.get(model, 768)
 
 
 settings = Settings()

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -32,7 +32,6 @@ _EMBEDDING_CANDIDATES = [
 # Fixed embedding dimensions for sqlite-vec.
 # All embeddings are truncated to this size so switching models never
 # breaks the vector table. Override via EMBEDDING_DIMS env var.
-_DEFAULT_EMBEDDING_DIMS = 768
 
 # --- Lifespan ---
 
@@ -56,7 +55,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
         native_dims = check_embedding_available(embedding_model)
         if native_dims > 0:
             if embedding_dims == 0:
-                embedding_dims = _DEFAULT_EMBEDDING_DIMS
+                embedding_dims = settings.get_model_dims(embedding_model)
             logger.info(
                 f"Embedding: {embedding_model} "
                 f"(native={native_dims}, stored={embedding_dims})"
@@ -75,7 +74,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
             if native_dims > 0:
                 embedding_model = candidate
                 if embedding_dims == 0:
-                    embedding_dims = _DEFAULT_EMBEDDING_DIMS
+                    embedding_dims = settings.get_model_dims(embedding_model)
                 logger.info(
                     f"Embedding: {embedding_model} "
                     f"(native={native_dims}, stored={embedding_dims})"

--- a/tests/test_config_dims.py
+++ b/tests/test_config_dims.py
@@ -1,0 +1,17 @@
+"""Tests for mnemo_mcp.config — Model dimensions."""
+
+from mnemo_mcp.config import Settings
+
+
+class TestModelDims:
+    def test_known_models(self):
+        s = Settings(api_keys=None)
+        assert s.get_model_dims("gemini/text-embedding-004") == 768
+        assert s.get_model_dims("text-embedding-3-small") == 1536
+        assert s.get_model_dims("text-embedding-3-large") == 3072
+        assert s.get_model_dims("text-embedding-ada-002") == 1536
+        assert s.get_model_dims("mistral/mistral-embed") == 1024
+
+    def test_unknown_model_default(self):
+        s = Settings(api_keys=None)
+        assert s.get_model_dims("unknown-model") == 768

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.0b7"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- Add `_MODEL_DIMENSIONS` map to `config.py` with known model dimensions.
- Implement `Settings.get_model_dims` to resolve dimensions based on model name, defaulting to 768.
- Update `server.py` to use `settings.get_model_dims` instead of hardcoded `_DEFAULT_EMBEDDING_DIMS`.
- Add tests in `tests/test_config_dims.py` to verify dimension resolution logic.

---
*PR created automatically by Jules for task [7123448409092730037](https://jules.google.com/task/7123448409092730037) started by @n24q02m*