### PR TITLE
[PERF] Synchronous file read for tokens

### DIFF
--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -60,23 +60,23 @@ _folder_id_cache: dict[str, str] = {}
 # ---------------------------------------------------------------------------
 
 
-def _load_token() -> dict | None:
+async def _load_token() -> dict | None:
     """Load Google Drive OAuth token from local storage."""
-    from mnemo_mcp.token_store import load_token
+    from mnemo_mcp.token_store import async_load_token
 
-    return load_token(_TOKEN_PROVIDER)
+    return await async_load_token(_TOKEN_PROVIDER)
 
 
-def _save_token(token: dict) -> None:
+async def _save_token(token: dict) -> None:
     """Save Google Drive OAuth token to local storage."""
-    from mnemo_mcp.token_store import save_token
+    from mnemo_mcp.token_store import async_save_token
 
-    save_token(_TOKEN_PROVIDER, token)
+    await async_save_token(_TOKEN_PROVIDER, token)
 
 
-def _has_token_available() -> bool:
+async def _has_token_available() -> bool:
     """Check if a Google Drive token is available."""
-    return _load_token() is not None
+    return await _load_token() is not None
 
 
 async def _refresh_token(token: dict) -> dict | None:
@@ -121,7 +121,7 @@ async def _refresh_token(token: dict) -> dict | None:
                 "client_id": client_id,
                 "token_type": data.get("token_type", "Bearer"),
             }
-            _save_token(updated)
+            await _save_token(updated)
             logger.debug("Token refreshed successfully")
             return updated
 
@@ -135,7 +135,7 @@ async def _get_valid_token() -> dict | None:
 
     Returns token dict with valid access_token, or None.
     """
-    token = _load_token()
+    token = await _load_token()
     if not token:
         return None
 
@@ -494,7 +494,7 @@ async def sync_full(db: MemoryDB) -> dict:
         }
 
     # Check for valid token
-    if not _has_token_available():
+    if not await _has_token_available():
         return {
             "status": "error",
             "message": "No Google Drive token available. "
@@ -684,7 +684,7 @@ async def setup_google_auth(
                         "client_id": client_id,
                         "token_type": data.get("token_type", "Bearer"),
                     }
-                    _save_token(token)
+                    await _save_token(token)
                     logger.info("Google Drive authentication successful!")
                     return True
 

--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -13,6 +13,7 @@ Token lifecycle:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import stat
@@ -104,3 +105,18 @@ def delete_token(provider: str) -> bool:
         logger.info(f"Token deleted: {path}")
         return True
     return False
+
+
+async def async_load_token(provider: str) -> dict | None:
+    """Load stored OAuth token for a provider asynchronously."""
+    return await asyncio.to_thread(load_token, provider)
+
+
+async def async_save_token(provider: str, token: dict) -> None:
+    """Save OAuth token to local storage asynchronously."""
+    await asyncio.to_thread(save_token, provider, token)
+
+
+async def async_delete_token(provider: str) -> bool:
+    """Delete a stored token asynchronously."""
+    return await asyncio.to_thread(delete_token, provider)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -21,16 +21,18 @@ from mnemo_mcp.sync import (
 
 
 class TestTokenManagement:
-    def test_has_token_false_when_no_token(self):
-        with patch("mnemo_mcp.sync._load_token", return_value=None):
-            assert _has_token_available() is False
+    async def test_has_token_false_when_no_token(self):
+        with patch(
+            "mnemo_mcp.sync._load_token", new_callable=AsyncMock, return_value=None
+        ):
+            assert await _has_token_available() is False
 
-    def test_has_token_true_when_token_exists(self):
+    async def test_has_token_true_when_token_exists(self):
         with patch(
             "mnemo_mcp.sync._load_token",
             return_value={"access_token": "ya29.abc"},
         ):
-            assert _has_token_available() is True
+            assert await _has_token_available() is True
 
     async def test_refresh_token_success(self):
         from mnemo_mcp.sync import _refresh_token
@@ -51,7 +53,7 @@ class TestTokenManagement:
 
         with (
             patch("httpx.AsyncClient") as mock_client_cls,
-            patch("mnemo_mcp.sync._save_token") as mock_save,
+            patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock) as mock_save,
             patch("mnemo_mcp.sync.settings") as mock_settings,
         ):
             mock_settings.google_drive_client_secret = "secret123"
@@ -103,7 +105,9 @@ class TestTokenManagement:
     async def test_get_valid_token_no_token(self):
         from mnemo_mcp.sync import _get_valid_token
 
-        with patch("mnemo_mcp.sync._load_token", return_value=None):
+        with patch(
+            "mnemo_mcp.sync._load_token", new_callable=AsyncMock, return_value=None
+        ):
             result = await _get_valid_token()
         assert result is None
 
@@ -116,7 +120,9 @@ class TestTokenManagement:
             "access_token": "valid",
             "expiry": time.time() + 3600,
         }
-        with patch("mnemo_mcp.sync._load_token", return_value=token):
+        with patch(
+            "mnemo_mcp.sync._load_token", new_callable=AsyncMock, return_value=token
+        ):
             result = await _get_valid_token()
         assert result == token
 
@@ -132,7 +138,9 @@ class TestTokenManagement:
         }
         refreshed = {"access_token": "new", "expiry": time.time() + 3600}
         with (
-            patch("mnemo_mcp.sync._load_token", return_value=token),
+            patch(
+                "mnemo_mcp.sync._load_token", new_callable=AsyncMock, return_value=token
+            ),
             patch(
                 "mnemo_mcp.sync._refresh_token",
                 new_callable=AsyncMock,
@@ -408,7 +416,11 @@ class TestSyncFull:
         """Sync errors when no token is available."""
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
-            patch("mnemo_mcp.sync._has_token_available", return_value=False),
+            patch(
+                "mnemo_mcp.sync._has_token_available",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             mock_settings.sync_enabled = True
             mock_settings.google_drive_client_id = "client123"
@@ -420,7 +432,11 @@ class TestSyncFull:
         """Sync errors when token refresh fails."""
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
-            patch("mnemo_mcp.sync._has_token_available", return_value=True),
+            patch(
+                "mnemo_mcp.sync._has_token_available",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
             patch(
                 "mnemo_mcp.sync._get_valid_token",
                 new_callable=AsyncMock,

--- a/tests/test_sync_gdrive_auth.py
+++ b/tests/test_sync_gdrive_auth.py
@@ -22,20 +22,20 @@ from mnemo_mcp.sync import (
 
 
 class TestTokenWrappers:
-    def test_load_token_delegates_to_store(self):
+    async def test_load_token_delegates_to_store(self):
         """_load_token calls token_store.load_token with 'google_drive'."""
         with patch(
             "mnemo_mcp.token_store.load_token", return_value={"access_token": "abc"}
         ) as mock:
-            result = _load_token()
+            result = await _load_token()
             assert result == {"access_token": "abc"}
             mock.assert_called_once_with("google_drive")
 
-    def test_save_token_delegates_to_store(self):
+    async def test_save_token_delegates_to_store(self):
         """_save_token calls token_store.save_token with 'google_drive'."""
         token = {"access_token": "xyz"}
         with patch("mnemo_mcp.token_store.save_token") as mock:
-            _save_token(token)
+            await _save_token(token)
             mock.assert_called_once_with("google_drive", token)
 
 
@@ -109,7 +109,7 @@ class TestSetupGoogleAuthFull:
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
             patch("httpx.AsyncClient") as mock_client_cls,
-            patch("mnemo_mcp.sync._save_token") as mock_save,
+            patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock) as mock_save,
             patch("mnemo_mcp.sync.asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_settings.google_drive_client_id = "client123"
@@ -162,7 +162,7 @@ class TestSetupGoogleAuthFull:
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
             patch("httpx.AsyncClient") as mock_client_cls,
-            patch("mnemo_mcp.sync._save_token"),
+            patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock),
             patch("mnemo_mcp.sync.asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_settings.google_drive_client_id = "client123"
@@ -204,7 +204,7 @@ class TestSetupGoogleAuthFull:
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
             patch("httpx.AsyncClient") as mock_client_cls,
-            patch("mnemo_mcp.sync._save_token"),
+            patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock),
             patch("mnemo_mcp.sync.asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_settings.google_drive_client_id = "client123"
@@ -250,7 +250,7 @@ class TestSetupGoogleAuthFull:
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
             patch("httpx.AsyncClient") as mock_client_cls,
-            patch("mnemo_mcp.sync._save_token"),
+            patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock),
             patch("mnemo_mcp.sync.asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_settings.google_drive_client_id = "client123"
@@ -428,7 +428,7 @@ class TestSetupGoogleAuthFull:
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
             patch("httpx.AsyncClient") as mock_client_cls,
-            patch("mnemo_mcp.sync._save_token"),
+            patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock),
             patch("mnemo_mcp.sync.asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_settings.google_drive_client_id = "client123"
@@ -535,7 +535,11 @@ class TestSyncFullMergeSuccess:
 
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
-            patch("mnemo_mcp.sync._has_token_available", return_value=True),
+            patch(
+                "mnemo_mcp.sync._has_token_available",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
             patch(
                 "mnemo_mcp.sync._get_valid_token",
                 new_callable=AsyncMock,

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -27,7 +27,7 @@ async def test_token_refresh_preserves_refresh_token():
 
     with (
         patch("httpx.AsyncClient") as mock_client_cls,
-        patch("mnemo_mcp.sync._save_token") as mock_save,
+        patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock) as mock_save,
         patch("mnemo_mcp.sync.settings") as mock_settings,
     ):
         mock_settings.google_drive_client_secret = "secret123"
@@ -70,7 +70,7 @@ async def test_token_refresh_updates_refresh_token():
 
     with (
         patch("httpx.AsyncClient") as mock_client_cls,
-        patch("mnemo_mcp.sync._save_token"),
+        patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock),
         patch("mnemo_mcp.sync.settings") as mock_settings,
     ):
         mock_settings.google_drive_client_secret = "secret123"
@@ -107,7 +107,7 @@ async def test_token_refresh_uses_settings_client_id():
 
     with (
         patch("httpx.AsyncClient") as mock_client_cls,
-        patch("mnemo_mcp.sync._save_token"),
+        patch("mnemo_mcp.sync._save_token", new_callable=AsyncMock),
         patch("mnemo_mcp.sync.settings") as mock_settings,
     ):
         mock_settings.google_drive_client_id = "settings_client_id"

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -257,3 +257,39 @@ class TestGetTokenPath:
             m.get_data_dir.return_value = token_dir.parent
             path = get_token_path("drive")
         assert path == token_dir / "drive.json"
+
+
+class TestAsyncTokenStore:
+    @pytest.mark.asyncio
+    async def test_async_load_valid_token(self, token_dir):
+        from mnemo_mcp.token_store import async_load_token
+
+        token = {"access_token": "async123", "token_type": "Bearer"}
+        (token_dir / "drive.json").write_text(json.dumps(token))
+
+        with patch("mnemo_mcp.token_store.settings") as m:
+            m.get_data_dir.return_value = token_dir.parent
+            result = await async_load_token("drive")
+        assert result == token
+
+    @pytest.mark.asyncio
+    async def test_async_save_creates_file(self, token_dir):
+        from mnemo_mcp.token_store import async_save_token
+
+        token = {"access_token": "async_save", "token_type": "Bearer"}
+        with patch("mnemo_mcp.token_store.settings") as m:
+            m.get_data_dir.return_value = token_dir.parent
+            await async_save_token("drive", token)
+
+        saved = json.loads((token_dir / "drive.json").read_text())
+        assert saved["access_token"] == "async_save"
+
+    @pytest.mark.asyncio
+    async def test_async_delete_existing(self, token_dir):
+        from mnemo_mcp.token_store import async_delete_token
+
+        (token_dir / "drive.json").write_text("{}")
+        with patch("mnemo_mcp.token_store.settings") as m:
+            m.get_data_dir.return_value = token_dir.parent
+            assert await async_delete_token("drive") is True
+        assert not (token_dir / "drive.json").exists()


### PR DESCRIPTION
Token loading `load_token` was synchronous using `path.read_text`, which could block the event loop in asynchronous execution contexts during synchronization processes. 

This PR:
1.  Introduces `async_load_token`, `async_save_token`, and `async_delete_token` in `src/mnemo_mcp/token_store.py` using `asyncio.to_thread` to offload blocking I/O.
2.  Refactors the internal token helpers in `src/mnemo_mcp/sync.py` (`_load_token`, `_save_token`, `_has_token_available`) to be asynchronous.
3.  Updates all call sites in `sync.py` to correctly `await` these operations.
4.  Updates the test suite (`tests/test_sync.py`, `tests/test_sync_gdrive_auth.py`, `tests/test_sync_version.py`) to handle the now-async helpers, using `AsyncMock` where appropriate.
5.  Adds specific async test cases for the new functions in `tests/test_token_store.py`.

All 137 tests passed.

---
*PR created automatically by Jules for task [1175002861240995134](https://jules.google.com/task/1175002861240995134) started by @n24q02m*