### PR TITLE
[FIX] Complex Function `import_jsonl` in `db.py`

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -774,7 +774,7 @@ class MemoryDB:
                 if line:
                     try:
                         iterator.append(json.loads(line))
-                    except Exception:
+                    except Exception:  # tool safety
                         rejected += 1
         else:
             iterator = []
@@ -784,81 +784,95 @@ class MemoryDB:
 
         for i in range(0, len(lines), BATCH_SIZE):
             batch_items = lines[i : i + BATCH_SIZE]
-            parsed_batch = []
-
-            # Validate batch
-            for mem in batch_items:
-                try:
-                    memory_id = mem.get("id", uuid.uuid4().hex)
-                    content = mem.get("content", "")
-
-                    if len(content) > MAX_CONTENT_LENGTH:
-                        logger.warning(
-                            f"[AUDIT] import rejected id={memory_id} "
-                            f"len={len(content)} exceeds {MAX_CONTENT_LENGTH}"
-                        )
-                        rejected += 1
-                        continue
-
-                    parsed_batch.append((memory_id, mem, content))
-                except Exception:
-                    rejected += 1
-                    continue
-
-            if not parsed_batch:
-                continue
-
-            to_insert = []
-            now = _now_iso()
-
-            for memory_id, mem, content in parsed_batch:
-                tags = mem.get("tags", [])
-                if isinstance(tags, list):
-                    tags_json = json.dumps(tags)
-                else:
-                    tags_json = tags
-
-                to_insert.append(
-                    (
-                        memory_id,
-                        content,
-                        mem.get("category", "general"),
-                        tags_json,
-                        mem.get("source"),
-                        mem.get("created_at", now),
-                        mem.get("updated_at", now),
-                        mem.get("access_count", 0),
-                        mem.get("last_accessed", now),
-                    )
-                )
-
-            if to_insert:
-                cursor = self._conn.cursor()
-                if mode == "replace":
-                    cursor.executemany(
-                        """INSERT OR REPLACE INTO memories
-                           (id, content, category, tags, source,
-                            created_at, updated_at, access_count, last_accessed)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                        to_insert,
-                    )
-                    imported += len(to_insert)
-                else:
-                    cursor.executemany(
-                        """INSERT OR IGNORE INTO memories
-                           (id, content, category, tags, source,
-                            created_at, updated_at, access_count, last_accessed)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                        to_insert,
-                    )
-                    inserted_batch = cursor.rowcount
-                    imported += inserted_batch
-                    skipped += len(to_insert) - inserted_batch
+            b_imp, b_skp, b_rej = self._process_import_batch(batch_items, mode)
+            imported += b_imp
+            skipped += b_skp
+            rejected += b_rej
 
         self._conn.commit()
         if imported > 0:
             logger.info(f"[AUDIT] import count={imported} mode={mode}")
         return {"imported": imported, "skipped": skipped, "rejected": rejected}
+
+    def _process_import_batch(
+        self, batch_items: list[dict], mode: str
+    ) -> tuple[int, int, int]:
+        """Process a batch of memories for import. (Internal tool safety)"""
+        imported = 0
+        skipped = 0
+        rejected = 0
+        parsed_batch = []
+
+        # Validate batch
+        for mem in batch_items:
+            try:
+                memory_id = mem.get("id", uuid.uuid4().hex)
+                content = mem.get("content", "")
+
+                if len(content) > MAX_CONTENT_LENGTH:
+                    logger.warning(
+                        f"[AUDIT] import rejected id={memory_id} "
+                        f"len={len(content)} exceeds {MAX_CONTENT_LENGTH}"
+                    )
+                    rejected += 1
+                    continue
+
+                parsed_batch.append((memory_id, mem, content))
+            except Exception:  # tool safety
+                rejected += 1
+                continue
+
+        if not parsed_batch:
+            return imported, skipped, rejected
+
+        to_insert = []
+        now = _now_iso()
+
+        for memory_id, mem, content in parsed_batch:
+            tags = mem.get("tags", [])
+            if isinstance(tags, list):
+                tags_json = json.dumps(tags)
+            else:
+                tags_json = tags
+
+            to_insert.append(
+                (
+                    memory_id,
+                    content,
+                    mem.get("category", "general"),
+                    tags_json,
+                    mem.get("source"),
+                    mem.get("created_at", now),
+                    mem.get("updated_at", now),
+                    mem.get("access_count", 0),
+                    mem.get("last_accessed", now),
+                )
+            )
+
+        if to_insert:
+            cursor = self._conn.cursor()
+            if mode == "replace":
+                cursor.executemany(
+                    """INSERT OR REPLACE INTO memories
+                       (id, content, category, tags, source,
+                        created_at, updated_at, access_count, last_accessed)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    to_insert,
+                )
+                imported += len(to_insert)
+            else:
+                cursor.executemany(
+                    """INSERT OR IGNORE INTO memories
+                       (id, content, category, tags, source,
+                        created_at, updated_at, access_count, last_accessed)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    to_insert,
+                )
+                inserted_batch = cursor.rowcount
+                imported += inserted_batch
+                skipped += len(to_insert) - inserted_batch
+
+        return imported, skipped, rejected
 
     def archive_old_memories(
         self, days: int = 90, importance_threshold: float = 0.3

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.15.1"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
This PR refactors the `import_jsonl` method in `src/mnemo_mcp/db.py` by extracting its complex inner loop logic into a dedicated private method `_process_import_batch`.

### Changes:
- Created `_process_import_batch(self, batch_items: list[dict], mode: str) -> tuple[int, int, int]` to handle validation, formatting, and batch database execution.
- Refactored `import_jsonl` to use this new method, reducing its size and complexity while correctly accumulating `imported`, `skipped`, and `rejected` counts.
- Maintained "tool safety" by preserving broad exception catches where appropriate for robustness against malformed input.
- Ensured transaction boundaries (commits) remain at the `import_jsonl` level.

### Verification:
- Ran `uv run pytest tests/test_db.py` (100% pass).
- Ran full test suite `uv run pytest` (666 tests pass).
- Verified linting and formatting with `ruff`.
- The refactor preserves original functionality and edge-case handling.

---
*PR created automatically by Jules for task [4055922999077301790](https://jules.google.com/task/4055922999077301790) started by @n24q02m*