### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions race condition in token store

### DIFF
--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -70,7 +70,13 @@ def save_token(provider: str, token: dict) -> None:
             pass
 
     path = get_token_path(provider)
-    path.write_text(json.dumps(token, indent=2), encoding="utf-8")
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR  # 0600
+
+    fd = os.open(path, flags, mode)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(token, f, indent=2)
 
     # Secure file permissions (Unix only)
     if os.name != "nt":

--- a/uv.lock
+++ b/uv.lock
@@ -573,7 +573,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.11.0b1"
+version = "1.11.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) / Insecure File Creation. The token file containing sensitive API keys is created with default permissions and then `chmod` is applied. In the brief time window before `chmod` is called, the token could be read by other local users.
🎯 Impact: A local attacker could read the sensitive tokens from the filesystem.
🔧 Fix: Use `os.open` with `O_CREAT` and `mode=0o600` to atomically create the file with restricted permissions.
✅ Verification: Tests pass and confirm permissions are restricted.

---
*PR created automatically by Jules for task [3748790809370046109](https://jules.google.com/task/3748790809370046109) started by @n24q02m*