### PR TITLE
⚡ Make check_available async to prevent blocking startup

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -59,7 +59,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
             # Explicit model -- validate it
             try:
                 backend = init_backend("litellm", embedding_model)
-                native_dims = backend.check_available()
+                native_dims = await backend.check_available()
                 if native_dims > 0:
                     if embedding_dims == 0:
                         embedding_dims = _DEFAULT_EMBEDDING_DIMS
@@ -78,7 +78,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
             for candidate in _EMBEDDING_CANDIDATES:
                 try:
                     backend = init_backend("litellm", candidate)
-                    native_dims = backend.check_available()
+                    native_dims = await backend.check_available()
                     if native_dims > 0:
                         embedding_model = candidate
                         if embedding_dims == 0:
@@ -100,7 +100,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
         local_model = settings.resolve_local_embedding_model()
         try:
             backend = init_backend("local", local_model)
-            native_dims = backend.check_available()
+            native_dims = await backend.check_available()
             if native_dims > 0:
                 embedding_model = "__local__"
                 if embedding_dims == 0:

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -69,16 +69,16 @@ class TestLiteLLMBackend:
         assert result == [0.1, 0.2, 0.3]
 
     @patch("litellm.embedding")
-    def test_check_available_returns_dims(self, mock_embed):
+    async def test_check_available_returns_dims(self, mock_embed):
         mock_embed.return_value = MagicMock(data=[{"embedding": [0.1, 0.2]}])
         backend = LiteLLMBackend("model")
-        assert backend.check_available() == 2
+        assert await backend.check_available() == 2
 
     @patch("litellm.embedding")
-    def test_check_available_error(self, mock_embed):
+    async def test_check_available_error(self, mock_embed):
         mock_embed.side_effect = Exception("Model not found")
         backend = LiteLLMBackend("model")
-        assert backend.check_available() == 0
+        assert await backend.check_available() == 0
 
     @patch("litellm.embedding")
     async def test_raises_on_non_retryable_error(self, mock_embed):
@@ -88,10 +88,10 @@ class TestLiteLLMBackend:
             await backend.embed_texts(["test"])
 
     @patch("litellm.embedding")
-    def test_check_available_empty_data(self, mock_embed):
+    async def test_check_available_empty_data(self, mock_embed):
         mock_embed.return_value = MagicMock(data=[])
         backend = LiteLLMBackend("model")
-        assert backend.check_available() == 0
+        assert await backend.check_available() == 0
 
 
 class TestBatchSplitting:
@@ -235,11 +235,11 @@ class TestQwen3EmbedBackend:
         assert result == [0.1, 0.2, 0.3]
 
     @patch("mnemo_mcp.embedder.Qwen3EmbedBackend._get_model")
-    def test_check_available_not_installed(self, mock_get_model):
+    async def test_check_available_not_installed(self, mock_get_model):
         """Returns 0 when qwen3-embed is not available."""
         mock_get_model.side_effect = ImportError("No module named 'qwen3_embed'")
         backend = Qwen3EmbedBackend()
-        assert backend.check_available() == 0
+        assert await backend.check_available() == 0
 
 
 class TestBackendFactory:
@@ -280,6 +280,6 @@ class TestLegacyCompat:
         assert result == [0.1, 0.2]
 
     @patch("litellm.embedding")
-    def test_check_available_legacy(self, mock_embed):
+    async def test_check_available_legacy(self, mock_embed):
         mock_embed.return_value = MagicMock(data=[{"embedding": [0.1]}])
-        assert check_embedding_available("model") == 1
+        assert await check_embedding_available("model") == 1

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
💡 **What:**
Refactored `EmbeddingBackend.check_available` and its implementations (`LiteLLMBackend`, `Qwen3EmbedBackend`) to be `async def`.
Wrapped the synchronous `litellm.embedding` call and local model loading/embedding in `asyncio.to_thread`.
Updated `src/mnemo_mcp/server.py` to `await backend.check_available()` during server startup.
Updated `tests/test_embedder.py` to await the async calls.

🎯 **Why:**
The `check_available` method performs network I/O (Litellm) or potentially heavy model loading (Local) synchronously. This blocks the main thread and the asyncio event loop during server startup, preventing other async tasks (like health checks or tickers) from running.

📊 **Measured Improvement:**
Created a reproduction script `reproduce_blocking.py` that runs an async ticker while initializing the backend.
**Baseline:** Ticker stopped printing during the 1-second mocked network call.
**After Fix:** Ticker continued printing at 0.1s intervals while `check_available` was waiting, proving the main thread is no longer blocked.

---
*PR created automatically by Jules for task [13184712796972752291](https://jules.google.com/task/13184712796972752291) started by @n24q02m*