### PR TITLE
⚡ Bolt: Optimize import_jsonl with executemany

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [SQLite Bulk Import]
+**Learning:** `executemany` with `INSERT OR IGNORE` in `sqlite3` correctly returns the count of *inserted* rows in `rowcount`. This allows efficient calculation of skipped duplicates (`total - rowcount`) without N+1 `SELECT` checks.
+**Action:** Use this pattern for all bulk data ingestion in SQLite.

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -580,6 +580,9 @@ class MemoryDB:
         skipped = 0
         rejected = 0
 
+        batch = []
+        now = _now_iso()
+
         for line in data.strip().split("\n"):
             line = line.strip()
             if not line:
@@ -598,25 +601,13 @@ class MemoryDB:
                 rejected += 1
                 continue
 
-            # Check if exists (for merge mode)
-            if mode == "merge":
-                existing = self.get(memory_id)
-                if existing:
-                    skipped += 1
-                    continue
-
             tags = mem.get("tags", [])
             if isinstance(tags, list):
                 tags_json = json.dumps(tags)
             else:
                 tags_json = tags
 
-            now = _now_iso()
-            self._conn.execute(
-                """INSERT OR REPLACE INTO memories
-                   (id, content, category, tags, source,
-                    created_at, updated_at, access_count, last_accessed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            batch.append(
                 (
                     memory_id,
                     content,
@@ -627,9 +618,33 @@ class MemoryDB:
                     mem.get("updated_at", now),
                     mem.get("access_count", 0),
                     mem.get("last_accessed", now),
-                ),
+                )
             )
-            imported += 1
+
+        if batch:
+            if mode == "merge":
+                # INSERT OR IGNORE skips existing primary keys
+                cursor = self._conn.executemany(
+                    """INSERT OR IGNORE INTO memories
+                       (id, content, category, tags, source,
+                        created_at, updated_at, access_count, last_accessed)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    batch,
+                )
+                # rowcount is number of inserted rows
+                imported = cursor.rowcount
+                skipped = len(batch) - imported
+            else:
+                # replace mode cleared table, so we just insert (or replace if dupes in batch)
+                cursor = self._conn.executemany(
+                    """INSERT OR REPLACE INTO memories
+                       (id, content, category, tags, source,
+                        created_at, updated_at, access_count, last_accessed)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    batch,
+                )
+                imported = cursor.rowcount
+                # skipped remains 0
 
         self._conn.commit()
         if imported > 0:


### PR DESCRIPTION
💡 What: Optimized `import_jsonl` in `src/mnemo_mcp/db.py` to use `executemany` instead of looping and inserting row by row.
🎯 Why: To solve the N+1 query problem during bulk imports, significantly improving performance for large datasets.
📊 Impact: Reduces database round-trips from N to 1 (or 2 for vector cleanup) per batch.
🔬 Measurement: Verified with `tests/test_db.py` ensuring all import tests pass and `skipped`/`imported` counts remain correct. Verified `executemany` with `INSERT OR IGNORE` correctly reports `rowcount` for inserted rows in SQLite.

---
*PR created automatically by Jules for task [13619309381039719364](https://jules.google.com/task/13619309381039719364) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Bulk data imports now process records in batches instead of per-record writes, significantly improving performance when importing large datasets and reducing database transaction overhead.
  * Duplicate detection for merge and replace operations is now more efficient, with optimized row counting to identify skipped duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->