### PR TITLE
fix: fix command injection in sync_provider

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -44,6 +44,25 @@ def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
     return onnx_name
 
 
+# Supported rclone providers to prevent command injection
+RCLONE_PROVIDERS = {
+    "drive",
+    "dropbox",
+    "s3",
+    "onedrive",
+    "b2",
+    "box",
+    "sftp",
+    "webdav",
+    "local",
+    "azureblob",
+    "ftp",
+    "smb",
+    "swift",
+    "gcs",
+}
+
+
 class Settings(BaseSettings):
     """Mnemo MCP Server configuration.
 
@@ -105,6 +124,16 @@ class Settings(BaseSettings):
         "case_sensitive": False,
         "validate_assignment": True,
     }
+
+    @field_validator("sync_provider")
+    @classmethod
+    def validate_sync_provider(cls, v: str) -> str:
+        """Validate sync_provider against allowlist to prevent argument injection."""
+        if not v:
+            return v
+        if v not in RCLONE_PROVIDERS:
+            raise ValueError(f"sync_provider must be one of {sorted(RCLONE_PROVIDERS)}")
+        return v
 
     @field_validator("sync_remote")
     @classmethod

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@
 import os
 from pathlib import Path
 
+import pytest
+
 from mnemo_mcp.config import Settings
 
 
@@ -204,3 +206,18 @@ class TestRcloneVersion:
         monkeypatch.setenv("RCLONE_VERSION", "v1.99.9")
         s = Settings(api_keys=None)
         assert s.rclone_version == "v1.99.9"
+
+
+def test_sync_provider_injection_prevention():
+    """Test that sync_provider rejects invalid values to prevent command injection."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Settings(sync_provider="-option")
+
+    with pytest.raises(ValidationError):
+        Settings(sync_provider="inject; rm -rf /")
+
+    # Should pass for valid providers
+    assert Settings(sync_provider="drive").sync_provider == "drive"
+    assert Settings(sync_provider="dropbox").sync_provider == "dropbox"

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 **Severity:** HIGH / CRITICAL
💡 **Vulnerability:** The configuration variable `sync_provider` lacked strict validation, which could be leveraged to pass arbitrary command-line arguments to `subprocess.run` (argument injection/command injection).
🎯 **Impact:** Potential remote code execution or unauthorized system access by injecting malicious arguments to `rclone` calls.
🔧 **Fix:** Added a constant `RCLONE_PROVIDERS` allowlist and enforced validation in the Pydantic model (`Settings.validate_sync_provider`).
✅ **Verification:** Added `test_sync_provider_injection_prevention` to `tests/test_config.py` using `pytest.raises(ValidationError)` to ensure invalid strings are rejected while valid ones pass. All existing and new tests pass successfully. Recorded learning into `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1191406323378381121](https://jules.google.com/task/1191406323378381121) started by @n24q02m*