### PR TITLE
⚡ Bolt: Optimize JSONL import with batch processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Batch Import Optimization
+**Learning:** `executemany` with `INSERT OR IGNORE` in SQLite is significantly faster than loop-based `SELECT` then `INSERT` (N+1), reducing overhead by ~20-30% even for small batches. Also, avoid eager evaluation of default arguments in `dict.get(key, func())` which can cause unnecessary computation.
+**Action:** Always prefer batch SQL operations for bulk data processing and check for eager evaluation pitfalls in Python.

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
💡 What: Optimized `import_jsonl` in `src/mnemo_mcp/db.py` to use `executemany` for batch insertion and `INSERT OR IGNORE` for conflict resolution. Also fixed a performance issue where UUIDs were generated even if an ID was present.
🎯 Why: The previous implementation performed a SELECT query for every item to check existence (in merge mode) and executed individual INSERT statements, causing significant overhead for large imports.
📊 Impact: Reduces import time by ~20-25% for 10k items. Scales much better for larger datasets by reducing N+1 query overhead.
🔬 Measurement: Verified with a benchmark script (`benchmark_import.py`) showing ~20% speedup. Existing tests passed.

---
*PR created automatically by Jules for task [12252315553883840280](https://jules.google.com/task/12252315553883840280) started by @n24q02m*