### PR TITLE
feat: testing improvement] Add tests for check_remote_configured in sync.py

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -339,3 +339,62 @@ class TestStartAutoSync:
             # Verify the global var was set
             assert mnemo_mcp.sync._sync_task == dummy_task
             mock_loop.assert_called_once_with(tmp_db)
+
+
+class TestCheckRemoteConfigured:
+    @patch("mnemo_mcp.sync.asyncio.to_thread")
+    async def test_success(self, mock_to_thread):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "remote1:\nmy_remote:\n"
+        mock_to_thread.return_value = mock_result
+
+        from pathlib import Path
+
+        from mnemo_mcp.sync import check_remote_configured
+
+        result = await check_remote_configured(Path("/tmp/rclone"), "my_remote")
+        assert result is True
+        mock_to_thread.assert_called_once()
+
+    @patch("mnemo_mcp.sync.asyncio.to_thread")
+    async def test_not_found(self, mock_to_thread):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "remote1:\nother_remote:\n"
+        mock_to_thread.return_value = mock_result
+
+        from pathlib import Path
+
+        from mnemo_mcp.sync import check_remote_configured
+
+        result = await check_remote_configured(Path("/tmp/rclone"), "my_remote")
+        assert result is False
+
+    @patch("mnemo_mcp.sync.asyncio.to_thread")
+    async def test_failure(self, mock_to_thread):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_to_thread.return_value = mock_result
+
+        from pathlib import Path
+
+        from mnemo_mcp.sync import check_remote_configured
+
+        result = await check_remote_configured(Path("/tmp/rclone"), "my_remote")
+        assert result is False
+
+    @patch("mnemo_mcp.sync.asyncio.to_thread")
+    async def test_empty_output(self, mock_to_thread):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "\n  \n"
+        mock_to_thread.return_value = mock_result
+
+        from pathlib import Path
+
+        from mnemo_mcp.sync import check_remote_configured
+
+        result = await check_remote_configured(Path("/tmp/rclone"), "my_remote")
+        assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The `check_remote_configured` function in `src/mnemo_mcp/sync.py` was completely untested. This function is critical for the auto-sync flow to verify if an rclone remote is actually configured before attempting to push or pull.

📊 **Coverage:** Added `TestCheckRemoteConfigured` class to `tests/test_sync.py` with test cases for successful configuration detection, remote not found, command failure, and empty output scenarios.

✨ **Result:** The specific behavior of `check_remote_configured` is fully exercised and validated via deterministic mocking of `asyncio.to_thread`.

---
*PR created automatically by Jules for task [12885197710731130706](https://jules.google.com/task/12885197710731130706) started by @n24q02m*