### PR TITLE
[FIX] N+1 Query in FTS Search Fallback

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -423,42 +423,62 @@ class MemoryDB:
         """Execute FTS5 search with tiered queries and BM25 column weights."""
         results: dict[str, dict] = {}
         fts_queries = _build_fts_queries(query)
+        if not fts_queries:
+            return results
 
-        for fts_query in fts_queries:
-            try:
-                fts_sql = """
-                    SELECT m.*,
-                           bm25(memories_fts, 0.0, 1.0, 0.0, 5.0) AS bm25_score
-                    FROM memories_fts f
-                    JOIN memories m ON f.id = m.id
-                    WHERE memories_fts MATCH ?
-                """
-                fts_params: list = [fts_query]
+        # Tiered Search Optimization:
+        # Combines PHRASE, AND, and OR queries into a single UNION ALL query.
+        # Uses a CTE to identify the highest-priority tier (lowest index) with matches,
+        # ensuring we break early and avoid N+1 query overhead.
+        subqueries = []
+        fts_params = []
 
-                if category:
-                    fts_sql += " AND m.category = ?"
-                    fts_params.append(category)
+        filter_sql = ""
+        filter_params = []
+        if category:
+            filter_sql += " AND m.category = ?"
+            filter_params.append(category)
+        if tags:
+            tag_placeholders = ",".join("?" for _ in tags)
+            filter_sql += f" AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
+            filter_params.extend(tags)
 
-                if tags:
-                    tag_placeholders = ",".join("?" for _ in tags)
-                    fts_sql += f" AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
-                    fts_params.extend(tags)
+        for idx, fts_query in enumerate(fts_queries):
+            subqueries.append(f"""
+                SELECT m.*,
+                       bm25(memories_fts, 0.0, 1.0, 0.0, 5.0) AS bm25_score,
+                       {idx} as tier_idx
+                FROM memories_fts f
+                JOIN memories m ON f.id = m.id
+                WHERE memories_fts MATCH ? {filter_sql}
+            """)
+            fts_params.append(fts_query)
+            fts_params.extend(filter_params)
 
-                fts_sql += " ORDER BY bm25_score LIMIT ?"
-                fts_params.append(limit * 3)
+        union_sql = " UNION ALL ".join(subqueries)
+        fts_sql = f"""
+            WITH all_matches AS (
+                {union_sql}
+            )
+            SELECT *
+            FROM all_matches
+            WHERE tier_idx = (SELECT MIN(tier_idx) FROM all_matches)
+            ORDER BY bm25_score
+            LIMIT ?
+        """
+        fts_params.append(limit * 3)
 
-                rows = self._conn.execute(fts_sql, fts_params).fetchall()
-                if rows:
-                    for row in rows:
-                        mid = row["id"]
-                        results[mid] = {
-                            **dict(row),
-                            "fts_score": -row["bm25_score"],
-                            "vec_score": 0.0,
-                        }
-                    break
-            except Exception:
-                continue
+        try:
+            rows = self._conn.execute(fts_sql, fts_params).fetchall()
+            for row in rows:
+                mid = row["id"]
+                results[mid] = {
+                    **dict(row),
+                    "fts_score": -row["bm25_score"],
+                    "vec_score": 0.0,
+                }
+        except Exception as e:
+            logger.error(f"FTS search failed: {e}")
 
         fts_vals = [m["fts_score"] for m in results.values() if m["fts_score"] > 0]
         if fts_vals:


### PR DESCRIPTION
Refactor the FTS search fallback logic in _search_fts to execute a single database query instead of multiple tiered queries. This uses a Common Table Expression (CTE) and UNION ALL to combine result sets from different query tiers (PHRASE, AND, OR) and selects matches from the highest priority tier that returns results. This eliminates the N+1 query pattern while maintaining the same fallback behavior and prioritization.

---
*PR created automatically by Jules for task [386254887966811772](https://jules.google.com/task/386254887966811772) started by @n24q02m*