### PR TITLE
[CLEANUP] Broad Exception Catching

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -21,7 +21,7 @@ def _detect_gpu() -> bool:
         return (
             "CUDAExecutionProvider" in providers or "DmlExecutionProvider" in providers
         )
-    except Exception:
+    except (ImportError, RuntimeError):
         return False
 
 

--- a/tests/test_config_helpers.py
+++ b/tests/test_config_helpers.py
@@ -37,7 +37,7 @@ class TestDetectGPU:
 
     def test_runtime_exception(self):
         mock_ort = MagicMock()
-        mock_ort.get_available_providers.side_effect = Exception("Runtime error")
+        mock_ort.get_available_providers.side_effect = RuntimeError("Runtime error")
         with patch.dict(sys.modules, {"onnxruntime": mock_ort}):
             assert _detect_gpu() is False
 
@@ -48,7 +48,7 @@ class TestDetectGPU:
 
         def mock_import(name, *args, **kwargs):
             if name == "onnxruntime":
-                raise Exception("Mocked Exception")
+                raise ImportError("Mocked ImportError")
             return orig_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=mock_import):

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.14.0b1"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
This PR addresses a broad exception catching issue in the `_detect_gpu` function within `src/mnemo_mcp/config.py`. By replacing the generic `except Exception:` with `except (ImportError, RuntimeError):`, we ensure that critical exceptions like `KeyboardInterrupt` and `SystemExit` are not accidentally caught, while still gracefully handling expected failures such as missing dependencies or runtime issues during GPU detection. Accompanying tests in `tests/test_config_helpers.py` have also been updated to use these specific exception types.

---
*PR created automatically by Jules for task [8484260793355356612](https://jules.google.com/task/8484260793355356612) started by @n24q02m*