### PR TITLE
fix: daily compliance audit 2026-02-15

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 python = "3.13"
 node = "24"
-uv = "latest"
+uv = "0.5.11"
 
 [settings]
 trusted_config_paths = ["."]

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.4b0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
=== DAILY AUDIT REPORT - mnemo-mcp - 2026-02-15 ===

Skills applied: repo-structure, security-practices, mcp-server, oci-vm-service

RESULTS:
[PASS] .gitignore: Correctly configured
[PASS] Pre-commit: Hooks present and correct (ruff, ty)
[PASS] CI/CD: CI runs tests/lint; CD uses workflow_dispatch (exception to release gate rule)
[PASS] Security: No hardcoded secrets found
[PASS] Docker: Uses specific tags and non-root user
[PASS] Code Standards: No emoji, no pandas, formatting compliant
[FIXED] .mise.toml: Pinned `uv` to `0.5.11` (was `latest`)
[FIXED] uv.lock: Updated to match current dependencies
[WARN] release-please: Repo uses `python-semantic-release` instead of `release-please`
[WARN] MCP Server: Tool naming uses dispatcher pattern (`memory`, `config`) instead of `service_action_resource`
[WARN] Test Workflow: Test naming follows `test_<action>_<condition>` but misses `_<expected>` suffix

SUMMARY: 6 passed, 2 fixed, 3 warnings, 0 failures


---
*PR created automatically by Jules for task [1736918394943673110](https://jules.google.com/task/1736918394943673110) started by @n24q02m*