### PR TITLE
fix: daily compliance audit 2026-02-16

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 python = "3.13"
 node = "24"
-uv = "latest"
+uv = "0.5.11"
 
 [settings]
 trusted_config_paths = ["."]

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -1,8 +1,10 @@
 """Configuration settings for Mnemo MCP Server."""
 
 import os
+import sys
 from pathlib import Path
 
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
@@ -23,6 +25,7 @@ class Settings(BaseSettings):
     - SYNC_REMOTE: Rclone remote name (e.g., "gdrive")
     - SYNC_FOLDER: Remote folder name (default: "mnemo-mcp")
     - SYNC_INTERVAL: Auto-sync interval in seconds (0 = manual only)
+    - LOG_JSON: Enable JSON logging (default: false)
     """
 
     # Database
@@ -44,6 +47,7 @@ class Settings(BaseSettings):
 
     # Logging
     log_level: str = "INFO"
+    log_json: bool = Field(default_factory=lambda: not sys.stderr.isatty())
 
     model_config = {"env_prefix": "", "case_sensitive": False}
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -476,6 +476,7 @@ async def config(
                 logger.add(
                     sys.stderr,
                     level=settings.log_level,
+                    serialize=settings.log_json,
                 )
             else:
                 setattr(settings, key, value)
@@ -576,7 +577,7 @@ def recall_context(topic: str) -> str:
 def main() -> None:
     """Run the MCP server."""
     logger.remove()
-    logger.add(sys.stderr, level=settings.log_level)
+    logger.add(sys.stderr, level=settings.log_level, serialize=settings.log_json)
     logger.info("Starting Mnemo MCP Server...")
 
     mcp.run()

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "0.1.4b0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
=== DAILY AUDIT REPORT - mnemo-mcp - 2026-02-16 ===

Skills applied: repo-structure, security-practices, test-workflow, mcp-server, observability.

RESULTS:
[FIXED] `mise.toml`: Updated `uv` version from `latest` to `0.5.11` to comply with fixed versioning rules.
[FIXED] `observability`: Added `log_json` configuration and support for structured logging (JSON).
  - Defaults to `True` in non-interactive environments (CI, Docker).
  - Defaults to `False` in interactive CLI sessions.
  - Can be forced via `LOG_JSON=true` environment variable.
[PASS] `repo-structure`: `mise.toml` versions (others), `pre-commit`, `CI` workflow.
[PASS] `mcp-server`: Tool annotations correct, naming (accepted deviation), error messages actionable.
[PASS] `test-workflow`: Tests exist and pass, naming conventions followed.
[PASS] `code-standards`: No emojis, no pandas, JSONL used.
[WARN] `docker`: `mem_limit` not specified (runtime config).
[WARN] `release-please`: Uses `python-semantic-release` (acceptable alternative).

SUMMARY: 4 passed, 2 fixed, 2 warnings.


---
*PR created automatically by Jules for task [14086867467607895864](https://jules.google.com/task/14086867467607895864) started by @n24q02m*