### PR TITLE
refactor: make rclone version configurable

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -78,6 +78,7 @@ class Settings(BaseSettings):
     sync_remote: str = ""  # rclone remote name
     sync_folder: str = "mnemo-mcp"
     sync_interval: int = 0  # seconds, 0 = manual only
+    rclone_version: str = "v1.68.2"
 
     # Logging
     log_level: str = "INFO"

--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -40,8 +40,6 @@ from mnemo_mcp.config import settings
 if TYPE_CHECKING:
     from mnemo_mcp.db import MemoryDB
 
-# Rclone version to download
-_RCLONE_VERSION = "v1.68.2"
 
 # Background sync task reference
 _sync_task: asyncio.Task | None = None
@@ -110,8 +108,8 @@ async def _download_rclone() -> Path | None:
     Returns path to binary on success, None on failure.
     """
     os_name, arch, ext = _get_platform_info()
-    archive_name = f"rclone-{_RCLONE_VERSION}-{os_name}-{arch}.zip"
-    url = f"https://github.com/rclone/rclone/releases/download/{_RCLONE_VERSION}/{archive_name}"
+    archive_name = f"rclone-{settings.rclone_version}-{os_name}-{arch}.zip"
+    url = f"https://github.com/rclone/rclone/releases/download/{settings.rclone_version}/{archive_name}"
 
     install_dir = _get_rclone_dir()
     install_dir.mkdir(parents=True, exist_ok=True)
@@ -120,7 +118,7 @@ async def _download_rclone() -> Path | None:
     if target_path.exists():
         return target_path
 
-    logger.info(f"Downloading rclone {_RCLONE_VERSION} for {os_name}-{arch}...")
+    logger.info(f"Downloading rclone {settings.rclone_version} for {os_name}-{arch}...")
 
     try:
         async with httpx.AsyncClient(follow_redirects=True) as client:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,3 +193,14 @@ class TestEmbeddingBackend:
         """Explicit backend takes priority over auto-detection."""
         s = Settings(embedding_backend="litellm", api_keys=None)
         assert s.resolve_embedding_backend() == "litellm"
+
+
+class TestRcloneVersion:
+    def test_default(self):
+        s = Settings(api_keys=None)
+        assert s.rclone_version == "v1.68.2"
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("RCLONE_VERSION", "v1.99.9")
+        s = Settings(api_keys=None)
+        assert s.rclone_version == "v1.99.9"

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mnemo_mcp.sync import _download_rclone
+
+
+@pytest.mark.asyncio
+async def test_download_rclone_uses_configured_version(tmp_path):
+    """Test that _download_rclone uses the version from settings."""
+    # Mock settings
+    with patch("mnemo_mcp.sync.settings") as mock_settings:
+        mock_settings.rclone_version = "v1.99.9"
+
+        # Mock platform info to get predictable URL
+        with patch(
+            "mnemo_mcp.sync._get_platform_info", return_value=("linux", "amd64", "")
+        ):
+            # Mock get_rclone_dir to return a temp dir
+            with patch("mnemo_mcp.sync._get_rclone_dir", return_value=tmp_path):
+                # Mock httpx.AsyncClient
+                mock_client = AsyncMock()
+                mock_response = MagicMock()
+                mock_response.content = b"fake-zip-content"
+                mock_client.get.return_value = mock_response
+                mock_client.__aenter__.return_value = mock_client
+
+                with patch(
+                    "mnemo_mcp.sync.httpx.AsyncClient", return_value=mock_client
+                ):
+                    # Mock zipfile to prevent errors
+                    with patch("mnemo_mcp.sync.zipfile.ZipFile"):
+                        # Mock tempfile to avoid writing
+                        with patch(
+                            "mnemo_mcp.sync.tempfile.NamedTemporaryFile"
+                        ) as mock_temp:
+                            mock_temp.return_value.__enter__.return_value.name = str(
+                                tmp_path / "temp.zip"
+                            )
+
+                            await _download_rclone()
+
+                            # Verify URL
+                            expected_url = "https://github.com/rclone/rclone/releases/download/v1.99.9/rclone-v1.99.9-linux-amd64.zip"
+                            mock_client.get.assert_called_with(
+                                expected_url, timeout=120.0
+                            )


### PR DESCRIPTION
Refactored `mnemo_mcp/sync.py` to use a configurable Rclone version instead of a hardcoded constant.
- Added `rclone_version` to `Settings` in `mnemo_mcp/config.py`.
- Updated `mnemo_mcp/sync.py` to use `settings.rclone_version`.
- Added tests for configuration and download URL generation.

🎯 **What:** Replaced hardcoded `_RCLONE_VERSION` with `settings.rclone_version`.
💡 **Why:** Allows overriding Rclone version via environment variables without code changes.
✅ **Verification:** Added `tests/test_sync_version.py` to verify download URL construction. Ran full test suite.
✨ **Result:** Code is more maintainable and configurable.

---
*PR created automatically by Jules for task [3693684292571771417](https://jules.google.com/task/3693684292571771417) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rclone version is now externalized as a configurable application setting with a default value of v1.68.2, supporting environment-based overrides via the RCLONE_VERSION variable for flexible deployment scenarios.

* **Tests**
  * Added unit tests to validate rclone version configuration, including default values, environment variable overrides, and correct download URL construction with the configured version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->