### PR TITLE
fix: fix Unbounded Search Limit DoS in _handle_search

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -310,6 +310,9 @@ async def _handle_search(
     if not query:
         return _json({"error": "query is required for search"})
 
+    # Clamp limit to reasonable bounds to prevent DoS
+    limit = max(1, min(limit, 100))
+
     embedding = await _embed(query, embedding_model, embedding_dims, is_query=True)
     results = await asyncio.to_thread(
         db.search,

--- a/tests/test_security_limits.py
+++ b/tests/test_security_limits.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mnemo_mcp.server import memory
+from mnemo_mcp.server import _handle_search, memory
 
 
 @pytest.mark.asyncio
@@ -35,3 +35,51 @@ async def test_list_limit_clamping():
         args, kwargs = mock_db.list_memories.call_args
         actual_limit = kwargs.get("limit")
         assert actual_limit == 100, f"Limit expected to be 100, got {actual_limit}"
+
+
+@pytest.mark.asyncio
+async def test_handle_search_limit_clamped():
+    """Verify that _handle_search limit is clamped independently."""
+    mock_db = MagicMock()
+    mock_db.search = MagicMock(return_value=[])
+
+    with patch("mnemo_mcp.server._embed", new_callable=AsyncMock) as mock_embed:
+        mock_embed.return_value = [0.1, 0.2]
+        await _handle_search(
+            db=mock_db,
+            query="test",
+            category=None,
+            tags=None,
+            limit=1000,
+            embedding_model="test_model",
+            embedding_dims=2,
+        )
+
+        # Verify db.search was called with limit=100
+        mock_db.search.assert_called_once_with(
+            query="test", embedding=[0.1, 0.2], category=None, tags=None, limit=100
+        )
+
+
+@pytest.mark.asyncio
+async def test_handle_search_limit_clamped_negative():
+    """Verify that _handle_search limit is clamped independently for negative values."""
+    mock_db = MagicMock()
+    mock_db.search = MagicMock(return_value=[])
+
+    with patch("mnemo_mcp.server._embed", new_callable=AsyncMock) as mock_embed:
+        mock_embed.return_value = [0.1, 0.2]
+        await _handle_search(
+            db=mock_db,
+            query="test",
+            category=None,
+            tags=None,
+            limit=-10,
+            embedding_model="test_model",
+            embedding_dims=2,
+        )
+
+        # Verify db.search was called with limit=1 (max 1)
+        mock_db.search.assert_called_once_with(
+            query="test", embedding=[0.1, 0.2], category=None, tags=None, limit=1
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 What:
The `_handle_search` function accepted an unbounded `limit` parameter, which was passed directly to the `db.search` function without validation. This allowed an attacker to request an enormous number of records in a single query.

⚠️ Risk:
An attacker could perform a Denial of Service (DoS) attack by specifying a massive limit (e.g., `10000000`), which would exhaust CPU and memory resources on the database and the server, degrading performance or crashing the application entirely.

🛡️ Solution:
Clamped the `limit` argument in `_handle_search` using `max(1, min(limit, 100))`, ensuring the system processes a maximum of 100 records per search request. Also added a dedicated security test to verify clamping behavior, without modifying existing coverage.

---
*PR created automatically by Jules for task [17396160008018252897](https://jules.google.com/task/17396160008018252897) started by @n24q02m*