### PR TITLE
[CLEANUP] Broad Exception Catching

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -70,7 +70,7 @@ async def _init_embedding_backend(
                 else:
                     logger.warning(f"Embedding model {embedding_model} not available")
                     embedding_model = None
-            except Exception as e:
+            except (ValueError, ImportError, RuntimeError) as e:
                 logger.warning(f"Embedding model {embedding_model} not available: {e}")
                 embedding_model = None
         elif mode == "sdk":
@@ -90,7 +90,7 @@ async def _init_embedding_backend(
                         ctx["embedding_model"] = embedding_model
                         ctx["embedding_dims"] = embedding_dims
                         return
-                except Exception:
+                except (ValueError, ImportError, RuntimeError):
                     continue
 
         # Cloud not available -- fallback to local
@@ -113,7 +113,7 @@ async def _init_embedding_backend(
             ctx["embedding_dims"] = embedding_dims
         else:
             logger.error("Local embedding model not available")
-    except Exception as e:
+    except (ValueError, ImportError, RuntimeError) as e:
         logger.error(f"Local embedding init failed: {e}")
 
 
@@ -140,7 +140,7 @@ async def _init_reranker_backend(mode: str) -> None:
                 if available:
                     logger.info(f"Reranker: {model}")
                     return
-            except Exception as e:
+            except (ValueError, ImportError, RuntimeError) as e:
                 logger.warning(f"Reranker {model} not available: {e}")
         logger.warning("Cloud reranker not available, using local fallback")
 
@@ -153,7 +153,7 @@ async def _init_reranker_backend(mode: str) -> None:
             logger.info(f"Reranker: local {local_model}")
         else:
             logger.error("Local reranker not available")
-    except Exception as e:
+    except (ValueError, ImportError, RuntimeError) as e:
         logger.error(f"Local reranker init failed: {e}")
 
 
@@ -188,7 +188,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
                 settings.google_drive_client_id = gdrive_id
 
             logger.info("Cloud API keys loaded from relay config")
-    except Exception as e:
+    except (ValueError, ImportError, RuntimeError) as e:
         logger.debug(f"Relay config not available: {e}")
 
     # 1. Setup provider mode (sdk/local)
@@ -324,7 +324,7 @@ async def _embed(
         if is_query and isinstance(backend, Qwen3EmbedBackend):
             return await backend.embed_single_query(text, dims)
         return await backend.embed_single(text, dims)
-    except Exception as e:
+    except (ValueError, ImportError, RuntimeError) as e:
         logger.debug(f"Embedding failed: {e}")
         return None
 
@@ -355,7 +355,7 @@ async def _handle_add(
             dedup_warning = dedup_result
         elif dedup_result and dedup_result.get("similar"):
             dedup_warning = dedup_result
-    except Exception:
+    except (ValueError, ImportError, RuntimeError):
         pass  # Non-blocking, ignore errors
 
     embedding = await _embed(content, embedding_model, embedding_dims)
@@ -369,7 +369,7 @@ async def _handle_add(
         )
     except ValueError as e:
         return _json({"error": str(e)})
-    except Exception:
+    except (ImportError, RuntimeError):
         logger.exception("Unexpected error in _handle_add")
         return _json({"error": "Internal error while adding memory"})
 
@@ -402,7 +402,7 @@ async def _enrich_memory(db: MemoryDB, memory_id: str, content: str) -> None:
         importance = await score_importance(content)
         if importance != 0.5:
             await asyncio.to_thread(db.update_importance, memory_id, importance)
-    except Exception as e:
+    except (ValueError, ImportError, RuntimeError) as e:
         logger.debug(f"Importance scoring background error: {e}")
 
     try:
@@ -419,7 +419,7 @@ async def _enrich_memory(db: MemoryDB, memory_id: str, content: str) -> None:
                 create_relations(conn, graph_data["relations"], name_to_id)
             link_memory_entities(conn, memory_id, entity_ids)
             conn.commit()
-    except Exception as e:
+    except (ValueError, ImportError, RuntimeError) as e:
         logger.debug(f"Entity extraction background error: {e}")
 
 
@@ -472,7 +472,7 @@ async def _handle_search(
                     reranked_results.append(r)
                 results = reranked_results
                 reranked = True
-        except Exception as e:
+        except (ValueError, ImportError, RuntimeError) as e:
             logger.debug(f"Reranking failed, using original order: {e}")
 
     # Graph boost: find related memories via entity graph
@@ -489,7 +489,7 @@ async def _handle_search(
                 for r in results:
                     if r["id"] in related_set:
                         r["graph_related"] = True
-        except Exception:
+        except (ValueError, ImportError, RuntimeError):
             pass  # Non-blocking
 
     response: dict = {
@@ -561,7 +561,7 @@ async def _handle_update(
         )
     except ValueError as e:
         return _json({"error": str(e)})
-    except Exception:
+    except (ImportError, RuntimeError):
         logger.exception("Unexpected error in _handle_update")
         return _json({"error": "Internal error while updating memory"})
     if ok:
@@ -726,7 +726,7 @@ async def _handle_consolidate(
                 "note": "Review the summary and use add/delete to apply changes.",
             }
         )
-    except Exception as e:
+    except (ValueError, ImportError, RuntimeError) as e:
         return _json({"error": f"Consolidation failed: {e}"})
 
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -137,7 +137,7 @@ async def test_lifespan_explicit_cloud_exception_fallback(
     backend_local = MagicMock()
     backend_local.check_available.return_value = 384
 
-    mock_embedder.side_effect = [Exception("API Error"), backend_local]
+    mock_embedder.side_effect = [RuntimeError("API Error"), backend_local]
 
     server = MagicMock()
     async with lifespan(server) as ctx:
@@ -155,7 +155,7 @@ async def test_lifespan_all_backends_fail(
     mock_settings.resolve_embedding_model.return_value = "crash-model"
 
     # Cloud raises, Local raises
-    mock_embedder.side_effect = [Exception("Cloud fail"), Exception("Local fail")]
+    mock_embedder.side_effect = [RuntimeError("Cloud fail"), RuntimeError("Local fail")]
 
     server = MagicMock()
     async with lifespan(server) as ctx:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,7 +167,7 @@ class TestWarmupInitEmbeddingBackend:
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
 
         mock_backend = MagicMock()
-        mock_backend.check_available.side_effect = Exception("import error")
+        mock_backend.check_available.side_effect = ImportError("import error")
         mock_init.return_value = mock_backend
 
         ctx: dict = {"embedding_model": None, "embedding_dims": 768}
@@ -194,7 +194,7 @@ class TestWarmupInitEmbeddingBackend:
         mock_settings.resolve_embedding_backend.return_value = "local"
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
 
-        mock_init.side_effect = Exception("Init Backend Failed")
+        mock_init.side_effect = RuntimeError("Init Backend Failed")
 
         ctx: dict = {"embedding_model": None, "embedding_dims": 768}
         await _init_embedding_backend("local", ctx)

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -59,7 +59,7 @@ class TestEmbed:
     async def test_embed_exception_returns_none(self):
         """Returns None when embedding raises an exception."""
         mock_backend = MagicMock()
-        mock_backend.embed_single = AsyncMock(side_effect=Exception("API error"))
+        mock_backend.embed_single = AsyncMock(side_effect=RuntimeError("API error"))
 
         with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
             result = await _embed("test text", "some-model", 768)
@@ -232,7 +232,7 @@ class TestInitEmbeddingBackendCandidate:
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
 
         # All candidates raise exception
-        mock_init.side_effect = Exception("API Error")
+        mock_init.side_effect = RuntimeError("API Error")
 
         # Local backend also fails
         ctx: dict = {"embedding_model": None, "embedding_dims": 768}
@@ -308,7 +308,7 @@ class TestMemoryLimitClamping:
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
 
         # Have init_backend throw an exception
-        mock_init.side_effect = Exception("init failed test error")
+        mock_init.side_effect = ValueError("init failed test error")
 
         ctx: dict = {"embedding_model": None, "embedding_dims": 768}
 

--- a/tests/test_server_embed.py
+++ b/tests/test_server_embed.py
@@ -54,7 +54,7 @@ async def test_embed_with_qwen3_backend_doc():
 async def test_embed_backend_exception():
     """Test _embed handles backend exceptions gracefully."""
     mock_backend = AsyncMock()
-    mock_backend.embed_single.side_effect = Exception("Embed error")
+    mock_backend.embed_single.side_effect = RuntimeError("Embed error")
 
     with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
         result = await _embed("text", "model", 768)

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -111,7 +111,7 @@ class TestInitRerankerBackend:
             nonlocal call_count
             call_count += 1
             if backend_type == "cloud":
-                raise Exception("Cloud init failed")
+                raise ValueError("Cloud init failed")
             return local_backend
 
         with patch("mnemo_mcp.reranker.init_reranker", side_effect=mock_init):
@@ -155,7 +155,7 @@ class TestInitRerankerBackend:
 
         with patch(
             "mnemo_mcp.reranker.init_reranker",
-            side_effect=Exception("ONNX not installed"),
+            side_effect=RuntimeError("ONNX not installed"),
         ):
             # Should not raise
             await _init_reranker_backend("local")
@@ -266,7 +266,7 @@ class TestEnrichMemory:
             patch(
                 "mnemo_mcp.graph.score_importance",
                 new_callable=AsyncMock,
-                side_effect=Exception("LLM error"),
+                side_effect=RuntimeError("LLM error"),
             ),
             patch(
                 "mnemo_mcp.graph.extract_entities",

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.14.0b1"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Refactored initialization logic in server.py to catch specific exceptions (ValueError, ImportError, RuntimeError) instead of broad Exception to prevent masking bugs. Updated relevant tests in tests/test_server_lifespan.py, tests/test_server_coverage.py, tests/test_main.py, tests/test_lifespan.py, and tests/test_server_embed.py to use these specific exception types for failure simulation. Verified changes with full test suite and linting.

---
*PR created automatically by Jules for task [11162603948339406154](https://jules.google.com/task/11162603948339406154) started by @n24q02m*