### PR TITLE
🧹 Refactor: Remove unreachable legacy fallback in server embedding helper

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -253,20 +253,15 @@ async def _embed(
     from mnemo_mcp.embedder import Qwen3EmbedBackend, get_backend
 
     backend = get_backend()
-    if backend is not None:
-        try:
-            if is_query and isinstance(backend, Qwen3EmbedBackend):
-                return await backend.embed_single_query(text, dims)
-            return await backend.embed_single(text, dims)
-        except Exception as e:
-            logger.debug(f"Embedding failed: {e}")
-            return None
-
-    # Legacy path: no backend initialized but model is set
-    from mnemo_mcp.embedder import embed_single
+    if backend is None:
+        # Should not happen if model is set (implies init succeeded), but safe guard.
+        logger.warning(f"Embedding backend not initialized despite model={model}")
+        return None
 
     try:
-        return await embed_single(text, model, dims)
+        if is_query and isinstance(backend, Qwen3EmbedBackend):
+            return await backend.embed_single_query(text, dims)
+        return await backend.embed_single(text, dims)
     except Exception as e:
         logger.debug(f"Embedding failed: {e}")
         return None


### PR DESCRIPTION
🎯 **What:** Removed the unreachable legacy fallback logic in `src/mnemo_mcp/server.py`'s `_embed` function. The code previously attempted to import and use `mnemo_mcp.embedder.embed_single` if the global backend was uninitialized but a model name was provided.

💡 **Why:**
1. **Dead Code:** The `model` parameter in `_embed` comes from `ctx["embedding_model"]`, which is only populated if the backend initialization succeeds (setting the global backend). Thus, the condition "model is set but backend is None" is theoretically impossible in normal operation.
2. **Safety:** The legacy fallback tried to instantiate a new `LiteLLMBackend` on the fly, which would fail or behave unpredictably if the model was actually a local model (e.g., named `"__local__"`).
3. **Clarity:** Removing this fallback simplifies the function and makes failure modes explicit.

✅ **Verification:**
- **New Test:** Created `tests/test_legacy_fallback.py` to simulate the "impossible" state (mocking `get_backend` to return `None` while passing a model name) and verified that the function now safely returns `None` and logs a warning instead of attempting the legacy path.
- **Regression Testing:** Ran the full test suite (`uv run pytest`), passing all 226 tests.

✨ **Result:** Cleaner, safer code with explicit safeguards for backend initialization state.

---
*PR created automatically by Jules for task [9716296925205695672](https://jules.google.com/task/9716296925205695672) started by @n24q02m*