### PR TITLE
[SECURITY] Potential SQL Injection in update method

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -641,39 +641,33 @@ class MemoryDB:
                 f"Content length {len(content)} exceeds limit of {MAX_CONTENT_LENGTH}"
             )
 
-        existing = self.get(memory_id)
-        if not existing:
-            return False
-
         now = _now_iso()
-        updates = []
-        params: list = []
 
-        if content is not None:
-            updates.append("content = ?")
-            params.append(content)
-        if category is not None:
-            updates.append("category = ?")
-            params.append(category)
-        if tags is not None:
-            updates.append("tags = ?")
-            params.append(json.dumps(tags))
-
-        updates.append("updated_at = ?")
-        params.append(now)
-        params.append(memory_id)
-
-        # Validate updates against allowlist before string joining
-        # to ensure no unexpected column names are injected.
-        _ALLOWED = {"content = ?", "category = ?", "tags = ?", "updated_at = ?"}
-        if not all(u in _ALLOWED for u in updates):
-            invalid = [u for u in updates if u not in _ALLOWED]
-            raise ValueError(f"Unauthorized update columns detected: {invalid}")
-
-        self._conn.execute(
-            f"UPDATE memories SET {', '.join(updates)} WHERE id = ?",
-            params,
+        # Use static parameterized query with CASE WHEN for safe partial updates.
+        # This prevents SQL injection and ensures only specified fields are changed.
+        cursor = self._conn.execute(
+            """
+            UPDATE memories SET
+                content = CASE WHEN :content_provided THEN :content ELSE content END,
+                category = CASE WHEN :category_provided THEN :category ELSE category END,
+                tags = CASE WHEN :tags_provided THEN :tags ELSE tags END,
+                updated_at = :now
+            WHERE id = :id
+            """,
+            {
+                "id": memory_id,
+                "now": now,
+                "content": content,
+                "content_provided": content is not None,
+                "category": category,
+                "category_provided": category is not None,
+                "tags": json.dumps(tags) if tags is not None else None,
+                "tags_provided": tags is not None,
+            },
         )
+
+        if cursor.rowcount == 0:
+            return False
 
         # Update embedding if provided
         if embedding and self._vec_enabled:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -27,3 +27,25 @@ def test_max_tags_limit(tmp_db: MemoryDB):
     large_tags = [f"tag{i}" for i in range(51)]
     with pytest.raises(ValueError, match="Maximum of 50 tags allowed in search filter"):
         tmp_db.search("memory", tags=large_tags)
+
+
+def test_update_security(tmp_db: MemoryDB):
+    """Verify update method robustness."""
+    mid = tmp_db.add("content", category="cat")
+
+    # Verify that we cannot update internal columns even if we try to be clever
+    # The new implementation doesn'\''t even take a list of columns, so it'\''s
+    # much harder to exploit.
+
+    # Normal update works
+    assert tmp_db.update(mid, content="new content") is True
+    mem = tmp_db.get(mid)
+    assert mem["content"] == "new content"
+
+    # Try to inject something into a parameter (though it'\''s already safe due to placeholders)
+    # This is more of a sanity check.
+    malicious_content = "content', category='pwned"
+    tmp_db.update(mid, content=malicious_content)
+    mem = tmp_db.get(mid)
+    assert mem["content"] == malicious_content
+    assert mem["category"] == "cat"  # Category remains unchanged

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -40,6 +40,7 @@ def test_update_security(tmp_db: MemoryDB):
     # Normal update works
     assert tmp_db.update(mid, content="new content") is True
     mem = tmp_db.get(mid)
+    assert mem is not None
     assert mem["content"] == "new content"
 
     # Try to inject something into a parameter (though it'\''s already safe due to placeholders)
@@ -47,5 +48,6 @@ def test_update_security(tmp_db: MemoryDB):
     malicious_content = "content', category='pwned"
     tmp_db.update(mid, content=malicious_content)
     mem = tmp_db.get(mid)
+    assert mem is not None
     assert mem["content"] == malicious_content
     assert mem["category"] == "cat"  # Category remains unchanged


### PR DESCRIPTION
Refactored the MemoryDB.update method to use a static parameterized SQL query with CASE WHEN logic. This eliminates dynamic SQL construction and the associated SQL injection risk. Also optimized by using cursor.rowcount instead of a preliminary get() call to check for existence. Added a new security test to verify robustness.

---
*PR created automatically by Jules for task [12279929000015271247](https://jules.google.com/task/12279929000015271247) started by @n24q02m*