### PR TITLE
[FIX] N+1 Query in upsert_entities

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -210,7 +210,12 @@ async def score_importance(content: str) -> float:
 
 
 def upsert_entities(conn, entities: list[dict]) -> list[str]:
-    """Insert or update entities. Returns list of entity IDs."""
+    """Insert or update entities. Returns list of entity IDs.
+
+    This implementation uses a single-pass UPSERT pattern with RETURNING to
+    eliminate the N+1 query overhead and minimize database round-trips.
+    We batch the operation to stay within SQLITE_MAX_VARIABLE_NUMBER.
+    """
     now = datetime.now(UTC).isoformat()
 
     unique_ents = {}
@@ -231,27 +236,27 @@ def upsert_entities(conn, entities: list[dict]) -> list[str]:
 
     unique_keys = list(unique_ents.keys())
 
-    # Use UPSERT (INSERT ... ON CONFLICT) for bulk write in one pass.
-    # This eliminates N+1 SELECTs and conditional INSERT/UPDATE overhead.
-    upsert_data = [(str(uuid.uuid4()), key[0], key[1], now, now) for key in unique_keys]
-    conn.executemany(
-        "INSERT INTO entities (id, name, entity_type, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?) "
-        "ON CONFLICT(name, entity_type) DO UPDATE SET updated_at = excluded.updated_at",
-        upsert_data,
-    )
-
-    # Fetch all IDs in bulk. Batch to stay under SQLITE_MAX_VARIABLE_NUMBER.
-    BATCH_SIZE = 400
+    # Bolt Performance Optimization:
+    # Use a single-pass `INSERT INTO ... ON CONFLICT ... RETURNING` pattern
+    # to eliminate N+1 queries. Since Python's `sqlite3` driver doesn't support
+    # `RETURNING` with `executemany`, we construct a single INSERT statement
+    # with multiple VALUES placeholders and execute it in batches.
+    BATCH_SIZE = 190  # 190 * 5 params = 950 < 999 max parameters
     for i in range(0, len(unique_keys), BATCH_SIZE):
         batch = unique_keys[i : i + BATCH_SIZE]
-        placeholders = ", ".join(["(?, ?)"] * len(batch))
-        params = [val for key in batch for val in key]
-        rows = conn.execute(
-            "SELECT name, entity_type, id FROM entities "
-            f"WHERE (name, entity_type) IN (VALUES {placeholders})",
-            params,
-        ).fetchall()
+        placeholders = ", ".join(["(?, ?, ?, ?, ?)"] * len(batch))
+        params = []
+        for key in batch:
+            params.extend([str(uuid.uuid4()), key[0], key[1], now, now])
+
+        query = (
+            f"INSERT INTO entities (id, name, entity_type, created_at, updated_at) "
+            f"VALUES {placeholders} "
+            f"ON CONFLICT(name, entity_type) DO UPDATE SET updated_at = excluded.updated_at "
+            f"RETURNING name, entity_type, id"
+        )
+
+        rows = conn.execute(query, params).fetchall()
         for r_name, r_type, r_id in rows:
             unique_ents[(r_name, r_type)] = r_id
 

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.18.5b1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Refactored `upsert_entities` in `src/mnemo_mcp/graph.py` to use a single-pass `INSERT ... ON CONFLICT ... RETURNING` pattern. This optimization eliminates N+1 query overhead and minimizes database round-trips by combining insertions and ID retrieval into a single operation per batch. The implementation respects SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit by using a batch size of 190 (5 parameters per entity). Verified through unit and coverage tests.

---
*PR created automatically by Jules for task [5603223417932397485](https://jules.google.com/task/5603223417932397485) started by @n24q02m*