### PR TITLE
[FIX] Refactor long setup_google_auth method into helpers

### DIFF
--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -577,29 +578,8 @@ async def check_health() -> bool:
 # ---------------------------------------------------------------------------
 
 
-async def setup_google_auth(
-    relay_url: str | None = None,
-    session_id: str | None = None,
-) -> bool:
-    """Interactive Google OAuth setup via Device Code flow.
-
-    If relay_url + session_id provided, send device code via relay messaging.
-    Otherwise print to stderr.
-
-    Returns True on success, False on failure.
-    """
-    import sys
-
-    client_id = settings.google_drive_client_id
-    client_secret = settings.google_drive_client_secret
-    if not client_id:
-        logger.error("GOOGLE_DRIVE_CLIENT_ID not configured")
-        return False
-    if not client_secret:
-        logger.error("GOOGLE_DRIVE_CLIENT_SECRET not configured")
-        return False
-
-    # 1. Request device code
+async def _request_device_code(client_id: str) -> dict | None:
+    """Request device code from Google OAuth2 endpoint."""
     try:
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -613,21 +593,22 @@ async def setup_google_auth(
 
             if response.status_code != 200:
                 logger.error(f"Device code request failed: {response.text}")
-                return False
+                return None
 
-            device_data = response.json()
+            return response.json()
 
     except Exception as e:
         logger.error(f"Device code request error: {e}")
-        return False
+        return None
 
-    device_code = device_data["device_code"]
-    user_code = device_data["user_code"]
-    verification_url = device_data["verification_url"]
-    interval = device_data.get("interval", 5)
-    expires_in = device_data.get("expires_in", 1800)
 
-    # 2. Present code to user
+async def _present_user_code(
+    verification_url: str,
+    user_code: str,
+    relay_url: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Present device code to user (via relay or stderr)."""
     auth_message = (
         f"Google Drive Authorization\n"
         f"Visit: {verification_url}\n"
@@ -654,7 +635,15 @@ async def setup_google_auth(
     else:
         print(f"\n{auth_message}\n", file=sys.stderr, flush=True)
 
-    # 3. Poll for token
+
+async def _poll_for_token(
+    client_id: str,
+    client_secret: str,
+    device_code: str,
+    interval: int,
+    expires_in: int,
+) -> bool:
+    """Poll Google token endpoint until authorized or expired."""
     deadline = time.time() + expires_in
 
     while time.time() < deadline:
@@ -707,6 +696,55 @@ async def setup_google_auth(
 
     logger.error("Device code expired")
     return False
+
+
+async def setup_google_auth(
+    relay_url: str | None = None,
+    session_id: str | None = None,
+) -> bool:
+    """Interactive Google OAuth setup via Device Code flow.
+
+    If relay_url + session_id provided, send device code via relay messaging.
+    Otherwise print to stderr.
+
+    Returns True on success, False on failure.
+    """
+    client_id = settings.google_drive_client_id
+    client_secret = settings.google_drive_client_secret
+    if not client_id:
+        logger.error("GOOGLE_DRIVE_CLIENT_ID not configured")
+        return False
+    if not client_secret:
+        logger.error("GOOGLE_DRIVE_CLIENT_SECRET not configured")
+        return False
+
+    # 1. Request device code
+    device_data = await _request_device_code(client_id)
+    if not device_data:
+        return False
+
+    device_code = device_data["device_code"]
+    user_code = device_data["user_code"]
+    verification_url = device_data["verification_url"]
+    interval = device_data.get("interval", 5)
+    expires_in = device_data.get("expires_in", 1800)
+
+    # 2. Present code to user
+    await _present_user_code(
+        verification_url=verification_url,
+        user_code=user_code,
+        relay_url=relay_url,
+        session_id=session_id,
+    )
+
+    # 3. Poll for token
+    return await _poll_for_token(
+        client_id=client_id,
+        client_secret=client_secret,
+        device_code=device_code,
+        interval=interval,
+        expires_in=expires_in,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The `setup_google_auth` method in `src/mnemo_mcp/sync.py` was previously a long, complex function handling the entire Google OAuth 2.0 Device Code flow. This PR refactors it by extracting the distinct phases of the flow into private helper methods:

- `_request_device_code`: Handles the initial POST to Google's device code endpoint.
- `_present_user_code`: Manages displaying the authorization message to the user, either via a relay service or to stderr.
- `_poll_for_token`: Implements the polling loop that waits for user authorization and saves the resulting token.

This refactoring improves code readability, separates concerns, and makes the OAuth flow easier to maintain and test. All existing tests in `tests/test_sync_gdrive_auth.py` and the wider test suite passed successfully after the changes.

---
*PR created automatically by Jules for task [2664406739707085714](https://jules.google.com/task/2664406739707085714) started by @n24q02m*