### PR TITLE
🛡️ Sentinel: [security improvement] Add defensive json_valid check to avoid DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-08 - [Add defensive json_valid check to avoid DoS]
+**Vulnerability:** Unvalidated JSON strings in the SQLite database could cause a query-crashing exception (`malformed JSON`) when `json_each` is used.
+**Learning:** `json_each` in SQLite raises an error if the input is not valid JSON. This can be exploited by an attacker to cause a Denial of Service by inserting invalid JSON into a column that is later queried with `json_each`.
+**Prevention:** Guard `json_each` calls with `json_valid` checks (e.g., `json_valid(column) AND EXISTS(SELECT 1 FROM json_each(column)...)`) to safely filter out invalid JSON without crashing the query.

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -265,7 +265,7 @@ class MemoryDB:
                 # Tag pre-filter in SQL
                 if tags:
                     tag_placeholders = ",".join("?" for _ in tags)
-                    fts_sql += f" AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
+                    fts_sql += f" AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
                     fts_params.extend(tags)
 
                 fts_sql += " ORDER BY bm25_score LIMIT ?"
@@ -316,7 +316,7 @@ class MemoryDB:
                 # Tag pre-filter in SQL
                 if tags:
                     tag_placeholders = ",".join("?" for _ in tags)
-                    vec_sql += f" AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
+                    vec_sql += f" AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
                     vec_params.extend(tags)
 
                 vec_sql += " ORDER BY distance LIMIT ?"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `json_each` function in SQLite throws an error if it encounters a malformed JSON string, which causes the entire SQL query to crash. An attacker could exploit this by introducing malformed JSON in the `tags` field, leading to a Denial of Service.
🎯 Impact: If the database contains invalid JSON in the `tags` column, any search queries using tags would fail with a 500 error or crash the server.
🔧 Fix: Added a defensive `json_valid(m.tags)` check before iterating over `m.tags` using SQLite's `json_each()` function.
✅ Verification: Tested against a local database containing invalid JSON strings. Without the check, the query throws an exception. With the check, it safely ignores the invalid rows and returns valid results.

---
*PR created automatically by Jules for task [5715251234818329085](https://jules.google.com/task/5715251234818329085) started by @n24q02m*