### PR TITLE
Refactor: Split search logic into helper methods

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Refactored `src/mnemo_mcp/db.py` to extract complex search logic into private helper methods (`_search_fts`, `_search_vector`, `_filter_by_tags`, `_compute_hybrid_scores`, `_update_access_stats`). This improves readability and maintainability. Verified with existing tests.

---
*PR created automatically by Jules for task [6060157172182401071](https://jules.google.com/task/6060157172182401071) started by @n24q02m*