### PR TITLE
[FIX] Complex Function `setup_google_auth` in `sync.py`

### DIFF
--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -569,29 +569,8 @@ async def check_health() -> bool:
 # ---------------------------------------------------------------------------
 
 
-async def setup_google_auth(
-    relay_url: str | None = None,
-    session_id: str | None = None,
-) -> bool:
-    """Interactive Google OAuth setup via Device Code flow.
-
-    If relay_url + session_id provided, send device code via relay messaging.
-    Otherwise print to stderr.
-
-    Returns True on success, False on failure.
-    """
-    import sys
-
-    client_id = settings.google_drive_client_id
-    client_secret = settings.google_drive_client_secret
-    if not client_id:
-        logger.error("GOOGLE_DRIVE_CLIENT_ID not configured")
-        return False
-    if not client_secret:
-        logger.error("GOOGLE_DRIVE_CLIENT_SECRET not configured")
-        return False
-
-    # 1. Request device code
+async def _request_device_code(client_id: str) -> dict | None:
+    """Request a device code from Google OAuth."""
     try:
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -605,21 +584,24 @@ async def setup_google_auth(
 
             if response.status_code != 200:
                 logger.error(f"Device code request failed: {response.text}")
-                return False
+                return None
 
-            device_data = response.json()
+            return response.json()
 
     except Exception as e:
         logger.error(f"Device code request error: {e}")
-        return False
+        return None
 
-    device_code = device_data["device_code"]
-    user_code = device_data["user_code"]
-    verification_url = device_data["verification_url"]
-    interval = device_data.get("interval", 5)
-    expires_in = device_data.get("expires_in", 1800)
 
-    # 2. Present code to user
+async def _present_device_code(
+    verification_url: str,
+    user_code: str,
+    relay_url: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Present the device code to the user via stderr or relay."""
+    import sys
+
     auth_message = (
         f"Google Drive Authorization\n"
         f"Visit: {verification_url}\n"
@@ -646,7 +628,15 @@ async def setup_google_auth(
     else:
         print(f"\n{auth_message}\n", file=sys.stderr, flush=True)
 
-    # 3. Poll for token
+
+async def _poll_for_token(
+    client_id: str,
+    client_secret: str,
+    device_code: str,
+    interval: int,
+    expires_in: int,
+) -> bool:
+    """Poll Google OAuth for the access token."""
     deadline = time.time() + expires_in
 
     while time.time() < deadline:
@@ -699,6 +689,46 @@ async def setup_google_auth(
 
     logger.error("Device code expired")
     return False
+
+
+async def setup_google_auth(
+    relay_url: str | None = None,
+    session_id: str | None = None,
+) -> bool:
+    """Interactive Google OAuth setup via Device Code flow.
+
+    If relay_url + session_id provided, send device code via relay messaging.
+    Otherwise print to stderr.
+
+    Returns True on success, False on failure.
+    """
+    client_id = settings.google_drive_client_id
+    client_secret = settings.google_drive_client_secret
+    if not client_id:
+        logger.error("GOOGLE_DRIVE_CLIENT_ID not configured")
+        return False
+    if not client_secret:
+        logger.error("GOOGLE_DRIVE_CLIENT_SECRET not configured")
+        return False
+
+    # 1. Request device code
+    device_data = await _request_device_code(client_id)
+    if not device_data:
+        return False
+
+    device_code = device_data["device_code"]
+    user_code = device_data["user_code"]
+    verification_url = device_data["verification_url"]
+    interval = device_data.get("interval", 5)
+    expires_in = device_data.get("expires_in", 1800)
+
+    # 2. Present code to user
+    await _present_device_code(verification_url, user_code, relay_url, session_id)
+
+    # 3. Poll for token
+    return await _poll_for_token(
+        client_id, client_secret, device_code, interval, expires_in
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.18.5b1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
The `setup_google_auth` function in `src/mnemo_mcp/sync.py` was identified as being too complex. It handled three distinct phases of the OAuth Device Code flow: requesting the code, presenting it to the user (via stderr or relay), and polling for the token.

This PR refactors the function by extracting these phases into private async helper functions:
- `_request_device_code(client_id)`
- `_present_device_code(verification_url, user_code, relay_url, session_id)`
- `_poll_for_token(client_id, client_secret, device_code, interval, expires_in)`

The main `setup_google_auth` function now coordinates these helpers, making the logic much easier to follow.
Tests in `tests/test_sync_gdrive_auth.py` and other sync tests were verified to pass.
Linting and formatting with `ruff` were also applied.

---
*PR created automatically by Jules for task [2378681743138561161](https://jules.google.com/task/2378681743138561161) started by @n24q02m*