### PR TITLE
feat: testing improvement] Add coverage for `sync_push` in auto-sync flow

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -272,6 +272,58 @@ class TestSetupSync:
             assert "auto-decodes base64" in captured.out
 
 
+class TestSyncPush:
+    async def test_push_success(self, tmp_path):
+        """Push local database to remote successfully."""
+        from mnemo_mcp.sync import sync_push
+
+        rclone_path = tmp_path / "rclone"
+        db_path = tmp_path / "db.sqlite"
+        db_path.touch()
+        remote = "myremote"
+        folder = "myfolder"
+
+        with patch("mnemo_mcp.sync.asyncio.to_thread") as mock_to_thread:
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_to_thread.return_value = mock_result
+
+            result = await sync_push(rclone_path, db_path, remote, folder)
+
+            assert result is True
+            mock_to_thread.assert_called_once()
+            args, _ = mock_to_thread.call_args
+            assert args[1] == rclone_path
+            assert args[2] == [
+                "copy",
+                "--progress",
+                "--",
+                str(db_path),
+                f"{remote}:{folder}",
+            ]
+            assert args[3] == 300
+
+    async def test_push_failure(self, tmp_path):
+        """Push local database to remote fails gracefully."""
+        from mnemo_mcp.sync import sync_push
+
+        rclone_path = tmp_path / "rclone"
+        db_path = tmp_path / "db.sqlite"
+        db_path.touch()
+        remote = "myremote"
+        folder = "myfolder"
+
+        with patch("mnemo_mcp.sync.asyncio.to_thread") as mock_to_thread:
+            mock_result = MagicMock()
+            mock_result.returncode = 1
+            mock_result.stderr = "error message"
+            mock_to_thread.return_value = mock_result
+
+            result = await sync_push(rclone_path, db_path, remote, folder)
+
+            assert result is False
+
+
 class TestStartAutoSync:
     def teardown_method(self):
         """Ensure _sync_task is reset after each test."""


### PR DESCRIPTION
## Description
This PR addresses a gap in test coverage by adding tests for the `sync_push` function.

🎯 **What:** The `sync_push` function in `src/mnemo_mcp/sync.py`, part of the auto-sync flow, was entirely untested. This PR adds dedicated unit tests to verify its behavior.

📊 **Coverage:**
* Tested the happy path where pushing the DB file via `rclone copy` succeeds (returncode 0).
* Tested the failure path where the push encounters an error (returncode non-zero).
* Ensured `asyncio.to_thread` is mocked so the tests are deterministic and assert on exact commands (`copy`, `--progress`, `--`, etc.) passed to `_run_rclone`.

✨ **Result:** Test suite coverage has increased in the `sync.py` module, specifically guaranteeing that any future regressions in argument construction or error handling in `sync_push` will be caught.

---
*PR created automatically by Jules for task [11790990569357196310](https://jules.google.com/task/11790990569357196310) started by @n24q02m*