### PR TITLE
Refactor: Move Rclone version to configuration

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -58,6 +58,7 @@ class Settings(BaseSettings):
     - SYNC_REMOTE: Rclone remote name (e.g., "gdrive")
     - SYNC_FOLDER: Remote folder name (default: "mnemo-mcp")
     - SYNC_INTERVAL: Auto-sync interval in seconds (0 = manual only)
+    - RCLONE_VERSION: Rclone version to download (default: "v1.68.2")
     """
 
     # Database
@@ -78,6 +79,7 @@ class Settings(BaseSettings):
     sync_remote: str = ""  # rclone remote name
     sync_folder: str = "mnemo-mcp"
     sync_interval: int = 0  # seconds, 0 = manual only
+    rclone_version: str = "v1.68.2"
 
     # Logging
     log_level: str = "INFO"

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -72,6 +72,7 @@ Configure via environment variables before starting the server:
 | `SYNC_REMOTE` | (none) | Rclone remote name |
 | `SYNC_FOLDER` | `mnemo-mcp` | Remote folder name |
 | `SYNC_INTERVAL` | `0` | Auto-sync interval (seconds) |
+| `RCLONE_VERSION` | `v1.68.2` | Rclone version to download |
 | `LOG_LEVEL` | `INFO` | Log level |
 
 ### API_KEYS Format

--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from mnemo_mcp.db import MemoryDB
 
 # Rclone version to download
-_RCLONE_VERSION = "v1.68.2"
 
 # Background sync task reference
 _sync_task: asyncio.Task | None = None
@@ -110,8 +109,8 @@ async def _download_rclone() -> Path | None:
     Returns path to binary on success, None on failure.
     """
     os_name, arch, ext = _get_platform_info()
-    archive_name = f"rclone-{_RCLONE_VERSION}-{os_name}-{arch}.zip"
-    url = f"https://github.com/rclone/rclone/releases/download/{_RCLONE_VERSION}/{archive_name}"
+    archive_name = f"rclone-{settings.rclone_version}-{os_name}-{arch}.zip"
+    url = f"https://github.com/rclone/rclone/releases/download/{settings.rclone_version}/{archive_name}"
 
     install_dir = _get_rclone_dir()
     install_dir.mkdir(parents=True, exist_ok=True)
@@ -120,7 +119,7 @@ async def _download_rclone() -> Path | None:
     if target_path.exists():
         return target_path
 
-    logger.info(f"Downloading rclone {_RCLONE_VERSION} for {os_name}-{arch}...")
+    logger.info(f"Downloading rclone {settings.rclone_version} for {os_name}-{arch}...")
 
     try:
         async with httpx.AsyncClient(follow_redirects=True) as client:

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Moved the hardcoded Rclone version constant (`_RCLONE_VERSION`) from `src/mnemo_mcp/sync.py` to the `Settings` class in `src/mnemo_mcp/config.py`.

This change allows the Rclone version to be configured via the `RCLONE_VERSION` environment variable, improving maintainability and flexibility.

The default version remains `v1.68.2`.

Also updated `src/mnemo_mcp/docs/config.md` to document the new environment variable.

The `uv.lock` file was automatically updated by `uv` to reflect the current project state (syncing with `pyproject.toml` version).

Verified with:
- `uv run pytest tests/test_sync.py`
- `uv run ruff check .`
- `uv run ruff format .`

---
*PR created automatically by Jules for task [3364311553395939689](https://jules.google.com/task/3364311553395939689) started by @n24q02m*