### PR TITLE
Sentinel: Validate sync config to prevent command injection and path traversal

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -18,6 +18,7 @@ from importlib import resources as pkg_resources
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import ValidationError
 
 from mnemo_mcp.config import settings
 from mnemo_mcp.db import MemoryDB
@@ -496,19 +497,31 @@ async def config(
                 )
 
             # Apply setting
-            if key == "sync_enabled":
-                settings.sync_enabled = value.lower() in ("true", "1", "yes")
-            elif key == "sync_interval":
-                settings.sync_interval = int(value)
-            elif key == "log_level":
-                settings.log_level = value.upper()
-                logger.remove()
-                logger.add(
-                    sys.stderr,
-                    level=settings.log_level,
-                )
-            else:
-                setattr(settings, key, value)
+            try:
+                if key == "sync_enabled":
+                    settings.sync_enabled = value.lower() in ("true", "1", "yes")
+                elif key == "sync_interval":
+                    settings.sync_interval = int(value)
+                elif key == "log_level":
+                    settings.log_level = value.upper()
+                    logger.remove()
+                    logger.add(
+                        sys.stderr,
+                        level=settings.log_level,
+                    )
+                else:
+                    setattr(settings, key, value)
+            except ValidationError as e:
+                # Format validation errors for the user
+                errors = []
+                for err in e.errors():
+                    msg = err.get("msg", "Invalid value")
+                    # loc is (key,)
+                    field = str(err["loc"][0]) if err["loc"] else key
+                    errors.append(f"{field}: {msg}")
+                return _json({"error": "Validation failed", "details": errors})
+            except ValueError as e:
+                return _json({"error": f"Invalid value for {key}: {str(e)}"})
 
             return _json(
                 {

--- a/tests/test_security_config.py
+++ b/tests/test_security_config.py
@@ -1,0 +1,65 @@
+"""Tests for security-related configuration validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from mnemo_mcp.config import Settings
+
+
+class TestSecurityConfig:
+    def test_sync_remote_validation(self):
+        """Test validation for sync_remote."""
+        s = Settings()
+
+        # Valid values
+        s.sync_remote = "gdrive"
+        s.sync_remote = "my-remote"
+        s.sync_remote = "remote_1"
+        s.sync_remote = "user.name"
+
+        # Invalid values
+        with pytest.raises(ValidationError) as exc:
+            s.sync_remote = "-gdrive"
+        assert "Remote name cannot start with '-'" in str(exc.value)
+
+        with pytest.raises(ValidationError) as exc:
+            s.sync_remote = "gdrive; rm -rf /"
+        assert "Remote name must contain only" in str(exc.value)
+
+    def test_sync_folder_validation(self):
+        """Test validation for sync_folder."""
+        s = Settings()
+
+        # Valid values
+        s.sync_folder = "mnemo"
+        s.sync_folder = "path/to/folder"
+        s.sync_folder = "my-folder_123"
+
+        # Invalid values
+        with pytest.raises(ValidationError) as exc:
+            s.sync_folder = "/etc/passwd"
+        assert "Folder must be a relative path" in str(exc.value)
+
+        with pytest.raises(ValidationError) as exc:
+            s.sync_folder = "../root"
+        assert "Folder path cannot contain '..' segments" in str(exc.value)
+
+        with pytest.raises(ValidationError) as exc:
+            s.sync_folder = "-folder"
+        assert "Folder name cannot start with '-'" in str(exc.value)
+
+        with pytest.raises(ValidationError) as exc:
+            s.sync_folder = "folder/../../root"
+        assert "Folder path cannot contain '..' segments" in str(exc.value)
+
+        with pytest.raises(ValidationError) as exc:
+            s.sync_folder = "folder|pipe"
+        assert "Folder path must contain only" in str(exc.value)
+
+    def test_init_validation(self):
+        """Test validation during initialization."""
+        with pytest.raises(ValidationError):
+            Settings(sync_remote="-bad")
+
+        with pytest.raises(ValidationError):
+            Settings(sync_folder="/bad")

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
**Vulnerability Fix: Command Injection & Path Traversal**

Identified that `sync_remote` and `sync_folder` settings were not validated, allowing potential attackers (or misconfiguration) to inject:
1.  **Command arguments:** e.g., setting `sync_remote` to `--config=/malicious.conf` could alter `rclone` behavior.
2.  **Path traversal:** e.g., setting `sync_folder` to `../root` could allow writing outside the intended directory.

**Changes:**
- Implemented strict validation in `Settings` using Pydantic.
- Updated `server.py` to handle validation errors gracefully.
- Added regression tests.


---
*PR created automatically by Jules for task [12526664669209220015](https://jules.google.com/task/12526664669209220015) started by @n24q02m*