### PR TITLE
fix: add Missing Error Test in Config GGUF Support Detection

### DIFF
--- a/tests/test_config_helpers.py
+++ b/tests/test_config_helpers.py
@@ -52,6 +52,23 @@ class TestHasGGUFSupport:
         with patch.dict(sys.modules, {"llama_cpp": None}):
             assert _has_gguf_support() is False
 
+    def test_llama_cpp_import_error(self):
+        import builtins
+
+        orig_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "llama_cpp":
+                raise ImportError("Mocked ImportError")
+            return orig_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            # Ensure sys.modules does not prevent the import call
+            with patch.dict(sys.modules):
+                if "llama_cpp" in sys.modules:
+                    del sys.modules["llama_cpp"]
+                assert _has_gguf_support() is False
+
 
 class TestResolveLocalModel:
     def test_gpu_and_gguf(self):

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** 
Added a unit test `test_llama_cpp_import_error` to explicitly verify that `mnemo_mcp.config._has_gguf_support` handles the `ImportError` gracefully and returns `False` when the `llama_cpp` module is missing.

📊 **Coverage:** 
- Covers the `except ImportError:` path in `_has_gguf_support()`.
- Uses a mock `builtins.__import__` to correctly simulate the `ImportError` without throwing unexpected errors for other modules and without leaking state to other tests.

✨ **Result:** 
Enhanced the robustness of configuration testing by explicitly covering the failure path. Tests run fast and independently.

---
*PR created automatically by Jules for task [1324541617043180740](https://jules.google.com/task/1324541617043180740) started by @n24q02m*