### PR TITLE
fix: fix incomplete exception handling in memory tool

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -288,6 +288,9 @@ async def _handle_add(
         )
     except ValueError as e:
         return _json({"error": str(e)})
+    except Exception as e:
+        logger.error(f"Error handling memory addition: {e}")
+        return _json({"error": "An internal error occurred while adding memory."})
     return _json(
         {
             "id": memory_id,
@@ -373,6 +376,9 @@ async def _handle_update(
         )
     except ValueError as e:
         return _json({"error": str(e)})
+    except Exception as e:
+        logger.error(f"Error handling memory update: {e}")
+        return _json({"error": "An internal error occurred while updating memory."})
     if ok:
         return _json({"status": "updated", "id": memory_id})
     return _json({"error": f"Memory {memory_id} not found"})

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The memory tool's `_handle_add` and `_handle_update` methods in `server.py` lacked robust exception handling. They only handled `ValueError` explicitly, which could leave the app vulnerable to crashing on unhandled generic exceptions or `sqlite3.Error`s, or leak sensitive system data.
⚠️ **Risk:** Without a generic exception boundary, database corruption, network interruptions, or internal runtime errors could result in an unhandled 500 status code/process crash. Furthermore, returning `str(e)` on unhandled broad exceptions can leak system internal details.
🛡️ **Solution:** Extended the exception handling to explicitly catch `Exception` alongside `ValueError`. If an exception other than `ValueError` is triggered, a sanitized message is returned to the user, while the internal `logger.error` captures the actual exception payload.

---
*PR created automatically by Jules for task [6759781231775737657](https://jules.google.com/task/6759781231775737657) started by @n24q02m*