### PR TITLE
⚡ Bolt: [performance] Fix N+1 query in hybrid search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - N+1 Query in Hybrid Search
+**Learning:** When performing hybrid search (FTS + Vector) in `src/mnemo_mcp/db.py`, fetching full memory details for vector-only results individually causes an N+1 query bottleneck. While `sqlite-vec` returns `id` and `distance`, it does not return the full row. A loop executing `SELECT * FROM memories WHERE id = ?` for each missing ID severely degrades performance as the number of results grows.
+**Action:** Always batch these lookups using a single `SELECT * FROM memories WHERE id IN (...)` query to fetch all missing records efficiently.

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -310,22 +310,31 @@ class MemoryDB:
                 vec_params.append(limit * 3)
 
                 vec_rows = self._conn.execute(vec_sql, vec_params).fetchall()
+
+                missing_ids = []
+                vec_scores = {}
                 for row in vec_rows:
                     mid = row["id"]
                     vec_score = max(0.0, 1.0 - row["distance"])
+                    vec_scores[mid] = vec_score
                     if mid in results:
                         results[mid]["vec_score"] = vec_score
                     else:
-                        # Fetch full memory
-                        mem = self._conn.execute(
-                            "SELECT * FROM memories WHERE id = ?", (mid,)
-                        ).fetchone()
-                        if mem:
-                            results[mid] = {
-                                **dict(mem),
-                                "fts_score": 0.0,
-                                "vec_score": vec_score,
-                            }
+                        missing_ids.append(mid)
+
+                if missing_ids:
+                    placeholders = ",".join("?" for _ in missing_ids)
+                    missing_mems = self._conn.execute(
+                        f"SELECT * FROM memories WHERE id IN ({placeholders})",
+                        missing_ids,
+                    ).fetchall()
+                    for mem in missing_mems:
+                        mid = mem["id"]
+                        results[mid] = {
+                            **dict(mem),
+                            "fts_score": 0.0,
+                            "vec_score": vec_scores[mid],
+                        }
             except Exception as e:
                 logger.debug(f"Vector search error: {e}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
💡 **What**: Refactored the semantic search logic in `MemoryDB.search` to use a batched `SELECT * FROM memories WHERE id IN (...)` query instead of a loop executing individual queries for each missing record.
🎯 **Why**: When hybrid search finds multiple vector matches that were not hit by FTS, the code was falling into an N+1 query pattern, looping and hitting SQLite individually.
📊 **Impact**: Reduces database query counts during hybrid search significantly (from N+1 to 2 queries), leading to measurable speedups as the database scales. Memory allocation overhead is also reduced by minimizing query compiling cycles.
🔬 **Measurement**: Verify by running `uv run pytest tests/test_db.py`. Search logic tests pass identically. You can also measure total DB roundtrips by enabling query logging; you'll see a single `IN (?, ?, ...)` instead of multiple `id = ?` lookups.

---
*PR created automatically by Jules for task [2590907513127477539](https://jules.google.com/task/2590907513127477539) started by @n24q02m*