### PR TITLE
fix: remove duplicate assertions from PR #224

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,13 +19,11 @@ class TestAdd:
         mid = tmp_db.add("test")
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["category"] == "general"
 
     def test_custom_category(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test", category="work")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["category"] == "work"
 
@@ -33,13 +31,11 @@ class TestAdd:
         mid = tmp_db.add("test", tags=["a", "b"])
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert json.loads(mem["tags"]) == ["a", "b"]
 
     def test_no_tags_empty_list(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert json.loads(mem["tags"]) == []
 
@@ -47,20 +43,17 @@ class TestAdd:
         mid = tmp_db.add("test", source="conversation")
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["source"] == "conversation"
 
     def test_source_default_none(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test")
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["source"] is None
 
     def test_timestamps_set(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["created_at"] is not None
         assert mem["updated_at"] is not None
@@ -70,7 +63,6 @@ class TestAdd:
         mid = tmp_db.add("test")
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["access_count"] == 0
 
 
@@ -78,7 +70,6 @@ class TestGet:
     def test_existing(self, tmp_db: MemoryDB):
         mid = tmp_db.add("hello world")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["content"] == "hello world"
         assert mem["id"] == mid
@@ -89,7 +80,6 @@ class TestGet:
     def test_all_fields_present(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test", category="cat", tags=["t"], source="src")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         expected_fields = {
             "id",
@@ -111,14 +101,12 @@ class TestUpdate:
         assert tmp_db.update(mid, content="updated") is True
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["content"] == "updated"
 
     def test_category(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test", category="old")
         tmp_db.update(mid, category="new")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["category"] == "new"
 
@@ -127,19 +115,16 @@ class TestUpdate:
         tmp_db.update(mid, tags=["b", "c"])
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert json.loads(mem["tags"]) == ["b", "c"]
 
     def test_updates_timestamp(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test")
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         old_ts = mem["updated_at"]
         time.sleep(0.01)
         tmp_db.update(mid, content="changed")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["updated_at"] >= old_ts
 
@@ -151,7 +136,6 @@ class TestUpdate:
         mid = tmp_db.add("content", category="old", tags=["tag1"])
         tmp_db.update(mid, category="new")
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["content"] == "content"
         assert mem["category"] == "new"
@@ -369,7 +353,6 @@ class TestExportImport:
         assert result["imported"] == 0
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["content"] == "original"
 
     def test_import_replace_clears_first(self, tmp_db: MemoryDB):
@@ -457,7 +440,6 @@ class TestEdgeCases:
         mid = tmp_db.add("")
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["content"] == ""
 
     def test_very_long_content(self, tmp_db: MemoryDB):
@@ -466,14 +448,12 @@ class TestEdgeCases:
         mid = tmp_db.add(content)
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["content"] == content
 
     def test_unicode_content(self, tmp_db: MemoryDB):
         content = "日本語テスト 한국어 中文 Tiếng Việt 🎉"
         mid = tmp_db.add(content)
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["content"] == content
 
@@ -487,7 +467,6 @@ class TestEdgeCases:
         mid = tmp_db.add(content)
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["content"] == content
 
     def test_newlines_in_content(self, tmp_db: MemoryDB):
@@ -495,14 +474,12 @@ class TestEdgeCases:
         mid = tmp_db.add(content)
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["content"] == content
 
     def test_many_tags(self, tmp_db: MemoryDB):
         tags = [f"tag{i}" for i in range(50)]
         mid = tmp_db.add("test", tags=tags)
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert json.loads(mem["tags"]) == tags
 
@@ -560,7 +537,6 @@ class TestContentLengthValidation:
         # Original content preserved
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["content"] == "short"
 
     def test_update_at_limit_ok(self, tmp_db: MemoryDB):
@@ -594,7 +570,6 @@ class TestImportanceColumn:
         mid = tmp_db.add("test content")
         mem = tmp_db.get(mid)
         assert mem is not None
-        assert mem is not None
         assert mem["importance"] == 0.5
 
     def test_update_importance(self, tmp_db: MemoryDB):
@@ -602,7 +577,6 @@ class TestImportanceColumn:
         ok = tmp_db.update_importance(mid, 0.9)
         assert ok is True
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["importance"] == 0.9
 
@@ -670,7 +644,6 @@ class TestArchive:
         ok = tmp_db.restore_memory(mid)
         assert ok is True
         mem = tmp_db.get(mid)
-        assert mem is not None
         assert mem is not None
         assert mem["content"] == "to archive"
 


### PR DESCRIPTION
## Summary
- Remove 27 duplicate `assert mem is not None` lines in `test_db.py` that were introduced by PR #224's merge
- Each `tmp_db.get()` call only needs one None-guard assertion, not two consecutive identical ones

## Test plan
- [x] `uv run pytest tests/test_db.py` -- all 99 tests pass
- [x] Ruff lint + format check pass