### PR TITLE
fix: fix Unbounded Search Limit DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Unvalidated JSON strings inserted into SQLite columns queried with `json_each()` will cause a query-crashing exception (`malformed JSON`), creating a potential Denial-of-Service vulnerability.
 **Learning:** `json_each` raises exceptions when passed malformed JSON. This is an issue when filtering is done directly via SQL queries.
 **Prevention:** Guard `json_each()` calls with `json_valid()` (e.g., `json_valid(column) AND EXISTS(SELECT 1 FROM json_each(column)...)`).
+## 2024-05-18 - 🛡️ Sentinel: [HIGH] Fix Unbounded Search Limit DoS
+**Vulnerability:** The internal `_handle_search` and `_handle_list` functions in `src/mnemo_mcp/server.py` passed the user-controlled `limit` parameter directly to the database layer without clamping it, causing a potential Denial-of-Service (DoS) via resource exhaustion if called with extremely large values.
+**Learning:** To prevent Denial of Service (DoS) attacks via resource exhaustion, pagination or result limits in endpoints must be strictly clamped to a reasonable maximum (e.g., `limit = max(1, min(limit, 100))`) before being passed to the database layer.
+**Prevention:** Always clamp limits at the earliest possible entry point to internal functions, even if a higher-level tool wrapper implements its own clamping, to provide defense-in-depth and protect against internal misuses.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -310,6 +310,8 @@ async def _handle_search(
     if not query:
         return _json({"error": "query is required for search"})
 
+    limit = max(1, min(limit, 100))
+
     embedding = await _embed(query, embedding_model, embedding_dims, is_query=True)
     results = await asyncio.to_thread(
         db.search,
@@ -333,6 +335,7 @@ async def _handle_list(
     category: str | None,
     limit: int,
 ) -> str:
+    limit = max(1, min(limit, 100))
     results = await asyncio.to_thread(
         db.list_memories,
         category=category,

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The `limit` parameter in the internal `_handle_search` and `_handle_list` functions was passed directly to the database without limits.

⚠️ **Risk:** An attacker could exploit an unbounded `limit` parameter by requesting an extremely large number of results (e.g., millions), leading to resource exhaustion (CPU, memory) in the database or server, effectively causing a Denial of Service (DoS).

🛡️ **Solution:** The limit was clamped directly inside the internal logic of `_handle_search` and `_handle_list` via `limit = max(1, min(limit, 100))`. This enforces defense-in-depth security by not relying exclusively on the external MCP tool parameter bounds, ensuring that any caller receives safely clamped pagination variables.

---
*PR created automatically by Jules for task [8338350660535732265](https://jules.google.com/task/8338350660535732265) started by @n24q02m*