### PR TITLE
⚡ Optimize vector search result fetching (N+1 -> 1 query)

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -310,27 +310,35 @@ class MemoryDB:
                 vec_params.append(limit * 3)
 
                 vec_rows = self._conn.execute(vec_sql, vec_params).fetchall()
+                missing_ids = []
+                vec_scores = {}
+
                 for row in vec_rows:
                     mid = row["id"]
                     vec_score = max(0.0, 1.0 - row["distance"])
                     if mid in results:
                         results[mid]["vec_score"] = vec_score
                     else:
-                        # Fetch full memory
-                        mem = self._conn.execute(
-                            "SELECT * FROM memories WHERE id = ?", (mid,)
-                        ).fetchone()
-                        if mem:
-                            results[mid] = {
-                                **dict(mem),
-                                "fts_score": 0.0,
-                                "vec_score": vec_score,
-                            }
+                        missing_ids.append(mid)
+                        vec_scores[mid] = vec_score
+
+                if missing_ids:
+                    # Batch fetch missing memories to avoid N+1 query
+                    placeholders = ",".join("?" for _ in missing_ids)
+                    rows = self._conn.execute(
+                        f"SELECT * FROM memories WHERE id IN ({placeholders})",
+                        missing_ids,
+                    ).fetchall()
+
+                    for mem in rows:
+                        mid = mem["id"]
+                        results[mid] = {
+                            **dict(mem),
+                            "fts_score": 0.0,
+                            "vec_score": vec_scores[mid],
+                        }
             except Exception as e:
                 logger.debug(f"Vector search error: {e}")
-
-        if not results:
-            return []
 
         # 3. Tag post-filter (JSON array matching not feasible in SQL)
         if tags:


### PR DESCRIPTION
💡 **What:** Optimized vector search result fetching in `MemoryDB` by replacing iterative `SELECT` queries with a single batch `SELECT ... WHERE id IN (...)` query.

🎯 **Why:** The previous implementation suffered from an N+1 query problem, executing a separate database query for each vector search result not already found by FTS. This caused performance degradation as the number of results increased.

📊 **Measured Improvement:** Verified with a reproduction script (`reproduce_issue.py`) which showed a reduction from N+1 individual queries (e.g., 3 queries for 3 results) to 1 batch query (plus the initial vector search query). Existing tests passed.

---
*PR created automatically by Jules for task [3220248295847445875](https://jules.google.com/task/3220248295847445875) started by @n24q02m*