### PR TITLE
[CLEANUP] Broad Exception Catching

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -247,7 +247,7 @@ class MemoryDB:
             self._conn.execute(
                 "ALTER TABLE memories ADD COLUMN importance REAL NOT NULL DEFAULT 0.5"
             )
-        except Exception:
+        except sqlite3.OperationalError:
             pass  # Column already exists
 
         # sqlite-vec virtual table (only if enabled)
@@ -457,7 +457,7 @@ class MemoryDB:
                             "vec_score": 0.0,
                         }
                     break
-            except Exception:
+            except sqlite3.Error:
                 continue
 
         fts_vals = [m["fts_score"] for m in results.values() if m["fts_score"] > 0]
@@ -735,7 +735,7 @@ class MemoryDB:
                 if line:
                     try:
                         iterator.append(json.loads(line))
-                    except Exception:
+                    except (json.JSONDecodeError, TypeError):
                         rejected += 1
         else:
             iterator = []
@@ -762,7 +762,7 @@ class MemoryDB:
                         continue
 
                     parsed_batch.append((memory_id, mem, content))
-                except Exception:
+                except (AttributeError, TypeError):
                     rejected += 1
                     continue
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.14.0b1"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Replaced bare Exception catches in src/mnemo_mcp/db.py with more specific exception types (sqlite3.OperationalError, sqlite3.Error, json.JSONDecodeError, AttributeError, TypeError) to avoid hiding system signals like KeyboardInterrupt and SystemExit.

---
*PR created automatically by Jules for task [13715620883803877704](https://jules.google.com/task/13715620883803877704) started by @n24q02m*