### PR TITLE
fix: improvement] Add mock assertions to Token Store chmod OSError tests

### DIFF
--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -119,11 +119,14 @@ class TestSaveToken:
         with (
             patch("mnemo_mcp.token_store.settings") as m,
             patch("mnemo_mcp.token_store.os.name", "posix"),
-            patch.object(Path, "chmod", side_effect=mock_chmod, autospec=True),
+            patch.object(
+                Path, "chmod", side_effect=mock_chmod, autospec=True
+            ) as mock_path_chmod,
         ):
             m.get_data_dir.return_value = token_dir.parent
             # This should ignore the OSError from token_dir.chmod
             save_token("drive", token)
+            assert mock_path_chmod.call_count == 2
 
         saved = json.loads((token_dir / "drive.json").read_text())
         assert saved["access_token"] == "abc"
@@ -145,11 +148,14 @@ class TestSaveToken:
         with (
             patch("mnemo_mcp.token_store.settings") as m,
             patch("mnemo_mcp.token_store.os.name", "posix"),
-            patch.object(Path, "chmod", side_effect=mock_chmod, autospec=True),
+            patch.object(
+                Path, "chmod", side_effect=mock_chmod, autospec=True
+            ) as mock_path_chmod,
         ):
             m.get_data_dir.return_value = token_dir.parent
             # This should ignore the OSError from path.chmod
             save_token("drive", token)
+            assert mock_path_chmod.call_count == 2
 
         saved = json.loads((token_dir / "drive.json").read_text())
         assert saved["access_token"] == "abc"


### PR DESCRIPTION
🎯 **What:** The existing testing gap in `token_store.py`'s `chmod` `OSError` handling tests. While the conditional `OSError` was raised via a mocked `Path.chmod` side-effect, the tests (`test_save_chmod_dir_oserror` and `test_save_chmod_file_oserror`) completely lacked any assertion to verify that `chmod` was actually executed. This resulted in false positive tests that would silently pass even if `chmod` was removed from the codebase.
📊 **Coverage:** The tests now actively assert `mock_path_chmod.call_count == 2` validating that both the token directory and token file had their permissions attempted to be altered, raising and safely trapping the `OSError` in execution.
✨ **Result:** Improved test reliability, guaranteeing that `OSError` handling and ignoring continues successfully without interrupting the token saving process.

---
*PR created automatically by Jules for task [13879101250655216702](https://jules.google.com/task/13879101250655216702) started by @n24q02m*