### PR TITLE
[CLEANUP] Broad Exception Catching

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -1,6 +1,7 @@
 """Lightweight knowledge graph: entity extraction + relation management."""
 
 import json
+import sqlite3
 import os
 import uuid
 from datetime import UTC, datetime
@@ -167,7 +168,7 @@ async def extract_entities(content: str) -> dict | None:
             if isinstance(r, dict) and r.get("type", "").lower() in _VALID_RELS
         ]
         return data
-    except Exception as e:
+    except (json.JSONDecodeError, ValueError, RuntimeError) as e:
         logger.debug(f"Entity extraction failed: {e}")
         return None
 
@@ -204,7 +205,7 @@ async def score_importance(content: str) -> float:
 
         score = float(text.strip())
         return max(0.0, min(1.0, score))
-    except Exception as e:
+    except (ValueError, RuntimeError) as e:
         logger.debug(f"Importance scoring failed: {e}")
         return 0.5
 
@@ -318,7 +319,7 @@ def link_memory_entities(conn, memory_id: str, entity_ids: list[str]) -> None:
             "INSERT OR IGNORE INTO memory_entities (memory_id, entity_id) VALUES (?, ?)",
             params,
         )
-    except Exception as e:
+    except sqlite3.Error as e:
         logger.debug(f"Failed to link memory entities: {e}")
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -66,7 +66,7 @@ class TestExtractEntities:
             patch(
                 "mnemo_mcp.graph._llm_completion",
                 new_callable=AsyncMock,
-                side_effect=Exception("API error"),
+                side_effect=RuntimeError("API error"),
             ),
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
@@ -183,7 +183,7 @@ class TestScoreImportance:
             patch(
                 "mnemo_mcp.graph._llm_completion",
                 new_callable=AsyncMock,
-                side_effect=Exception("API error"),
+                side_effect=RuntimeError("API error"),
             ),
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -9,6 +9,7 @@ find_related_memory_ids no_new_ids early break.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import sqlite3
 from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.graph import (
     _has_llm_provider,
@@ -372,7 +373,7 @@ class TestLinkMemoryEntitiesCoverage:
     def test_exception_is_caught(self, tmp_db: MemoryDB):
         """Exception during linking is caught and logged."""
         conn = MagicMock()
-        conn.executemany.side_effect = Exception("DB error")
+        conn.executemany.side_effect = sqlite3.Error("DB error")
         # Should not raise
         link_memory_entities(conn, "fake-id", ["eid1", "eid2"])
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.14.0b1"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Replaced broad `except Exception` clauses in `src/mnemo_mcp/graph.py` with more specific exception types (`sqlite3.Error`, `json.JSONDecodeError`, `ValueError`, `RuntimeError`). This prevents catching system-level exceptions and improves code quality by being more explicit about expected failure modes. Updated corresponding tests to use specific exception types in mocks.

---
*PR created automatically by Jules for task [16092559224673492629](https://jules.google.com/task/16092559224673492629) started by @n24q02m*