### PR TITLE
fix: fix Logging Disruption via Invalid Configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Unvalidated JSON strings inserted into SQLite columns queried with `json_each()` will cause a query-crashing exception (`malformed JSON`), creating a potential Denial-of-Service vulnerability.
 **Learning:** `json_each` raises exceptions when passed malformed JSON. This is an issue when filtering is done directly via SQL queries.
 **Prevention:** Guard `json_each()` calls with `json_valid()` (e.g., `json_valid(column) AND EXISTS(SELECT 1 FROM json_each(column)...)`).
+
+## 2026-03-10 - Logging Disruption via Invalid Configuration
+**Vulnerability:** Unvalidated inputs used in logger configuration can cause the application logger to crash or stop functioning, leading to loss of audit trails or application failure.
+**Learning:** External or user-provided configuration values must be strictly validated against an allowlist before being applied to internal state or components like the logging system.
+**Prevention:** Validate log levels against a predefined set of valid string values (e.g., TRACE, DEBUG, INFO, SUCCESS, WARNING, ERROR, CRITICAL) before updating the logger configuration.

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.5.9"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is Logging Disruption via Invalid Configuration.\n⚠️ **Risk:** The potential impact if left unfixed is that unvalidated inputs used in logger configuration can cause the application logger to crash or stop functioning, leading to loss of audit trails or application failure.\n🛡️ **Solution:** How the fix addresses the vulnerability: Validate log levels against a predefined set of valid string values (e.g., TRACE, DEBUG, INFO, SUCCESS, WARNING, ERROR, CRITICAL) before updating the logger configuration. The repository code in `src/mnemo_mcp/server.py` was found to already have the fix applied correctly, so only `.jules/sentinel.md` was updated.

---
*PR created automatically by Jules for task [8487467050450012420](https://jules.google.com/task/8487467050450012420) started by @n24q02m*