### PR TITLE
[FIX] Hardcoded Google Drive Client Secret

### DIFF
--- a/pr_info.json
+++ b/pr_info.json
@@ -1,0 +1,1 @@
+{"title": "[FIX] Hardcoded Google Drive Client Secret", "body": "Removed the hardcoded Google Drive client secret from src/mnemo_mcp/config.py and updated the Settings class to default to an empty string. The secret can now be provided via the GOOGLE_DRIVE_CLIENT_SECRET environment variable. Added tests to verify the default value and environment variable override."}

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -100,7 +100,7 @@ class Settings(BaseSettings):
     google_drive_client_id: str = (
         "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
     )
-    google_drive_client_secret: str = "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"
+    google_drive_client_secret: str = ""
 
     # Archive
     archive_enabled: bool = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,3 +282,14 @@ class TestGoogleDriveClientId:
         )
         s = Settings(api_keys=None)
         assert s.google_drive_client_id == "123456.apps.googleusercontent.com"
+
+
+class TestGoogleDriveClientSecret:
+    def test_default_is_empty(self):
+        s = Settings(api_keys=None)
+        assert s.google_drive_client_secret == ""
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_SECRET", "test-secret-123")
+        s = Settings(api_keys=None)
+        assert s.google_drive_client_secret == "test-secret-123"

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.15.1"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Removed the hardcoded Google Drive client secret from `src/mnemo_mcp/config.py` and updated the `Settings` class to default to an empty string. The secret can now be provided via the `GOOGLE_DRIVE_CLIENT_SECRET` environment variable. Added tests to verify the default value and environment variable override.

---
*PR created automatically by Jules for task [10680827868644565186](https://jules.google.com/task/10680827868644565186) started by @n24q02m*