### PR TITLE
🛡️ Sentinel: [medium] Fix potential SQL injection in table creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Hardening SQLite Table Creation and Updates
+**Learning:** Dynamically constructing SQL statements with f-strings, even for internal parameters like table dimensions or column names, is a potential injection vector if those parameters ever become user-controlled.
+**Action:** Implemented strict bounds validation for vector dimensions and allowlist validation for dynamic update columns.

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -94,6 +94,10 @@ class MemoryDB:
                 f"embedding_dims must be an integer, got {type(embedding_dims).__name__}"
             )
         self._embedding_dims = embedding_dims
+        if not (0 <= embedding_dims <= 10000):
+            raise ValueError(
+                f"embedding_dims must be between 0 and 10000, got {embedding_dims}"
+            )
         self._recency_half_life = float(recency_half_life_days)
 
         # Create parent directory
@@ -257,7 +261,15 @@ class MemoryDB:
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='memories_vec'"
             ).fetchone()
             if not row:
+                # Sentinel Security Hardening:
+                # Explicitly validate and cast dimensions before f-string interpolation
+                # to prevent potential SQL injection if the source ever becomes untrusted.
                 dims = int(self._embedding_dims)
+                if not (0 <= dims <= 10000):
+                    raise ValueError(
+                        f"embedding_dims must be between 0 and 10000, got {dims}"
+                    )
+
                 self._conn.execute(f"""
                     CREATE VIRTUAL TABLE memories_vec
                     USING vec0(
@@ -618,6 +630,14 @@ class MemoryDB:
         updates.append("updated_at = ?")
         params.append(now)
         params.append(memory_id)
+
+        # Sentinel Security Hardening:
+        # Validate updates list against an allowlist before string joining
+        # to ensure no unexpected column names are injected.
+        _ALLOWED = {"content = ?", "category = ?", "tags = ?", "updated_at = ?"}
+        if not all(u in _ALLOWED for u in updates):
+            invalid = [u for u in updates if u not in _ALLOWED]
+            raise ValueError(f"Unauthorized update columns detected: {invalid}")
 
         self._conn.execute(
             f"UPDATE memories SET {', '.join(updates)} WHERE id = ?",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -737,3 +737,13 @@ class TestDBInitSecurity:
 
         with pytest.raises(ValueError, match="embedding_dims must be an integer"):
             MemoryDB(db_path, embedding_dims=1536.5)  # type: ignore
+
+
+def test_invalid_embedding_dims(tmp_path):
+    """Test that invalid embedding dimensions raise ValueError."""
+    from mnemo_mcp.db import MemoryDB
+
+    with pytest.raises(ValueError, match="embedding_dims must be between 0 and 10000"):
+        MemoryDB(tmp_path / "fail.db", embedding_dims=20000)
+    with pytest.raises(ValueError, match="embedding_dims must be between 0 and 10000"):
+        MemoryDB(tmp_path / "fail2.db", embedding_dims=-1)


### PR DESCRIPTION
This PR hardens the MemoryDB class against potential SQL injection by implementing strict validation for embedding dimensions during virtual table creation and adding allowlist checks for dynamic update columns. While these values were previously internally controlled or cast to integers, these changes provide defense-in-depth against future modifications that might expose these parameters to external input.

---
*PR created automatically by Jules for task [7423448528992518112](https://jules.google.com/task/7423448528992518112) started by @n24q02m*