### PR TITLE
fix: fix argument injection risks in rclone providers

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -44,6 +44,25 @@ def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
     return onnx_name
 
 
+# Allowlist for rclone providers to prevent argument injection
+RCLONE_PROVIDERS = {
+    "drive",
+    "dropbox",
+    "s3",
+    "local",
+    "sftp",
+    "ftp",
+    "webdav",
+    "b2",
+    "azureblob",
+    "onedrive",
+    "box",
+    "smb",
+    "jottacloud",
+    "mega",
+}
+
+
 class Settings(BaseSettings):
     """Mnemo MCP Server configuration.
 
@@ -105,6 +124,16 @@ class Settings(BaseSettings):
         "case_sensitive": False,
         "validate_assignment": True,
     }
+
+    @field_validator("sync_provider")
+    @classmethod
+    def validate_sync_provider(cls, v: str) -> str:
+        """Validate sync_provider against allowlist to prevent argument injection."""
+        if v not in RCLONE_PROVIDERS:
+            raise ValueError(
+                f"sync_provider must be one of: {', '.join(sorted(RCLONE_PROVIDERS))}"
+            )
+        return v
 
     @field_validator("sync_remote")
     @classmethod

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -170,3 +170,29 @@ def test_sync_remote_starts_with_hyphen():
 
     with pytest.raises(ValidationError, match="must not start with a hyphen"):
         s.sync_remote = "--config"
+
+
+def test_sync_provider_valid():
+    """Valid sync_provider values should be accepted."""
+    s = Settings(sync_provider="drive")
+    assert s.sync_provider == "drive"
+
+    s.sync_provider = "dropbox"
+    assert s.sync_provider == "dropbox"
+
+
+def test_sync_provider_invalid():
+    """Invalid sync_provider values should be rejected to prevent argument injection."""
+    invalid_providers = [
+        "invalid",
+        "drive --config=malicious",
+        "drive; rm -rf /",
+        "-malicious",
+    ]
+    for provider in invalid_providers:
+        with pytest.raises(ValidationError, match="sync_provider must be one of"):
+            Settings(sync_provider=provider)
+
+        s = Settings()
+        with pytest.raises(ValidationError, match="sync_provider must be one of"):
+            s.sync_provider = provider

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `sync_provider` configuration value was passed directly into `subprocess.run` as part of the `RCLONE_CONFIG_*_TYPE` environment variable setup without validation. A malicious user or an attacker who could modify the environment could inject malicious provider types or even argument flags (e.g., `-malicious`) into the subprocess environment, leading to potential argument injection in the `rclone` subprocess.
🎯 Impact: This could be exploited by an attacker to alter the behavior of `rclone`, potentially leading to unauthorized access, remote code execution or data exfiltration.
🔧 Fix: Add an explicit `RCLONE_PROVIDERS` allowlist and implement a Pydantic `field_validator` in `src/mnemo_mcp/config.py` to ensure that `sync_provider` must match a known-safe provider type (like `drive`, `dropbox`, `s3`, etc.). Added comprehensive unit tests in `tests/test_sync_security.py` to cover these cases.
✅ Verification: Ran unit tests `uv run pytest` and linters `uv run ruff check .` which all pass.

---
*PR created automatically by Jules for task [3874395473970544219](https://jules.google.com/task/3874395473970544219) started by @n24q02m*