### PR TITLE
[SECURITY] Potential SQL Injection via Dynamic Query Construction

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -370,9 +370,10 @@ class MemoryDB:
                     vec_params.append(category)
 
                 if tags:
-                    tag_placeholders = ",".join("?" for _ in tags)
-                    vec_sql += f" AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
-                    vec_params.extend(tags)
+                    if len(tags) > 50:
+                        raise ValueError("Maximum 50 tags allowed in search")
+                    vec_sql += " AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN (SELECT value FROM json_each(?)))"
+                    vec_params.append(json.dumps(tags))
 
                 vec_sql += " ORDER BY distance LIMIT ?"
                 vec_params.append(limit * 3)
@@ -391,10 +392,9 @@ class MemoryDB:
                         missing_ids.append(mid)
 
                 if missing_ids:
-                    placeholders = ",".join("?" for _ in missing_ids)
                     missing_mems = self._conn.execute(
-                        f"SELECT * FROM memories WHERE id IN ({placeholders})",
-                        missing_ids,
+                        "SELECT * FROM memories WHERE id IN (SELECT value FROM json_each(?))",
+                        (json.dumps(missing_ids),),
                     ).fetchall()
                     for mem in missing_mems:
                         mid = mem["id"]
@@ -451,9 +451,10 @@ class MemoryDB:
             filter_sql += " AND m.category = ?"
             filter_params.append(category)
         if tags:
-            tag_placeholders = ",".join("?" for _ in tags)
-            filter_sql += f" AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({tag_placeholders}))"
-            filter_params.extend(tags)
+            if len(tags) > 50:
+                raise ValueError("Maximum 50 tags allowed in search")
+            filter_sql += " AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN (SELECT value FROM json_each(?)))"
+            filter_params.append(json.dumps(tags))
 
         for idx, fts_query in enumerate(fts_queries):
             subqueries.append(f"""
@@ -566,13 +567,12 @@ class MemoryDB:
             return
 
         ids = [m["id"] for m in top]
-        placeholders = ",".join("?" for _ in ids)
         self._conn.execute(
-            f"""UPDATE memories
+            """UPDATE memories
                 SET access_count = access_count + 1,
                     last_accessed = ?
-                WHERE id IN ({placeholders})""",
-            [_now_iso(), *ids],
+                WHERE id IN (SELECT value FROM json_each(?))""",
+            (_now_iso(), json.dumps(ids)),
         )
         self._conn.commit()
 

--- a/tests/test_security_limits.py
+++ b/tests/test_security_limits.py
@@ -36,9 +36,11 @@ async def test_list_limit_clamping():
         actual_limit = kwargs.get("limit")
         assert actual_limit == 100, f"Limit expected to be 100, got {actual_limit}"
 
+
 def test_db_search_tags_limit(tmp_path):
     """Verify that search tags are limited to prevent DoS."""
     from mnemo_mcp.db import MemoryDB
+
     db = MemoryDB(tmp_path / "test.db", embedding_dims=0)
     tags = [f"tag{i}" for i in range(51)]
     with pytest.raises(ValueError, match="Maximum 50 tags allowed in search"):

--- a/tests/test_security_limits.py
+++ b/tests/test_security_limits.py
@@ -35,3 +35,12 @@ async def test_list_limit_clamping():
         args, kwargs = mock_db.list_memories.call_args
         actual_limit = kwargs.get("limit")
         assert actual_limit == 100, f"Limit expected to be 100, got {actual_limit}"
+
+def test_db_search_tags_limit(tmp_path):
+    """Verify that search tags are limited to prevent DoS."""
+    from mnemo_mcp.db import MemoryDB
+    db = MemoryDB(tmp_path / "test.db", embedding_dims=0)
+    tags = [f"tag{i}" for i in range(51)]
+    with pytest.raises(ValueError, match="Maximum 50 tags allowed in search"):
+        db.search("test", tags=tags)
+    db.close()

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.18.5b1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
Refactored dynamic SQL placeholder construction in `src/mnemo_mcp/db.py` to use SQLite's `json_each(?)` function. This approach eliminates the need for dynamic string concatenation for SQL placeholders, mitigating potential SQL injection vulnerabilities.

Key Changes:
- Replaced the dynamic `tag_placeholders` and `placeholders` generation using `",".join("?" for _ in list)` with a more secure pattern: `IN (SELECT value FROM json_each(?))`.
- Updated `search`, `_search_fts`, and `_update_access_stats` methods to pass list parameters as single JSON-encoded strings.
- Implemented a limit of 50 items for the `tags` list in the `search` and `_search_fts` methods to prevent potential Denial of Service (DoS) attacks via excessively large inputs.
- Added a dedicated test case in `tests/test_security_limits.py` to verify that the tag limit is correctly enforced.

These modifications enhance the security posture of the database layer by ensuring that all user-provided list inputs are handled as data rather than being part of the SQL query structure.

---
*PR created automatically by Jules for task [9281510891515940826](https://jules.google.com/task/9281510891515940826) started by @n24q02m*