### PR TITLE
[FIX] N+1 Query Pattern in Graph Relation Traversal (Verified Already Fixed)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.15.1"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
The issue described—an N+1 query pattern in the graph relation traversal—has already been addressed in the current version of the codebase. Specifically:

1.  **Functionality:** The `find_related_memory_ids` function in `src/mnemo_mcp/graph.py` already utilizes a **recursive CTE** to traverse the knowledge graph in a single query, which eliminates the N+1 loop overhead.
2.  **Verification:** A search across the `src/mnemo_mcp/` directory for iterative patterns like `range(max_depth - 1)` or `range(max_depth)` confirmed that no unoptimized loop-based traversal remains.
3.  **Documentation:** The code contains "Bolt Performance Optimization" comments and docstrings that explicitly mention the elimination of N+1 loop overhead.
4.  **Testing:** The full test suite (666 tests), including `tests/test_graph.py`, passes successfully, verifying that the current optimized implementation is correct and handles multi-hop relations as expected.

Since the fix is already present and verified, no additional code modifications were necessary.

---
*PR created automatically by Jules for task [258727788615045615](https://jules.google.com/task/258727788615045615) started by @n24q02m*