### PR TITLE
fix: fix Unbounded Search Limit causing potential DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Unvalidated JSON strings inserted into SQLite columns queried with `json_each()` will cause a query-crashing exception (`malformed JSON`), creating a potential Denial-of-Service vulnerability.
 **Learning:** `json_each` raises exceptions when passed malformed JSON. This is an issue when filtering is done directly via SQL queries.
 **Prevention:** Guard `json_each()` calls with `json_valid()` (e.g., `json_valid(column) AND EXISTS(SELECT 1 FROM json_each(column)...)`).
+## 2024-05-24 - Unbounded Search Limit causing potential DoS
+**Vulnerability:** Unbounded `limit` parameter in the `_handle_search` and `_handle_list` functions allowed for potential Denial of Service (DoS) attacks by requesting an excessively large number of records.
+**Learning:** Always validate and clamp integer limits received from user inputs or tool requests before passing them to the database layer, to prevent memory exhaustion and excessive database load.
+**Prevention:** Ensured limits are clamped using `max(1, min(limit, 100))` directly before the `db.search` and `db.list_memories` calls in the server handlers.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -311,6 +311,8 @@ async def _handle_search(
         return _json({"error": "query is required for search"})
 
     embedding = await _embed(query, embedding_model, embedding_dims, is_query=True)
+
+    limit = max(1, min(limit, 100))
     results = await asyncio.to_thread(
         db.search,
         query=query,
@@ -333,6 +335,7 @@ async def _handle_list(
     category: str | None,
     limit: int,
 ) -> str:
+    limit = max(1, min(limit, 100))
     results = await asyncio.to_thread(
         db.list_memories,
         category=category,

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The `limit` parameter in `_handle_search` and `_handle_list` handlers within `src/mnemo_mcp/server.py` was not properly bounded, allowing it to be excessively large.
⚠️ **Risk:** A malicious or erroneous client could pass a huge `limit` (e.g., 1000000) leading to massive database queries and out-of-memory errors on the server, causing a Denial of Service (DoS).
🛡️ **Solution:** Implemented integer clamping (`limit = max(1, min(limit, 100))`) immediately before invoking the underlying database methods (`db.search` and `db.list_memories`), ensuring the limit remains within safe operational bounds (1 to 100) even when large values are passed internally. Tested explicitly via `test_security_limits.py`.

---
*PR created automatically by Jules for task [2662679054329823103](https://jules.google.com/task/2662679054329823103) started by @n24q02m*