### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Hardcoded Secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Hardcoded Google Drive Client Secret
+**Vulnerability:** A hardcoded Google Drive Client Secret (`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`) was found in `src/mnemo_mcp/config.py` as a default value for the Pydantic `Settings` class.
+**Learning:** Hardcoding secrets as default values in configuration classes exposes them in the repository history and makes them available to anyone with read access to the code.
+**Prevention:** Always default sensitive fields in configuration classes (like Pydantic `BaseSettings`) to empty strings (`""`) or `None`, and rely on environment variables or secure configuration files to populate them at runtime.

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -100,7 +100,7 @@ class Settings(BaseSettings):
     google_drive_client_id: str = (
         "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
     )
-    google_drive_client_secret: str = "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"
+    google_drive_client_secret: str = ""
 
     # Archive
     archive_enabled: bool = True

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.18.5b1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded Google Drive Client Secret (`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`) found in `src/mnemo_mcp/config.py`.
🎯 Impact: This could be exploited by anyone with access to the source code to authenticate to Google Drive using the leaked credentials.
🔧 Fix: Removed the hardcoded secret from the default value, changing it to an empty string (`""`). This follows standard security coding practices.
✅ Verification: Ran `uv run pytest` and `uv run pytest -m integration`, both passing. Tested successfully in a local dev environment. The code has been checked and the `google_drive_client_secret` variable correctly defaults to an empty string.

---
*PR created automatically by Jules for task [10845904570866421947](https://jules.google.com/task/10845904570866421947) started by @n24q02m*