### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize rclone subprocess environment

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Implemented environment variable sanitization for the `rclone` subprocess to prevent API key leakage.

- **Security Enhancement:** Created `_ENV_ALLOWLIST` with safe variables (PATH, HOME, TMP, etc.) and proxy settings.
- **Implementation:** Modified `_prepare_rclone_env` in `src/mnemo_mcp/sync.py` to use an allowlist strategy instead of copying the entire `os.environ`.
- **Testing:** Added unit test `test_env_sanitization` in `tests/test_sync.py` to ensure sensitive keys are blocked and allowed keys are preserved.
- **Verification:** Verified with `uv run pytest tests/test_sync.py` and full test suite.


---
*PR created automatically by Jules for task [9404545750118888186](https://jules.google.com/task/9404545750118888186) started by @n24q02m*