### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in run_setup_sync

### DIFF
--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -158,8 +158,12 @@ async def run_setup_sync(provider: str = "drive") -> dict:
 
     Returns a structured dict with setup results.
     """
+    from mnemo_mcp.config import RCLONE_PROVIDERS
     from mnemo_mcp.sync import _download_rclone, _extract_token, _get_rclone_path
     from mnemo_mcp.token_store import get_token_path, save_token
+
+    if provider not in RCLONE_PROVIDERS:
+        return {"status": "error", "error": f"Invalid provider: {provider}"}
 
     rclone_path = _get_rclone_path()
     if not rclone_path:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `run_setup_sync` lacked argument validation for `provider`.
🎯 Impact: If called directly, an attacker could potentially execute arbitrary commands via `subprocess.run` through argument injection in the `rclone authorize` command.
🔧 Fix: Added an allowlist validation check for `provider` using `RCLONE_PROVIDERS`.
✅ Verification: Tests run via pytest to ensure no regressions.

---
*PR created automatically by Jules for task [18141712499118246929](https://jules.google.com/task/18141712499118246929) started by @n24q02m*