### PR TITLE
[FIX] N+1 Query in _search_fts

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -448,20 +448,19 @@ class MemoryDB:
         filter_sql = ""
         filter_params: list = []
         if category:
-            filter_sql += " AND m.category = ?"
+            filter_sql += " AND category = ?"
             filter_params.append(category)
         if tags:
             tag_placeholders = ",".join("?" for _ in tags)
-            filter_sql += f" AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
+            filter_sql += f" AND json_valid(tags) AND EXISTS (SELECT 1 FROM json_each(tags) WHERE value IN ({tag_placeholders}))"
             filter_params.extend(tags)
 
         for idx, fts_query in enumerate(fts_queries):
             subqueries.append(f"""
-                SELECT m.*,
+                SELECT id,
                        bm25(memories_fts, 0.0, 1.0, 0.0, 5.0) AS bm25_score,
                        {idx} as tier_idx
-                FROM memories_fts f
-                JOIN memories m ON f.id = m.id
+                FROM memories_fts
                 WHERE memories_fts MATCH ? {filter_sql}
             """)
             fts_params.append(fts_query)
@@ -471,12 +470,17 @@ class MemoryDB:
         fts_sql = f"""
             WITH all_matches AS (
                 {union_sql}
+            ),
+            best_matches AS (
+                SELECT id, bm25_score
+                FROM all_matches
+                WHERE tier_idx = (SELECT MIN(tier_idx) FROM all_matches)
+                ORDER BY bm25_score
+                LIMIT ?
             )
-            SELECT *
-            FROM all_matches
-            WHERE tier_idx = (SELECT MIN(tier_idx) FROM all_matches)
-            ORDER BY bm25_score
-            LIMIT ?
+            SELECT m.*, b.bm25_score
+            FROM best_matches b
+            JOIN memories m ON b.id = m.id
         """
         fts_params.append(limit * 3)
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.15.1"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
This PR optimizes the `_search_fts` method in `src/mnemo_mcp/db.py` by implementing a 'Deferred Join' pattern. 

Previously, the method used a tiered `UNION ALL` query to handle PHRASE -> AND -> OR fallback, but it joined the `memories` table within each subquery of the `UNION ALL`. This caused unnecessary join overhead for all intermediate matches.

The optimized implementation:
1. Pushes `category` and `tags` filters directly into the `memories_fts` subqueries (leveraging `UNINDEXED` columns).
2. Selects only `id` and `bm25_score` in the `all_matches` CTE.
3. Performs a single `JOIN` with the `memories` table only for the final, limited set of results.

This improves search performance, especially for broad queries or large databases, while maintaining the same tiered fallback logic and results.

Verified with the full suite of database tests (129 passed).

---
*PR created automatically by Jules for task [1725715105950846727](https://jules.google.com/task/1725715105950846727) started by @n24q02m*