### PR TITLE
feat: testing improvement] Add tests for embed_single_query in Qwen3EmbedBackend

### DIFF
--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -234,6 +234,32 @@ class TestQwen3EmbedBackend:
         result = await backend.embed_single("hello")
         assert result == [0.1, 0.2, 0.3]
 
+    @patch("mnemo_mcp.embedder.asyncio.to_thread")
+    async def test_embed_single_query(self, mock_to_thread):
+        mock_to_thread.return_value = [0.1, 0.2, 0.3]
+        backend = Qwen3EmbedBackend()
+        result = await backend.embed_single_query("hello")
+        assert result == [0.1, 0.2, 0.3]
+        mock_to_thread.assert_called_once()
+
+    @patch("mnemo_mcp.embedder.asyncio.to_thread")
+    @patch("mnemo_mcp.embedder.Qwen3EmbedBackend._get_model")
+    async def test_embed_single_query_closure(self, mock_get_model, mock_to_thread):
+        """Test internal closure passes arguments correctly via direct execution."""
+        mock_to_thread.side_effect = lambda f: f()
+
+        mock_model = MagicMock()
+        mock_result = MagicMock()
+        mock_result.tolist.return_value = [0.1, 0.2, 0.3]
+        mock_model.query_embed.return_value = iter([mock_result])
+        mock_get_model.return_value = mock_model
+
+        backend = Qwen3EmbedBackend()
+        result = await backend.embed_single_query("hello", dimensions=256)
+
+        assert result == [0.1, 0.2, 0.3]
+        mock_model.query_embed.assert_called_once_with("hello", dim=256)
+
     @patch("mnemo_mcp.embedder.Qwen3EmbedBackend._get_model")
     def test_check_available_not_installed(self, mock_get_model):
         """Returns 0 when qwen3-embed is not available."""

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The `embed_single_query` method in `Qwen3EmbedBackend` within `src/mnemo_mcp/embedder.py` was completely untested. This method runs inference in a local thread via `asyncio.to_thread` for asymmetric embedding retrieval queries.

📊 **Coverage:** What scenarios are now tested:
- Correct execution of the inner method via `asyncio.to_thread`.
- Argument passing (including the instruction prefix `text` and `dim` args) to the inner `query_embed` function.
- Proper execution of the closure with mocking `to_thread` logic mimicking `lambda f: f()`.
- Mocking the model itself correctly inside the inner query context.

✨ **Result:** The improvement in test coverage: The entirety of the `embed_single_query` function is fully tested, boosting code coverage and establishing solid, deterministic validations of `asyncio.to_thread` behavior and local embedding argument handling.

---
*PR created automatically by Jules for task [5789365169127496422](https://jules.google.com/task/5789365169127496422) started by @n24q02m*