### PR TITLE
[FIX] Long method ensure_config

### DIFF
--- a/src/mnemo_mcp/relay_setup.py
+++ b/src/mnemo_mcp/relay_setup.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import sys
+from typing import Any
 
 from loguru import logger
 
@@ -67,26 +68,19 @@ async def ensure_config() -> dict[str, str] | None:
     Returns:
         Config dict with credential keys, or None if skipped/failed (local mode).
     """
-    # 1. Check if env vars already provide cloud keys (highest priority)
-    if any(os.environ.get(k) for k in CLOUD_KEYS):
-        logger.info("Cloud API keys found in environment, skipping relay")
-        return None  # env vars take priority, no relay needed
+    # 1. Check local credentials
+    local_res = _check_local_credentials()
+    if local_res is True:
+        return None
+    if isinstance(local_res, dict):
+        return local_res
 
-    # 2. Check saved relay config file
-    config = load_relay_config()
-    if config is not None:
-        return config
-
-    # 3. No local credentials found -- trigger relay setup
+    # 2. No local credentials found -- trigger relay setup
     logger.info("No cloud credentials found. Starting relay setup...")
 
     relay_url = DEFAULT_RELAY_URL
     try:
-        from mcp_core.relay.client import create_session, poll_for_result
-
-        from .relay_schema import RELAY_SCHEMA
-
-        session = await create_session(relay_url, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
+        session = await _initiate_relay_session(relay_url)
     except Exception:
         logger.debug("Cannot reach relay server at {}. Using local mode.", relay_url)
         return None
@@ -100,72 +94,125 @@ async def ensure_config() -> dict[str, str] | None:
         flush=True,
     )
 
-    # Poll for result with shorter timeout
+    # 3. Poll for result with shorter timeout
     try:
         from mcp_core.relay.client import poll_for_result
-        from mcp_core.storage.config_file import write_config
 
         config = await poll_for_result(relay_url, session, timeout_s=RELAY_TIMEOUT_S)
 
-        # Save to config file
-        write_config(SERVER_NAME, config)
-        logger.info("Cloud config saved successfully")
-
-        apply_config(config)
-
-        # Notify relay page: config saved (info, NOT complete — GDrive OAuth follows)
-        try:
-            import httpx
-
-            async with httpx.AsyncClient() as http:
-                await http.post(
-                    f"{relay_url}/api/sessions/{session.session_id}/messages",
-                    json={
-                        "type": "info",
-                        "text": "API keys saved. Starting Google Drive sync setup...",
-                    },
-                )
-        except Exception:
-            pass
-
-        # Trigger GDrive OAuth Device Code using default client ID from settings
-        from mnemo_mcp.config import settings as _settings
-
-        gdrive_ok = False
-        if _settings.google_drive_client_id:
-            logger.info("Starting Google Drive OAuth setup...")
-            try:
-                from mnemo_mcp.sync import setup_google_auth
-
-                gdrive_ok = await setup_google_auth(
-                    relay_url=relay_url,
-                    session_id=session.session_id,
-                )
-            except Exception as e:
-                logger.warning(f"GDrive OAuth setup failed: {e}")
-
-        # NOW send complete (after GDrive OAuth finishes or skips)
-        try:
-            async with httpx.AsyncClient() as http:
-                msg = (
-                    "Setup complete!"
-                    if gdrive_ok
-                    else "API keys saved. Google Drive sync can be configured later via config tool."
-                )
-                await http.post(
-                    f"{relay_url}/api/sessions/{session.session_id}/messages",
-                    json={"type": "complete", "text": msg},
-                )
-        except Exception:
-            pass
-
+        await _handle_post_config_setup(relay_url, session, config)
         return config
 
     except RuntimeError as e:
-        if "RELAY_SKIPPED" in str(e):
-            logger.info("Relay setup skipped by user. Using local mode.")
-        elif "timed out" in str(e).lower():
-            logger.info("Relay setup timed out. Using local mode.")
-        else:
-            logger.debug("Relay setup ended: {}", e)
+        _handle_relay_error(e)
         return None
+
+
+def _check_local_credentials() -> dict[str, str] | None | bool:
+    """Check for credentials in environment variables or saved config file.
+
+    Returns:
+        True if credentials found in environment (env takes priority).
+        Dict if credentials found in saved config file.
+        None if no credentials found locally.
+    """
+    # 1. Check if env vars already provide cloud keys (highest priority)
+    if any(os.environ.get(k) for k in CLOUD_KEYS):
+        logger.info("Cloud API keys found in environment, skipping relay")
+        return True
+
+    # 2. Check saved relay config file
+    config = load_relay_config()
+    if config is not None:
+        return config
+
+    return None
+
+
+async def _initiate_relay_session(relay_url: str) -> Any:
+    """Create a new relay session for configuration."""
+    from mcp_core.relay.client import create_session
+
+    from .relay_schema import RELAY_SCHEMA
+
+    return await create_session(relay_url, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
+
+
+async def _handle_post_config_setup(
+    relay_url: str, session: Any, config: dict[str, str]
+) -> bool:
+    """Save and apply config, then trigger Google Drive setup if needed."""
+    from mcp_core.storage.config_file import write_config
+
+    # Save to config file
+    write_config(SERVER_NAME, config)
+    logger.info("Cloud config saved successfully")
+
+    apply_config(config)
+
+    # Notify relay page: config saved (info, NOT complete — GDrive OAuth follows)
+    await _send_relay_message(
+        relay_url,
+        session.session_id,
+        "info",
+        "API keys saved. Starting Google Drive sync setup...",
+    )
+
+    # Trigger GDrive OAuth Device Code using default client ID from settings
+    gdrive_ok = await _setup_gdrive_sync(relay_url, session.session_id)
+
+    # NOW send complete (after GDrive OAuth finishes or skips)
+    msg = (
+        "Setup complete!"
+        if gdrive_ok
+        else "API keys saved. Google Drive sync can be configured later via config tool."
+    )
+    await _send_relay_message(relay_url, session.session_id, "complete", msg)
+
+    return gdrive_ok
+
+
+async def _setup_gdrive_sync(relay_url: str, session_id: str) -> bool:
+    """Handle Google Drive OAuth setup if a client ID is configured."""
+    from mnemo_mcp.config import settings as _settings
+
+    if not _settings.google_drive_client_id:
+        return False
+
+    logger.info("Starting Google Drive OAuth setup...")
+    try:
+        from mnemo_mcp.sync import setup_google_auth
+
+        return await setup_google_auth(
+            relay_url=relay_url,
+            session_id=session_id,
+        )
+    except Exception as e:
+        logger.warning(f"GDrive OAuth setup failed: {e}")
+        return False
+
+
+async def _send_relay_message(
+    relay_url: str, session_id: str, msg_type: str, text: str
+) -> None:
+    """Send a status message to the relay server."""
+    try:
+        import httpx
+
+        async with httpx.AsyncClient() as http:
+            await http.post(
+                f"{relay_url}/api/sessions/{session_id}/messages",
+                json={"type": msg_type, "text": text},
+            )
+    except Exception:
+        pass
+
+
+def _handle_relay_error(e: Exception) -> None:
+    """Log appropriate messages for relay setup errors."""
+    if "RELAY_SKIPPED" in str(e):
+        logger.info("Relay setup skipped by user. Using local mode.")
+    elif "timed out" in str(e).lower():
+        logger.info("Relay setup timed out. Using local mode.")
+    else:
+        logger.debug("Relay setup ended: {}", e)


### PR DESCRIPTION
The `ensure_config` function in `src/mnemo_mcp/relay_setup.py` was identified as a "long method" that handled multiple responsibilities, including local credential checking, relay session management, post-configuration processing, and Google Drive sync orchestration.

This PR modularizes the function by extracting these logical blocks into discrete private helper functions:

1.  `_check_local_credentials()`: Centralizes checks for environment variables and saved config files.
2.  `_initiate_relay_session()`: Handles the creation of relay sessions.
3.  `_handle_post_config_setup()`: Coordinates the tasks performed after a successful configuration poll (saving, applying, and triggering sync).
4.  `_setup_gdrive_sync()`: Encapsulates the Google Drive OAuth flow.
5.  `_send_relay_message()`: Provides a reusable helper for reporting status back to the relay server.
6.  `_handle_relay_error()`: Centralizes logging for various relay failure modes.

The resulting `ensure_config` function is now a clean orchestration layer, significantly improving readability and making the setup flow easier to maintain and test.

Verification performed:
- Full linting and formatting with `ruff`.
- Execution of existing unit tests in `tests/test_relay_setup.py` and `tests/test_relay_setup_coverage.py`, all of which pass.
- Manual inspection of the refactored code to ensure structural integrity.

---
*PR created automatically by Jules for task [7141755553096459506](https://jules.google.com/task/7141755553096459506) started by @n24q02m*