### PR TITLE
[CLEANUP] Broad Exception Catching

### DIFF
--- a/src/mnemo_mcp/relay_setup.py
+++ b/src/mnemo_mcp/relay_setup.py
@@ -46,7 +46,7 @@ def load_relay_config() -> dict[str, str] | None:
             logger.info("Config loaded from file")
             return saved
         return None
-    except Exception:
+    except (ImportError, OSError, ValueError):
         return None
 
 
@@ -87,7 +87,7 @@ async def ensure_config() -> dict[str, str] | None:
         from .relay_schema import RELAY_SCHEMA
 
         session = await create_session(relay_url, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
-    except Exception:
+    except (ImportError, ConnectionError, RuntimeError):
         logger.debug("Cannot reach relay server at {}. Using local mode.", relay_url)
         return None
 
@@ -125,7 +125,7 @@ async def ensure_config() -> dict[str, str] | None:
                         "text": "API keys saved. Starting Google Drive sync setup...",
                     },
                 )
-        except Exception:
+        except (ImportError, httpx.HTTPError):
             pass
 
         # Trigger GDrive OAuth Device Code using default client ID from settings
@@ -141,11 +141,13 @@ async def ensure_config() -> dict[str, str] | None:
                     relay_url=relay_url,
                     session_id=session.session_id,
                 )
-            except Exception as e:
+            except (ImportError, RuntimeError, ValueError) as e:
                 logger.warning(f"GDrive OAuth setup failed: {e}")
 
         # NOW send complete (after GDrive OAuth finishes or skips)
         try:
+            import httpx
+
             async with httpx.AsyncClient() as http:
                 msg = (
                     "Setup complete!"
@@ -156,7 +158,7 @@ async def ensure_config() -> dict[str, str] | None:
                     f"{relay_url}/api/sessions/{session.session_id}/messages",
                     json={"type": "complete", "text": msg},
                 )
-        except Exception:
+        except (ImportError, httpx.HTTPError):
             pass
 
         return config

--- a/tests/test_relay_setup_coverage.py
+++ b/tests/test_relay_setup_coverage.py
@@ -89,7 +89,7 @@ class TestLoadRelayConfigCoverage:
     @patch("mcp_relay_core.storage.config_file.read_config")
     def test_returns_none_on_generic_exception(self, mock_read):
         """Returns None on any exception."""
-        mock_read.side_effect = RuntimeError("Unexpected error")
+        mock_read.side_effect = OSError("Unexpected error")
         result = load_relay_config()
         assert result is None
 
@@ -246,7 +246,7 @@ class TestEnsureConfigCoverage:
             patch(
                 "mnemo_mcp.sync.setup_google_auth",
                 new_callable=AsyncMock,
-                side_effect=Exception("GDrive OAuth failed"),
+                side_effect=RuntimeError("GDrive OAuth failed"),
             ),
         ):
             mock_client = AsyncMock()
@@ -267,7 +267,7 @@ class TestEnsureConfigCoverage:
         for key in CLOUD_KEYS:
             monkeypatch.delenv(key, raising=False)
         mock_read.return_value = None
-        mock_session.side_effect = Exception("DNS resolution failed")
+        mock_session.side_effect = ConnectionError("DNS resolution failed")
 
         result = await ensure_config()
         assert result is None
@@ -295,8 +295,10 @@ class TestEnsureConfigCoverage:
             patch("httpx.AsyncClient") as mock_httpx,
             patch("mnemo_mcp.config.settings") as mock_settings,
         ):
+            import httpx
+
             mock_client = AsyncMock()
-            mock_client.post.side_effect = Exception("Network error")
+            mock_client.post.side_effect = httpx.ConnectError("Network error")
             mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
             mock_settings.google_drive_client_id = ""

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.14.0b1"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Replaces bare 'except Exception:' clauses with specific exception types in src/mnemo_mcp/relay_setup.py to prevent hiding KeyboardInterrupt, SystemExit, and other unrelated errors. This improves code quality and error visibility.

---
*PR created automatically by Jules for task [16456822271239135211](https://jules.google.com/task/16456822271239135211) started by @n24q02m*