### PR TITLE
[FIX] N+1 Query in upsert_entities

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -231,30 +231,29 @@ def upsert_entities(conn, entities: list[dict]) -> list[str]:
 
     unique_keys = list(unique_ents.keys())
 
-    # Use UPSERT (INSERT ... ON CONFLICT) for bulk write in one pass.
-    # This eliminates N+1 SELECTs and conditional INSERT/UPDATE overhead.
-    upsert_data = [(str(uuid.uuid4()), key[0], key[1], now, now) for key in unique_keys]
-    conn.executemany(
-        "INSERT INTO entities (id, name, entity_type, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?) "
-        "ON CONFLICT(name, entity_type) DO UPDATE SET updated_at = excluded.updated_at",
-        upsert_data,
-    )
-
-    # Fetch all IDs in bulk. Batch to stay under SQLITE_MAX_VARIABLE_NUMBER.
-    BATCH_SIZE = 400
+    # Bolt Performance Optimization:
+    # Use a single-pass INSERT INTO ... ON CONFLICT ... RETURNING pattern to eliminate N+1 queries.
+    # Since Python sqlite3 doesn't support RETURNING with executemany, we construct a single INSERT
+    # with multiple VALUES placeholders per batch to reduce database round-trips to one per batch.
+    # Each row uses 5 parameters (id, name, type, created_at, updated_at).
+    BATCH_SIZE = 190  # 190 * 5 = 950 < 999 (SQLITE_MAX_VARIABLE_NUMBER)
     for i in range(0, len(unique_keys), BATCH_SIZE):
         batch = unique_keys[i : i + BATCH_SIZE]
-        placeholders = ", ".join(["(?, ?)"] * len(batch))
-        params = [val for key in batch for val in key]
-        rows = conn.execute(
-            "SELECT name, entity_type, id FROM entities "
-            f"WHERE (name, entity_type) IN (VALUES {placeholders})",
-            params,
-        ).fetchall()
+        placeholders = ", ".join(["(?, ?, ?, ?, ?)"] * len(batch))
+        params = []
+        for key in batch:
+            params.extend([str(uuid.uuid4()), key[0], key[1], now, now])
+
+        query = f"""
+            INSERT INTO entities (id, name, entity_type, created_at, updated_at)
+            VALUES {placeholders}
+            ON CONFLICT(name, entity_type) DO UPDATE SET
+                updated_at = excluded.updated_at
+            RETURNING name, entity_type, id
+        """
+        rows = conn.execute(query, params).fetchall()
         for r_name, r_type, r_id in rows:
             unique_ents[(r_name, r_type)] = r_id
-
     return [unique_ents[key] for key in ordered_ents]
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -372,3 +372,18 @@ class TestFindRelatedMemoryIds:
 
         related = find_related_memory_ids(conn, mid1, max_depth=3)
         assert mid2 in related
+
+    def test_bulk_upsert_large_batch(self, tmp_db: MemoryDB):
+        conn = tmp_db._conn
+        # Create 250 entities to trigger batching (BATCH_SIZE=190)
+        entities = [{"name": f"Entity {i}", "type": "concept"} for i in range(250)]
+        ids = upsert_entities(conn, entities)
+        assert len(ids) == 250
+        assert len(set(ids)) == 250
+
+        # Upsert again to verify updates/RETURNING on existing
+        ids2 = upsert_entities(conn, entities)
+        assert ids == ids2
+
+        count = conn.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+        assert count == 250

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.18.5b1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Refactored `upsert_entities` in `src/mnemo_mcp/graph.py` to use a single-pass `INSERT ... ON CONFLICT ... RETURNING` pattern. This optimization eliminates the previous two-step process (UPSERT then batched SELECT) by retrieving the entity IDs directly from the UPSERT operation.

Key improvements:
- Reduced database round-trips from O(N/BATCH_SIZE * 2) to O(N/BATCH_SIZE).
- Implemented batching with a `BATCH_SIZE` of 190 to respect `SQLITE_MAX_VARIABLE_NUMBER` (190 * 5 parameters = 950 < 999).
- Added `test_bulk_upsert_large_batch` to `tests/test_graph.py` to verify the batching logic and correct ID retrieval for large entity sets.
- Followed the "Bolt Performance Optimization" pattern with explanatory comments.

All tests passed, and linting/formatting checks were successful.

---
*PR created automatically by Jules for task [10077262117143493788](https://jules.google.com/task/10077262117143493788) started by @n24q02m*