### PR TITLE
fix: testing improvement] Add missing error test for check_available in LiteLLMBackend

### DIFF
--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -294,12 +294,17 @@ class TestCheckAvailableApiKeyValidation:
         backend = LiteLLMBackend("model")
         assert backend.check_available() == 0
 
+    @patch("mnemo_mcp.embedder.logger")
     @patch("litellm.embedding")
-    def test_non_auth_error_logged_at_debug(self, mock_embed):
+    def test_non_auth_error_logged_at_debug(self, mock_embed, mock_logger):
         """Non-auth errors (e.g. model not found) go to debug level."""
-        mock_embed.side_effect = Exception("Model not found: xyz")
+        error_msg = "Model not found: xyz"
+        mock_embed.side_effect = Exception(error_msg)
         backend = LiteLLMBackend("model")
         assert backend.check_available() == 0
+        mock_logger.debug.assert_called_once_with(
+            f"Embedding model model not available: {error_msg}"
+        )
 
 
 class TestQwen3GetModelWarning:

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 What: Added an assertion to `test_non_auth_error_logged_at_debug` in `tests/test_embedder.py` to verify that a non-auth API exception leads to a `logger.debug` call instead of just returning 0.
📊 Coverage: The debug logging branch for LiteLLMBackend `check_available` method when it hits an unknown exception.
✨ Result: `logger.debug` calls on the failure path are properly tested.

---
*PR created automatically by Jules for task [8338350660535730855](https://jules.google.com/task/8338350660535730855) started by @n24q02m*