### PR TITLE
🛡️ Sentinel: [HIGH] Prevent Argument Injection in Rclone via sync_remote config

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -1,8 +1,10 @@
 """Configuration settings for Mnemo MCP Server."""
 
 import os
+import re
 from pathlib import Path
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -82,7 +84,25 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = "INFO"
 
-    model_config = {"env_prefix": "", "case_sensitive": False}
+    model_config = {
+        "env_prefix": "",
+        "case_sensitive": False,
+        "validate_assignment": True,
+    }
+
+    @field_validator("sync_remote")
+    @classmethod
+    def validate_sync_remote(cls, v: str) -> str:
+        """Validate sync_remote to prevent argument injection."""
+        if not v:
+            return v
+        if v.startswith("-"):
+            raise ValueError("sync_remote must not start with a hyphen (-)")
+        if not re.match(r"^[a-zA-Z0-9_.-]*$", v):
+            raise ValueError(
+                "sync_remote can only contain alphanumeric characters, dashes, underscores, and dots"
+            )
+        return v
 
     def get_db_path(self) -> Path:
         """Get resolved database path."""

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -4,8 +4,10 @@ from io import BytesIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from mnemo_mcp.sync import _download_rclone
+from mnemo_mcp.config import Settings
 
 
 @pytest.mark.asyncio
@@ -69,3 +71,53 @@ async def test_rclone_download_checksum_mismatch():
         path = await _download_rclone()
         # The function catches exceptions and logs error, returns None on failure
         assert path is None
+
+def test_sync_remote_valid():
+    """Valid sync_remote values should be accepted."""
+    s = Settings(sync_remote="my-gdrive_1.2")
+    assert s.sync_remote == "my-gdrive_1.2"
+
+    s = Settings(sync_remote="")
+    assert s.sync_remote == ""
+
+    s.sync_remote = "another.valid-remote_name"
+    assert s.sync_remote == "another.valid-remote_name"
+
+
+def test_sync_remote_invalid_characters():
+    """Invalid characters should be rejected to prevent injection."""
+    invalid_remotes = [
+        "my gdrive",
+        "my;gdrive",
+        "my&gdrive",
+        "my|gdrive",
+        "my`gdrive",
+        "my$gdrive",
+        "my(gdrive",
+        "my)gdrive",
+        "my<gdrive",
+        "my>gdrive",
+    ]
+    for remote in invalid_remotes:
+        with pytest.raises(ValidationError, match="can only contain alphanumeric"):
+            Settings(sync_remote=remote)
+
+        s = Settings()
+        with pytest.raises(ValidationError, match="can only contain alphanumeric"):
+            s.sync_remote = remote
+
+
+def test_sync_remote_starts_with_hyphen():
+    """sync_remote starting with hyphen should be rejected to prevent argument injection."""
+    with pytest.raises(ValidationError, match="must not start with a hyphen"):
+        Settings(sync_remote="-my-gdrive")
+
+    with pytest.raises(ValidationError, match="must not start with a hyphen"):
+        Settings(sync_remote="--config")
+
+    s = Settings()
+    with pytest.raises(ValidationError, match="must not start with a hyphen"):
+        s.sync_remote = "-my-gdrive"
+
+    with pytest.raises(ValidationError, match="must not start with a hyphen"):
+        s.sync_remote = "--config"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `sync_remote` configuration parameter in `src/mnemo_mcp/config.py` is passed to the `rclone` CLI in `subprocess.run` (e.g. `["copy", str(db_path), f"{remote}:{folder}", "--progress"]`). While safe from shell injection (since it uses `subprocess.run` with a list of args), it is vulnerable to **Argument Injection**. If a user sets `sync_remote` to a value starting with a hyphen (e.g., `--config=/etc/shadow` or `--dump`), `rclone` will interpret the remote name as a flag/option rather than a positional argument. This could lead to information disclosure or unauthorized system interactions.
🎯 **Impact:** Malicious configuration values could manipulate the underlying `rclone` process into reading or exposing sensitive system files, executing unintended commands, or bypassing intended isolation boundaries.
🔧 **Fix:** Added a rigorous Pydantic `field_validator` in `Settings` that restricts `sync_remote` to safe characters (`^[a-zA-Z0-9_.-]*$`) and explicitly rejects any value starting with a hyphen (`-`). Additionally enabled `validate_assignment=True` in `model_config` so this protection applies even if the config is updated at runtime.
✅ **Verification:** Verified via comprehensive tests added in `tests/test_sync_security.py` using `pytest`. Run `uv run pytest tests/test_sync_security.py` to confirm. All 228 project tests passed. Also confirmed formatting with `uv run ruff`.

---
*PR created automatically by Jules for task [13234094805839454249](https://jules.google.com/task/13234094805839454249) started by @n24q02m*