### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in token storage

### DIFF
--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -70,14 +70,29 @@ def save_token(provider: str, token: dict) -> None:
             pass
 
     path = get_token_path(provider)
-    path.write_text(json.dumps(token, indent=2), encoding="utf-8")
+    token_json = json.dumps(token, indent=2)
 
-    # Secure file permissions (Unix only)
     if os.name != "nt":
         try:
-            path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+            # Prevent TOCTOU vulnerability by setting permissions on creation
+            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            mode = stat.S_IRUSR | stat.S_IWUSR  # 0600
+            fd = os.open(path, flags, mode)
+            try:
+                # Ensure existing files also get their permissions restricted
+                os.fchmod(fd, mode)
+            except OSError:
+                pass
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(token_json)
         except OSError:
-            pass
+            path.write_text(token_json, encoding="utf-8")
+            try:
+                path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                pass
+    else:
+        path.write_text(token_json, encoding="utf-8")
 
     logger.info(f"Token saved: {path}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.11.0"
+version = "1.12.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the sensitive token file briefly exists with potentially world-readable permissions before `chmod` is called.
🎯 Impact: Another process/user could potentially read the OAuth token and gain unauthorized access to the provider (e.g. Google Drive).
🔧 Fix: Use `os.open` with explicit mode permissions (like `0600`) and creation flags (`os.O_CREAT | os.O_WRONLY | os.O_TRUNC`) instead of writing the file and subsequently applying `chmod`.
✅ Verification: Ensure tests pass and the local token is properly scoped.

---
*PR created automatically by Jules for task [8751272962581187990](https://jules.google.com/task/8751272962581187990) started by @n24q02m*