### PR TITLE
[CLEANUP] Broad Exception Catching

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -116,7 +116,7 @@ class MemoryDB:
                 self._conn.enable_load_extension(False)
                 self._vec_enabled = True
                 logger.debug(f"sqlite-vec loaded (dims={embedding_dims})")
-            except Exception as e:
+            except (RuntimeError, sqlite3.Error, ImportError) as e:
                 logger.warning(f"sqlite-vec load failed: {e}")
 
         self._init_schema()


### PR DESCRIPTION
Replaced broad Exception catch in src/mnemo_mcp/db.py with specific (RuntimeError, sqlite3.Error, ImportError) to improve error handling and prevent masking of critical system exceptions like KeyboardInterrupt or SystemExit during sqlite-vec loading.

---
*PR created automatically by Jules for task [7035422125639296386](https://jules.google.com/task/7035422125639296386) started by @n24q02m*