### PR TITLE
🔒 Fix insecure rclone installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,7 @@ FROM python:3.13-slim-bookworm
 WORKDIR /app
 
 # Install rclone for sync support
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    unzip \
-    && curl -fsSL https://rclone.org/install.sh | bash \
-    && apt-get purge -y curl unzip \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+COPY --from=rclone/rclone:1.68.2 --chmod=755 /usr/local/bin/rclone /usr/bin/rclone
 
 # Copy virtual environment from builder
 COPY --from=builder /app/.venv /app/.venv

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Replaced the insecure `curl | bash` installation method for `rclone` in `Dockerfile` with a secure `COPY --from` pattern using the official `rclone/rclone:1.68.2` Docker image.

**Changes:**
- Removed `RUN` block installing `curl`, `unzip` and piping `install.sh` to bash.
- Added `COPY --from=rclone/rclone:1.68.2 --chmod=755 /usr/local/bin/rclone /usr/bin/rclone`.
- This pins the version to 1.68.2 (matching project default) and leverages Docker's built-in image verification and multi-arch support.
- Updated `uv.lock` as `uv run` synchronized dependencies.

**Verification:**
- Verified `Dockerfile` syntax and content.
- Ran full test suite (`uv run pytest`) with 190 tests passing.

---
*PR created automatically by Jules for task [13095304868924122138](https://jules.google.com/task/13095304868924122138) started by @n24q02m*