### PR TITLE
[FIX] Hardcoded Google Drive Client Secret

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
     - SYNC_FOLDER: Google Drive folder name (default: "mnemo-mcp")
     - SYNC_INTERVAL: Auto-sync interval in seconds (default: 300)
     - GOOGLE_DRIVE_CLIENT_ID: OAuth client ID for Google Drive sync
+    - GOOGLE_DRIVE_CLIENT_SECRET: OAuth client secret for Google Drive sync
     """
 
     # Database
@@ -97,10 +98,8 @@ class Settings(BaseSettings):
     sync_enabled: bool = True
     sync_folder: str = "mnemo-mcp"  # Google Drive folder name
     sync_interval: int = 300  # seconds, 0 = manual only
-    google_drive_client_id: str = (
-        "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
-    )
-    google_drive_client_secret: str = "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"
+    google_drive_client_id: str = ""
+    google_drive_client_secret: str = ""
 
     # Archive
     archive_enabled: bool = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -271,10 +271,9 @@ class TestRerankSettings:
 
 
 class TestGoogleDriveClientId:
-    def test_default_ships_oauth_client_id(self):
+    def test_default_google_drive_client_id_is_empty(self):
         s = Settings(api_keys=None)
-        assert s.google_drive_client_id != ""
-        assert "apps.googleusercontent.com" in s.google_drive_client_id
+        assert s.google_drive_client_id == ""
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv(

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -8,11 +8,10 @@ from mnemo_mcp.config import Settings
 
 
 def test_google_drive_client_id_default(monkeypatch):
-    """Default google_drive_client_id ships OAuth app ID for Device Code flow."""
+    """Default google_drive_client_id is empty for security."""
     monkeypatch.delenv("GOOGLE_DRIVE_CLIENT_ID", raising=False)
     s = Settings(api_keys=None)
-    assert s.google_drive_client_id != ""
-    assert "apps.googleusercontent.com" in s.google_drive_client_id
+    assert s.google_drive_client_id == ""
 
 
 def test_google_drive_client_id_from_env(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.18.5b1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Removed hardcoded Google Drive credentials from the configuration and updated tests to reflect this change. This ensures that sensitive information is not stored in the codebase and must be provided via environment variables.

---
*PR created automatically by Jules for task [8126680499025918773](https://jules.google.com/task/8126680499025918773) started by @n24q02m*