### PR TITLE
[CLEANUP] Broad Exception Catching

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -247,7 +247,7 @@ class MemoryDB:
             self._conn.execute(
                 "ALTER TABLE memories ADD COLUMN importance REAL NOT NULL DEFAULT 0.5"
             )
-        except Exception:
+        except sqlite3.OperationalError:
             pass  # Column already exists
 
         # sqlite-vec virtual table (only if enabled)
@@ -457,7 +457,7 @@ class MemoryDB:
                             "vec_score": 0.0,
                         }
                     break
-            except Exception:
+            except sqlite3.Error:
                 continue
 
         fts_vals = [m["fts_score"] for m in results.values() if m["fts_score"] > 0]
@@ -735,7 +735,7 @@ class MemoryDB:
                 if line:
                     try:
                         iterator.append(json.loads(line))
-                    except Exception:
+                    except json.JSONDecodeError:
                         rejected += 1
         else:
             iterator = []
@@ -762,7 +762,7 @@ class MemoryDB:
                         continue
 
                     parsed_batch.append((memory_id, mem, content))
-                except Exception:
+                except (AttributeError, TypeError):
                     rejected += 1
                     continue
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.14.0b1"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Refined broad exception catching in src/mnemo_mcp/db.py to avoid catching SystemExit and KeyboardInterrupt. Replaced Exception with specific exceptions like sqlite3.OperationalError, sqlite3.Error, json.JSONDecodeError, AttributeError, and TypeError where appropriate.

Specifically:
- Line 250: Changed `Exception` to `sqlite3.OperationalError` for migration column check.
- Line 460: Changed `Exception` to `sqlite3.Error` for FTS5 search.
- Line 738: Changed `Exception` to `json.JSONDecodeError` for JSONL line parsing.
- Line 765: Changed `Exception` to `(AttributeError, TypeError)` for memory object validation.

Verified with existing tests and a reproduction script for the refined exceptions.

---
*PR created automatically by Jules for task [9250275038492120236](https://jules.google.com/task/9250275038492120236) started by @n24q02m*