### PR TITLE
[FIX] Complex Function `config` in `server.py`

### DIFF
--- a/config_refactor.diff
+++ b/config_refactor.diff
@@ -1,0 +1,116 @@
+<<<<<<< SEARCH
+    match action:
+        case "status":
+            s = await asyncio.to_thread(db.stats)
+            return _json(
+                {
+                    "database": {
+                        "path": str(settings.get_db_path()),
+                        "total_memories": s["total_memories"],
+                        "categories": s["categories"],
+                        "vec_enabled": s["vec_enabled"],
+                    },
+                    "embedding": {
+                        "model": embedding_model,
+                        "dims": embedding_dims,
+                        "available": embedding_model is not None,
+                    },
+                    "sync": {
+                        "enabled": settings.sync_enabled,
+                        "provider": "google_drive",
+                        "folder": settings.sync_folder,
+                        "interval": settings.sync_interval,
+                    },
+                }
+            )
+
+        case "sync":
+            from mnemo_mcp.sync import sync_full
+
+            result = await sync_full(db)
+            return _json(result)
+
+        case "set":
+            if not key or value is None:
+                return _json({"error": "key and value are required for set"})
+
+            valid_keys = {
+                "sync_enabled",
+                "sync_interval",
+                "log_level",
+            }
+            if key not in valid_keys:
+                return _json(
+                    {
+                        "error": f"Invalid key: {key}",
+                        "valid_keys": sorted(valid_keys),
+                    }
+                )
+
+            # Apply setting
+            if key == "sync_enabled":
+                settings.sync_enabled = value.lower() in ("true", "1", "yes")
+            elif key == "sync_interval":
+                settings.sync_interval = int(value)
+            elif key == "log_level":
+                level = value.upper()
+                valid_levels = {
+                    "TRACE",
+                    "DEBUG",
+                    "INFO",
+                    "SUCCESS",
+                    "WARNING",
+                    "ERROR",
+                    "CRITICAL",
+                }
+                if level not in valid_levels:
+                    return _json(
+                        {
+                            "error": f"Invalid log level: {value}",
+                            "valid_levels": sorted(valid_levels),
+                        }
+                    )
+
+                settings.log_level = level
+                logger.remove()
+                logger.add(
+                    sys.stderr,
+                    level=settings.log_level,
+                )
+
+            return _json(
+                {
+                    "status": "updated",
+                    "key": key,
+                    "value": getattr(settings, key),
+                }
+            )
+
+        case "warmup":
+            from mnemo_mcp.setup_tool import run_warmup
+
+            result = await run_warmup()
+            return _json(result)
+
+        case "setup_sync":
+            from mnemo_mcp.setup_tool import run_setup_sync
+
+            result = await run_setup_sync()
+            return _json(result)
+=======
+    match action:
+        case "status":
+            return await _handle_config_status(db, embedding_model, embedding_dims)
+
+        case "sync":
+            return await _handle_config_sync(db)
+
+        case "set":
+            return await _handle_config_set(key, value)
+
+        case "warmup":
+            return await _handle_config_warmup()
+
+        case "setup_sync":
+            return await _handle_config_setup_sync()
+>>>>>>> REPLACE

--- a/mnemo_mcp_config_refactor_learning.md
+++ b/mnemo_mcp_config_refactor_learning.md
@@ -1,0 +1,18 @@
+# Learning: Refactoring Complex Tool Functions in mnemo_mcp
+
+## Context
+In `src/mnemo_mcp/server.py`, several MCP tools (e.g., `memory`, `config`) are implemented as large functions with a `match action:` block. This pattern, while functional, can lead to high cognitive load and maintainability issues as the number of actions grows.
+
+## Pattern: Tiered Dispatcher
+The repository follows a tiered dispatcher pattern for complex tools:
+1. **Tool Entry Point**: The `@mcp.tool` function handles documentation, context retrieval (`_get_ctx`), and parameter normalization (e.g., clamping `limit`).
+2. **Dispatcher**: A `match action:` block routes the request to action-specific async handlers.
+3. **Action Handlers**: Private async functions (e.g., `_handle_config_status`, `_handle_config_set`) implement the core logic for each action.
+
+## Implementation Details
+- **Lazy Imports**: Heavy dependencies or those only needed for specific actions should be imported inside the action handler (e.g., `from mnemo_mcp.sync import sync_full`).
+- **Standardized Response**: All tool actions return a JSON string via the `_json()` helper.
+- **Error Handling**: Handlers should return structured JSON errors instead of raising exceptions when possible, to provide graceful feedback to the MCP client.
+
+## Example Refactoring
+The `config` tool was refactored by extracting its `status`, `sync`, `set`, `warmup`, and `setup_sync` logic into `_handle_config_*` functions, significantly reducing the size of the main `config` function and aligning it with the pattern used for the `memory` tool.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -851,6 +851,111 @@ async def memory(
             )
 
 
+async def _handle_config_status(
+    db: MemoryDB, embedding_model: str | None, embedding_dims: int
+) -> str:
+    s = await asyncio.to_thread(db.stats)
+    return _json(
+        {
+            "database": {
+                "path": str(settings.get_db_path()),
+                "total_memories": s["total_memories"],
+                "categories": s["categories"],
+                "vec_enabled": s["vec_enabled"],
+            },
+            "embedding": {
+                "model": embedding_model,
+                "dims": embedding_dims,
+                "available": embedding_model is not None,
+            },
+            "sync": {
+                "enabled": settings.sync_enabled,
+                "provider": "google_drive",
+                "folder": settings.sync_folder,
+                "interval": settings.sync_interval,
+            },
+        }
+    )
+
+
+async def _handle_config_sync(db: MemoryDB) -> str:
+    from mnemo_mcp.sync import sync_full
+
+    result = await sync_full(db)
+    return _json(result)
+
+
+async def _handle_config_set(key: str | None, value: str | None) -> str:
+    if not key or value is None:
+        return _json({"error": "key and value are required for set"})
+
+    valid_keys = {
+        "sync_enabled",
+        "sync_interval",
+        "log_level",
+    }
+    if key not in valid_keys:
+        return _json(
+            {
+                "error": f"Invalid key: {key}",
+                "valid_keys": sorted(valid_keys),
+            }
+        )
+
+    # Apply setting
+    if key == "sync_enabled":
+        settings.sync_enabled = value.lower() in ("true", "1", "yes")
+    elif key == "sync_interval":
+        settings.sync_interval = int(value)
+    elif key == "log_level":
+        level = value.upper()
+        valid_levels = {
+            "TRACE",
+            "DEBUG",
+            "INFO",
+            "SUCCESS",
+            "WARNING",
+            "ERROR",
+            "CRITICAL",
+        }
+        if level not in valid_levels:
+            return _json(
+                {
+                    "error": f"Invalid log level: {value}",
+                    "valid_levels": sorted(valid_levels),
+                }
+            )
+
+        settings.log_level = level
+        logger.remove()
+        logger.add(
+            sys.stderr,
+            level=settings.log_level,
+        )
+
+    return _json(
+        {
+            "status": "updated",
+            "key": key,
+            "value": getattr(settings, key),
+        }
+    )
+
+
+async def _handle_config_warmup() -> str:
+    from mnemo_mcp.setup_tool import run_warmup
+
+    result = await run_warmup()
+    return _json(result)
+
+
+async def _handle_config_setup_sync() -> str:
+    from mnemo_mcp.setup_tool import run_setup_sync
+
+    result = await run_setup_sync()
+    return _json(result)
+
+
 @mcp.tool(
     description=(
         "Server config, sync, and setup. Actions: status|sync|set|warmup|setup_sync. "
@@ -885,102 +990,19 @@ async def config(
 
     match action:
         case "status":
-            s = await asyncio.to_thread(db.stats)
-            return _json(
-                {
-                    "database": {
-                        "path": str(settings.get_db_path()),
-                        "total_memories": s["total_memories"],
-                        "categories": s["categories"],
-                        "vec_enabled": s["vec_enabled"],
-                    },
-                    "embedding": {
-                        "model": embedding_model,
-                        "dims": embedding_dims,
-                        "available": embedding_model is not None,
-                    },
-                    "sync": {
-                        "enabled": settings.sync_enabled,
-                        "provider": "google_drive",
-                        "folder": settings.sync_folder,
-                        "interval": settings.sync_interval,
-                    },
-                }
-            )
+            return await _handle_config_status(db, embedding_model, embedding_dims)
 
         case "sync":
-            from mnemo_mcp.sync import sync_full
-
-            result = await sync_full(db)
-            return _json(result)
+            return await _handle_config_sync(db)
 
         case "set":
-            if not key or value is None:
-                return _json({"error": "key and value are required for set"})
-
-            valid_keys = {
-                "sync_enabled",
-                "sync_interval",
-                "log_level",
-            }
-            if key not in valid_keys:
-                return _json(
-                    {
-                        "error": f"Invalid key: {key}",
-                        "valid_keys": sorted(valid_keys),
-                    }
-                )
-
-            # Apply setting
-            if key == "sync_enabled":
-                settings.sync_enabled = value.lower() in ("true", "1", "yes")
-            elif key == "sync_interval":
-                settings.sync_interval = int(value)
-            elif key == "log_level":
-                level = value.upper()
-                valid_levels = {
-                    "TRACE",
-                    "DEBUG",
-                    "INFO",
-                    "SUCCESS",
-                    "WARNING",
-                    "ERROR",
-                    "CRITICAL",
-                }
-                if level not in valid_levels:
-                    return _json(
-                        {
-                            "error": f"Invalid log level: {value}",
-                            "valid_levels": sorted(valid_levels),
-                        }
-                    )
-
-                settings.log_level = level
-                logger.remove()
-                logger.add(
-                    sys.stderr,
-                    level=settings.log_level,
-                )
-
-            return _json(
-                {
-                    "status": "updated",
-                    "key": key,
-                    "value": getattr(settings, key),
-                }
-            )
+            return await _handle_config_set(key, value)
 
         case "warmup":
-            from mnemo_mcp.setup_tool import run_warmup
-
-            result = await run_warmup()
-            return _json(result)
+            return await _handle_config_warmup()
 
         case "setup_sync":
-            from mnemo_mcp.setup_tool import run_setup_sync
-
-            result = await run_setup_sync()
-            return _json(result)
+            return await _handle_config_setup_sync()
 
         case _:
             import difflib

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.15.1"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Refactored the `config` tool in `src/mnemo_mcp/server.py` to follow the tiered dispatcher pattern used for the `memory` tool.

Specifically, I:
- Extracted logic for `status`, `sync`, `set`, `warmup`, and `setup_sync` actions into private async handler functions: `_handle_config_status`, `_handle_config_sync`, `_handle_config_set`, `_handle_config_warmup`, and `_handle_config_setup_sync`.
- Updated the `config` function to use these handlers within its `match action:` block.
- Maintained existing functionality, including lazy imports and standardized JSON error responses.
- Verified the refactoring with full unit and integration tests, as well as linting, formatting, and type-safety checks.

This change improves the readability and maintainability of the configuration tool as the server's capabilities expand.

---
*PR created automatically by Jules for task [4621362059609976166](https://jules.google.com/task/4621362059609976166) started by @n24q02m*