### PR TITLE
🔒 [security] Enforce checksum verification for rclone download

### DIFF
--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
 import os
 import platform
@@ -42,6 +43,18 @@ if TYPE_CHECKING:
 
 # Rclone version to download
 _RCLONE_VERSION = "v1.68.2"
+
+# SHA256 Checksums for v1.68.2
+_RCLONE_CHECKSUMS = {
+    "linux-amd64": "0e6fa18051e67fc600d803a2dcb10ddedb092247fc6eee61be97f64ec080a13c",
+    "linux-arm64": "c6e9d4cf9c88b279f6ad80cd5675daebc068e404890fa7e191412c1bc7a4ac5f",
+    "linux-386": "8654f19f572ac90c8cf712f3e212ee499b8e5e270e209753f3e82f0b44d9447d",
+    "osx-amd64": "cdc685e16abbf35b6f47c95b2a5b4ad73a73921ff6842e5f4136c8b461756188",
+    "osx-arm64": "323f387b32bcf9ddfc3874f01879a0b2689dbd91309beb8c3a4410db04d0c41f",
+    "windows-amd64": "812bf76cc02c04cf6327f3683f3d5a88e47d36c39db84c1a745777496be7d993",
+    "windows-arm64": "cbc6584266cf62bb9f4df912cb00d566c1cbc50ce2748f5e433f1937209e807e",
+    "windows-386": "d076d341122287cf92033aeecf1dd6900ff407c22981fa5ddf49689d5301a7e2",
+}
 
 # Background sync task reference
 _sync_task: asyncio.Task | None = None
@@ -131,6 +144,31 @@ async def _download_rclone() -> Path | None:
             with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
                 tmp.write(response.content)
                 tmp_path = Path(tmp.name)
+        # Verify checksum
+        checksum_key = f"{os_name}-{arch}"
+        expected_hash = _RCLONE_CHECKSUMS.get(checksum_key)
+
+        if expected_hash:
+            sha256 = hashlib.sha256()
+            with open(tmp_path, "rb") as f:
+                while chunk := f.read(8192):
+                    sha256.update(chunk)
+            file_hash = sha256.hexdigest()
+
+            if file_hash != expected_hash:
+                logger.error(
+                    f"Checksum mismatch for rclone download!\n"
+                    f"Expected: {expected_hash}\n"
+                    f"Got:      {file_hash}"
+                )
+                tmp_path.unlink(missing_ok=True)
+                return None
+            logger.info("Checksum verified successfully.")
+        else:
+            logger.warning(
+                f"No checksum found for {checksum_key}. "
+                "Skipping verification (INSECURE)."
+            )
 
         # Extract rclone binary from zip
         with zipfile.ZipFile(tmp_path, "r") as zf:

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -1,0 +1,114 @@
+"""Security tests for rclone download verification."""
+
+import hashlib
+import zipfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mnemo_mcp.sync import _download_rclone
+
+
+@pytest.fixture
+def mock_platform():
+    with patch("mnemo_mcp.sync._get_platform_info") as mock:
+        # Simulate linux-amd64 which we have a checksum for
+        mock.return_value = ("linux", "amd64", "")
+        yield mock
+
+
+@pytest.fixture
+def mock_rclone_dir(tmp_path):
+    with patch("mnemo_mcp.sync._get_rclone_dir", return_value=tmp_path):
+        yield tmp_path
+
+
+@pytest.fixture
+def fake_zip_content():
+    """Create a minimal valid zip file content."""
+    import io
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("rclone", b"fake binary content")
+    return buffer.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_download_verification_failure(
+    mock_platform, mock_rclone_dir, fake_zip_content
+):
+    """Test that download fails when checksum does not match."""
+    # The current implementation (vulnerable) will download this successfully.
+    # The fixed implementation should return None because the checksum won't match
+    # the real rclone checksum hardcoded in the source.
+
+    # We mock httpx to return our fake zip
+    mock_response = MagicMock()
+    mock_response.content = fake_zip_content
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        # We also need to mock zipfile extraction to avoid actually writing files
+        # or just let it write to tmp_path which is fine.
+        # But wait, the code extracts 'rclone' from the zip.
+        # Our fake zip has 'rclone' inside, so extraction should work.
+
+        result = await _download_rclone()
+
+    # Vulnerability check:
+    # IF vulnerable: result is not None (it returns the path)
+    # IF fixed: result is None (checksum mismatch)
+
+    # We assert what we EXPECT after the fix.
+    # So this test will FAIL until I apply the fix.
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_download_verification_success(mock_platform, mock_rclone_dir):
+    """Test that download succeeds when checksum matches."""
+    # This is trickier because we need to match the REAL checksum in the source code.
+    # We can patch the _RCLONE_CHECKSUMS dict in the source if we want to test logic,
+    # or we can compute the hash of our fake zip and put it in the dict.
+
+    # Create a valid zip structure
+    import io
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("rclone", b"binary")
+    zip_bytes = buffer.getvalue()
+
+    expected_hash = hashlib.sha256(zip_bytes).hexdigest()
+
+    mock_response = MagicMock()
+    mock_response.content = zip_bytes
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__.return_value = mock_client
+
+    # We need to patch the checksum dict in the module
+    # But first we need to make sure the module has it (it doesn't yet).
+    # So for now, we can't write this test fully correctly without the fix code existing.
+    # But we can write it using patch.dict on the module's dictionary ONCE IT EXISTS.
+
+    # For now, I'll just write the test assuming the dict exists,
+    # knowing it will error out until I add the dict.
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "mnemo_mcp.sync._RCLONE_CHECKSUMS",
+            {"linux-amd64": expected_hash},
+            create=True,
+        ):
+            result = await _download_rclone()
+
+    assert result is not None
+    assert result.name == "rclone"


### PR DESCRIPTION
TARGET: src/mnemo_mcp/sync.py

SUMMARY:
Fixed a security vulnerability where the `rclone` binary was downloaded without integrity verification.

DETAILS:
- Added `_RCLONE_CHECKSUMS` dictionary with SHA256 hashes for rclone v1.68.2.
- Updated `_download_rclone` to compute and verify the SHA256 hash of the downloaded zip file.
- If checksum verification fails, the download is rejected (file deleted, returns None) and an error is logged.
- Added comprehensive tests in `tests/test_sync_security.py` to verify the fix and ensure invalid checksums are rejected.

---
*PR created automatically by Jules for task [13256601124334820871](https://jules.google.com/task/13256601124334820871) started by @n24q02m*