### PR TITLE
🛡️ Sentinel: [HIGH] Fix rclone flag injection via positional arguments

### DIFF
--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -277,7 +277,7 @@ async def sync_push(rclone_path: Path, db_path: Path, remote: str, folder: str) 
     result = await asyncio.to_thread(
         _run_rclone,
         rclone_path,
-        ["copy", str(db_path), remote_dest, "--progress"],
+        ["copy", "--progress", "--", str(db_path), remote_dest],
         300,
     )
 
@@ -307,7 +307,7 @@ async def sync_pull(
     result = await asyncio.to_thread(
         _run_rclone,
         rclone_path,
-        ["copyto", remote_src, str(temp_db), "--progress"],
+        ["copyto", "--progress", "--", remote_src, str(temp_db)],
         300,
     )
 
@@ -461,7 +461,7 @@ def setup_sync(remote_type: str = "drive") -> None:
     # Capture stdout (contains token JSON), let stderr pass through
     # so user sees rclone progress messages in real-time
     result = subprocess.run(
-        [str(rclone_path), "authorize", remote_type],
+        [str(rclone_path), "authorize", "--", remote_type],
         stdout=subprocess.PIPE,
         text=True,
         timeout=300,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -189,7 +189,7 @@ class TestSetupSync:
             setup_sync("drive")
             mock_run.assert_called_once()
             args = mock_run.call_args
-            assert args[0][0] == [str(rclone_path), "authorize", "drive"]
+            assert args[0][0] == [str(rclone_path), "authorize", "--", "drive"]
 
     def test_rclone_downloaded(self, tmp_path, capsys):
         """setup_sync downloads rclone when not found."""

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.0"
+version = "1.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Command-line flag injection via positional arguments to `rclone`
🎯 **Impact:** If an attacker can control configurations like `sync_folder` or `remote_type`, they can inject arbitrary flags like `--config=malicious.conf` into the `rclone` process. This may allow reading or executing local files depending on `rclone`'s operational flags.
🔧 **Fix:** Added `--` before positional arguments in `subprocess.run` executions of `rclone` in `sync_push`, `sync_pull`, and `setup_sync`. This tells the command-line parser to stop processing flags, safely interpreting all subsequent input as literal paths or backend identifiers.
✅ **Verification:** Verified by running the test suite (`uv run pytest`) and lint checks (`uv run ruff check .`). Explicit testing of an injected string (like `--config=x`) correctly results in an error about a missing backend or file instead of processing the flag.

---
*PR created automatically by Jules for task [12257470954392728443](https://jules.google.com/task/12257470954392728443) started by @n24q02m*