### PR TITLE
fix: testing improvement] Add test for local embedding initialization error

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -712,3 +712,25 @@ class TestPrompts:
         result = recall_context("machine learning")
         assert "machine learning" in result
         assert "search" in result.lower()
+
+
+class TestServerInit:
+    async def test_init_embedding_backend_exception(self):
+        ctx = {"embedding_dims": 0, "embedding_model": None}
+
+        with patch("mnemo_mcp.embedder.init_backend") as mock_init:
+            mock_init.side_effect = Exception("Test init exception")
+
+            # Use log capture or patch logger to verify the log occurs
+            with patch("mnemo_mcp.server.logger.error") as mock_error:
+                from mnemo_mcp.server import _init_embedding_backend
+
+                await _init_embedding_backend("local", ctx)
+
+                # Should not update ctx
+                assert ctx["embedding_model"] is None
+
+                # Should have logged the error
+                mock_error.assert_called_with(
+                    "Local embedding init failed: Test init exception"
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.10.0b1"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The exception handling block in `mnemo_mcp.server._init_embedding_backend` was lacking test coverage for the scenario where local model initialization fails (i.e. `init_backend` raises an Exception).

📊 **Coverage:** Added the `TestServerInit.test_init_embedding_backend_exception` test which specifically mocks `mnemo_mcp.embedder.init_backend` to raise an Exception. The test asserts that the exception is gracefully caught, the expected error is logged using `logger.error`, and the context (`ctx["embedding_model"]`) remains unmodified (`None`).

✨ **Result:** Increased test coverage by ensuring the fallback and error logging mechanisms during local embedding model initialization function properly and prevent unhandled exceptions.

---
*PR created automatically by Jules for task [14083551703942909838](https://jules.google.com/task/14083551703942909838) started by @n24q02m*