### PR TITLE
fix: test JSONDecodeError logging in _interactive_auth]

### DIFF
--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -844,6 +844,40 @@ class TestInteractiveAuth:
             result = await _interactive_auth(rclone_path, "drive")
             assert result is None
 
+    async def test_auth_invalid_extracted_json_logs_error(self, tmp_path, caplog):
+        import logging
+
+        from loguru import logger
+
+        from mnemo_mcp.sync import _interactive_auth
+
+        rclone_path = tmp_path / "rclone"
+
+        # The output has dashes but the JSON inside is invalid (e.g., missing quotes)
+        # This will pass _extract_token but fail json.loads()
+        invalid_json_output = "----\n{access_token: no_quotes}\n----"
+
+        class PropagateHandler(logging.Handler):
+            def emit(self, record):
+                logging.getLogger(record.name).handle(record)
+
+        handler_id = logger.add(PropagateHandler(), format="{message}")
+
+        with caplog.at_level(logging.ERROR):
+            with patch(
+                "mnemo_mcp.sync.asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=MagicMock(returncode=0, stdout=invalid_json_output),
+            ):
+                result = await _interactive_auth(rclone_path, "drive")
+                assert result is None
+                assert any(
+                    "Invalid token JSON from rclone" in record.message
+                    for record in caplog.records
+                )
+
+        logger.remove(handler_id)
+
 
 # ---------------------------------------------------------------------------
 # _has_token_available


### PR DESCRIPTION
🎯 **What:** Added a test targeting the `except json.JSONDecodeError` block in `_interactive_auth` to assert that it logs the expected error message when parsed extracted token JSON is invalid.
📊 **Coverage:** Covered the log error path in `_interactive_auth` inside `src/mnemo_mcp/sync.py:531` ensuring the system fails gracefully with an explicit message.
✨ **Result:** Enhanced the unit test suite with 1 additional error-path validation, confirming accurate and visible error logging to the console.

---
*PR created automatically by Jules for task [10324307284904223188](https://jules.google.com/task/10324307284904223188) started by @n24q02m*