### PR TITLE
[FIX] Hardcoded Google Drive Client Secret

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
     - SYNC_FOLDER: Google Drive folder name (default: "mnemo-mcp")
     - SYNC_INTERVAL: Auto-sync interval in seconds (default: 300)
     - GOOGLE_DRIVE_CLIENT_ID: OAuth client ID for Google Drive sync
+    - GOOGLE_DRIVE_CLIENT_SECRET: OAuth client secret for Google Drive sync
     """
 
     # Database
@@ -100,7 +101,7 @@ class Settings(BaseSettings):
     google_drive_client_id: str = (
         "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
     )
-    google_drive_client_secret: str = "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"
+    google_drive_client_secret: str = ""
 
     # Archive
     archive_enabled: bool = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,3 +282,14 @@ class TestGoogleDriveClientId:
         )
         s = Settings(api_keys=None)
         assert s.google_drive_client_id == "123456.apps.googleusercontent.com"
+
+
+class TestGoogleDriveClientSecret:
+    def test_default_empty(self):
+        s = Settings(api_keys=None)
+        assert s.google_drive_client_secret == ""
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_SECRET", "test-secret-123")
+        s = Settings(api_keys=None)
+        assert s.google_drive_client_secret == "test-secret-123"

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.18.5b1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Removed the hardcoded value for google_drive_client_secret in src/mnemo_mcp/config.py and updated the configuration to load it from the GOOGLE_DRIVE_CLIENT_SECRET environment variable. Added unit tests to verify the default value and environment variable override. Verified with full test suite and e2e tests.

---
*PR created automatically by Jules for task [3472023443036394922](https://jules.google.com/task/3472023443036394922) started by @n24q02m*