### PR TITLE
🛡️ Sentinel: Validate sync configuration inputs to prevent injection and traversal

### DIFF
--- a/tests/test_security_config.py
+++ b/tests/test_security_config.py
@@ -1,0 +1,64 @@
+"""Security tests for configuration validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from mnemo_mcp.config import Settings
+
+
+class TestSecurityConfig:
+    def test_sync_remote_injection(self):
+        """Ensure sync_remote cannot start with '-' to prevent argument injection."""
+        with pytest.raises(ValidationError) as exc:
+            Settings(sync_remote="-bad-remote")
+        assert "sync_remote" in str(exc.value)
+
+    def test_sync_remote_special_chars(self):
+        """Ensure sync_remote only contains alphanumeric chars, dashes, underscores, and dots."""
+        invalid_remotes = [
+            "remote; rm -rf /",
+            "remote | bash",
+            "remote&",
+            "remote$(whoami)",
+        ]
+        for remote in invalid_remotes:
+            with pytest.raises(ValidationError) as exc:
+                Settings(sync_remote=remote)
+            assert "sync_remote" in str(exc.value)
+
+    def test_sync_remote_valid(self):
+        """Ensure valid remotes are accepted."""
+        valid_remotes = [
+            "gdrive",
+            "my-remote",
+            "my_remote",
+            "remote.1",
+            "USER_backup",
+        ]
+        for remote in valid_remotes:
+            s = Settings(sync_remote=remote)
+            assert s.sync_remote == remote
+
+    def test_sync_folder_traversal(self):
+        """Ensure sync_folder cannot contain traversal sequences."""
+        invalid_folders = [
+            "../parent",
+            "folder/../parent",
+            "..",
+            "/absolute/path",  # Should also reject absolute paths
+        ]
+        for folder in invalid_folders:
+            with pytest.raises(ValidationError) as exc:
+                Settings(sync_folder=folder)
+            assert "sync_folder" in str(exc.value)
+
+    def test_sync_folder_valid(self):
+        """Ensure valid folders are accepted."""
+        valid_folders = [
+            "mnemo-mcp",
+            "sub/folder",
+            "data_2024",
+        ]
+        for folder in valid_folders:
+            s = Settings(sync_folder=folder)
+            assert s.sync_folder == folder

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This patch hardens the application configuration by adding strict validation for `sync_remote` and `sync_folder` settings.

**Security Improvements:**
1.  **Command Injection Mitigation:** `sync_remote` is now validated to ensure it does not start with `-` (preventing flag injection in `rclone` commands) and only contains safe characters.
2.  **Path Traversal Prevention:** `sync_folder` is now validated to ensure it is a relative path and does not contain `..` sequences, preventing potential file system traversal during sync operations.

**Changes:**
- Modified `src/mnemo_mcp/config.py` to include `field_validator` logic.
- Added `tests/test_security_config.py` with comprehensive test cases.

**Verification:**
- New security tests pass.
- Existing tests pass (no regressions).

---
*PR created automatically by Jules for task [3105760601751186780](https://jules.google.com/task/3105760601751186780) started by @n24q02m*