### PR TITLE
🔒 Fix sensitive configuration modification vulnerability

### DIFF
--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -47,8 +47,6 @@ Change runtime settings. Changes persist for the current session.
 
 **Available settings:**
 - `sync_enabled`: Enable/disable sync ("true" / "false")
-- `sync_remote`: Rclone remote name
-- `sync_folder`: Remote folder name
 - `sync_interval`: Auto-sync interval in seconds (0 = manual)
 - `log_level`: Logging level ("DEBUG", "INFO", "WARNING", "ERROR")
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -483,8 +483,6 @@ async def config(
 
             valid_keys = {
                 "sync_enabled",
-                "sync_remote",
-                "sync_folder",
                 "sync_interval",
                 "log_level",
             }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -222,7 +222,7 @@ class TestConfigTool:
         assert "sync" in result
         assert "path" in result["database"]
 
-    async def test_set_valid_key(self, ctx_with_db):
+    async def test_set_sync_folder_rejected(self, ctx_with_db):
         ctx, _ = ctx_with_db
         result = json.loads(
             await config(
@@ -232,7 +232,21 @@ class TestConfigTool:
                 ctx=ctx,
             )
         )
-        assert result["status"] == "updated"
+        assert "error" in result
+        assert "valid_keys" in result
+
+    async def test_set_sync_remote_rejected(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = json.loads(
+            await config(
+                action="set",
+                key="sync_remote",
+                value="bad-remote",
+                ctx=ctx,
+            )
+        )
+        assert "error" in result
+        assert "valid_keys" in result
 
     async def test_set_sync_enabled(self, ctx_with_db):
         ctx, _ = ctx_with_db

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
**What:**
Fixed a security vulnerability where sensitive configuration settings (`sync_remote` and `sync_folder`) could be modified at runtime without authorization.

**Risk:**
Allowing runtime modification of these settings could enable an attacker (or compromised prompt) to redirect the data synchronization destination, potentially exfiltrating sensitive memory data to an attacker-controlled remote storage.

**Solution:**
Restricted the `config` tool's `set` action by removing `sync_remote` and `sync_folder` from the list of modifiable keys. These settings must now be configured via environment variables, which is safer for infrastructure-level configuration.
- Modified `src/mnemo_mcp/server.py` to enforce the allowlist.
- Updated `src/mnemo_mcp/docs/config.md` to reflect the changes.
- Updated `tests/test_server.py` to assert that modification attempts fail.

---
*PR created automatically by Jules for task [6881806165830129399](https://jules.google.com/task/6881806165830129399) started by @n24q02m*