### PR TITLE
[PERF] Synchronous file read in sync loop

### DIFF
--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -54,6 +54,9 @@ _TOKEN_PROVIDER = "google_drive"
 # In-memory folder ID cache to avoid duplicate folder creation
 _folder_id_cache: dict[str, str] = {}
 
+# Lock to prevent race conditions during disk cache operations
+_folder_id_disk_lock = asyncio.Lock()
+
 
 # ---------------------------------------------------------------------------
 # Token management
@@ -184,30 +187,34 @@ async def _drive_request(
     return response
 
 
-def _load_folder_id(folder_name: str) -> str | None:
+async def _load_folder_id(folder_name: str) -> str | None:
     """Load cached folder ID from disk."""
     path = settings.get_data_dir() / "sync_folder_ids.json"
-    try:
-        if path.exists():
-            data = json.loads(path.read_text(encoding="utf-8"))
-            return data.get(folder_name)
-    except (json.JSONDecodeError, OSError):
-        pass
+    async with _folder_id_disk_lock:
+        try:
+            if await asyncio.to_thread(path.exists):
+                text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+                data = json.loads(text)
+                return data.get(folder_name)
+        except (json.JSONDecodeError, OSError):
+            pass
     return None
 
 
-def _save_folder_id(folder_name: str, folder_id: str) -> None:
+async def _save_folder_id(folder_name: str, folder_id: str) -> None:
     """Persist folder ID to disk."""
     path = settings.get_data_dir() / "sync_folder_ids.json"
-    data: dict[str, str] = {}
-    try:
-        if path.exists():
-            data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        pass
-    data[folder_name] = folder_id
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data), encoding="utf-8")
+    async with _folder_id_disk_lock:
+        data: dict[str, str] = {}
+        try:
+            if await asyncio.to_thread(path.exists):
+                text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+                data = json.loads(text)
+        except (json.JSONDecodeError, OSError):
+            pass
+        data[folder_name] = folder_id
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(path.write_text, json.dumps(data), encoding="utf-8")
 
 
 async def _verify_folder_exists(token: dict, folder_id: str) -> bool:
@@ -237,7 +244,7 @@ async def _find_or_create_folder(token: dict, folder_name: str) -> str | None:
         del _folder_id_cache[folder_name]
 
     # 2. Check disk cache
-    saved_id = _load_folder_id(folder_name)
+    saved_id = await _load_folder_id(folder_name)
     if saved_id:
         if await _verify_folder_exists(token, saved_id):
             _folder_id_cache[folder_name] = saved_id
@@ -263,7 +270,7 @@ async def _find_or_create_folder(token: dict, folder_name: str) -> str | None:
             if files:
                 fid = files[0]["id"]
                 _folder_id_cache[folder_name] = fid
-                _save_folder_id(folder_name, fid)
+                await _save_folder_id(folder_name, fid)
                 return fid
 
         if attempt < 2:
@@ -286,7 +293,7 @@ async def _find_or_create_folder(token: dict, folder_name: str) -> str | None:
         fid = response.json().get("id")
         if fid:
             _folder_id_cache[folder_name] = fid
-            _save_folder_id(folder_name, fid)
+            await _save_folder_id(folder_name, fid)
         return fid
 
     logger.error(f"Failed to create folder '{folder_name}': {response.text}")

--- a/tests/test_sync_folder_cache.py
+++ b/tests/test_sync_folder_cache.py
@@ -24,43 +24,43 @@ from mnemo_mcp.sync import (
 
 
 class TestLoadFolderId:
-    def test_returns_none_when_file_missing(self, tmp_path):
+    async def test_returns_none_when_file_missing(self, tmp_path):
         """Returns None when sync_folder_ids.json doesn't exist."""
         with patch("mnemo_mcp.sync.settings") as mock_settings:
             mock_settings.get_data_dir.return_value = tmp_path
-            result = _load_folder_id("test-folder")
+            result = await _load_folder_id("test-folder")
         assert result is None
 
-    def test_returns_id_when_present(self, tmp_path):
+    async def test_returns_id_when_present(self, tmp_path):
         """Returns folder ID from saved file."""
         path = tmp_path / "sync_folder_ids.json"
         path.write_text(json.dumps({"my-folder": "folder-123"}), encoding="utf-8")
 
         with patch("mnemo_mcp.sync.settings") as mock_settings:
             mock_settings.get_data_dir.return_value = tmp_path
-            result = _load_folder_id("my-folder")
+            result = await _load_folder_id("my-folder")
 
         assert result == "folder-123"
 
-    def test_returns_none_for_unknown_folder(self, tmp_path):
+    async def test_returns_none_for_unknown_folder(self, tmp_path):
         """Returns None when folder name not in saved file."""
         path = tmp_path / "sync_folder_ids.json"
         path.write_text(json.dumps({"other-folder": "id-456"}), encoding="utf-8")
 
         with patch("mnemo_mcp.sync.settings") as mock_settings:
             mock_settings.get_data_dir.return_value = tmp_path
-            result = _load_folder_id("my-folder")
+            result = await _load_folder_id("my-folder")
 
         assert result is None
 
-    def test_handles_json_decode_error(self, tmp_path):
+    async def test_handles_json_decode_error(self, tmp_path):
         """Returns None when file contains invalid JSON."""
         path = tmp_path / "sync_folder_ids.json"
         path.write_text("not-valid-json", encoding="utf-8")
 
         with patch("mnemo_mcp.sync.settings") as mock_settings:
             mock_settings.get_data_dir.return_value = tmp_path
-            result = _load_folder_id("my-folder")
+            result = await _load_folder_id("my-folder")
 
         assert result is None
 
@@ -71,38 +71,38 @@ class TestLoadFolderId:
 
 
 class TestSaveFolderId:
-    def test_creates_new_file(self, tmp_path):
+    async def test_creates_new_file(self, tmp_path):
         """Creates sync_folder_ids.json with folder ID."""
         with patch("mnemo_mcp.sync.settings") as mock_settings:
             mock_settings.get_data_dir.return_value = tmp_path
-            _save_folder_id("my-folder", "folder-123")
+            await _save_folder_id("my-folder", "folder-123")
 
         path = tmp_path / "sync_folder_ids.json"
         assert path.exists()
         data = json.loads(path.read_text(encoding="utf-8"))
         assert data["my-folder"] == "folder-123"
 
-    def test_appends_to_existing_file(self, tmp_path):
+    async def test_appends_to_existing_file(self, tmp_path):
         """Adds new folder ID to existing file."""
         path = tmp_path / "sync_folder_ids.json"
         path.write_text(json.dumps({"existing": "id-1"}), encoding="utf-8")
 
         with patch("mnemo_mcp.sync.settings") as mock_settings:
             mock_settings.get_data_dir.return_value = tmp_path
-            _save_folder_id("new-folder", "id-2")
+            await _save_folder_id("new-folder", "id-2")
 
         data = json.loads(path.read_text(encoding="utf-8"))
         assert data["existing"] == "id-1"
         assert data["new-folder"] == "id-2"
 
-    def test_handles_corrupt_existing_file(self, tmp_path):
+    async def test_handles_corrupt_existing_file(self, tmp_path):
         """Overwrites corrupt existing file."""
         path = tmp_path / "sync_folder_ids.json"
         path.write_text("corrupt-json", encoding="utf-8")
 
         with patch("mnemo_mcp.sync.settings") as mock_settings:
             mock_settings.get_data_dir.return_value = tmp_path
-            _save_folder_id("folder", "id-1")
+            await _save_folder_id("folder", "id-1")
 
         data = json.loads(path.read_text(encoding="utf-8"))
         assert data["folder"] == "id-1"
@@ -209,8 +209,12 @@ class TestFindOrCreateFolderCache:
                     new_callable=AsyncMock,
                     side_effect=[verify_stale, search_resp],
                 ),
-                patch("mnemo_mcp.sync._load_folder_id", return_value=None),
-                patch("mnemo_mcp.sync._save_folder_id"),
+                patch(
+                    "mnemo_mcp.sync._load_folder_id",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ),
+                patch("mnemo_mcp.sync._save_folder_id", new_callable=AsyncMock),
             ):
                 result = await _find_or_create_folder(
                     {"access_token": "t"}, "test-folder"
@@ -232,7 +236,11 @@ class TestFindOrCreateFolderCache:
             verify_resp.json.return_value = {"id": "disk-id", "trashed": False}
 
             with (
-                patch("mnemo_mcp.sync._load_folder_id", return_value="disk-id"),
+                patch(
+                    "mnemo_mcp.sync._load_folder_id",
+                    new_callable=AsyncMock,
+                    return_value="disk-id",
+                ),
                 patch(
                     "mnemo_mcp.sync._drive_request",
                     new_callable=AsyncMock,
@@ -261,13 +269,19 @@ class TestFindOrCreateFolderCache:
             search_resp.json.return_value = {"files": [{"id": "search-id"}]}
 
             with (
-                patch("mnemo_mcp.sync._load_folder_id", return_value=None),
+                patch(
+                    "mnemo_mcp.sync._load_folder_id",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ),
                 patch(
                     "mnemo_mcp.sync._drive_request",
                     new_callable=AsyncMock,
                     return_value=search_resp,
                 ),
-                patch("mnemo_mcp.sync._save_folder_id") as mock_save,
+                patch(
+                    "mnemo_mcp.sync._save_folder_id", new_callable=AsyncMock
+                ) as mock_save,
             ):
                 result = await _find_or_create_folder(
                     {"access_token": "t"}, "test-folder"
@@ -294,13 +308,19 @@ class TestFindOrCreateFolderCache:
             create_resp.json.return_value = {"id": "new-id"}
 
             with (
-                patch("mnemo_mcp.sync._load_folder_id", return_value=None),
+                patch(
+                    "mnemo_mcp.sync._load_folder_id",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ),
                 patch(
                     "mnemo_mcp.sync._drive_request",
                     new_callable=AsyncMock,
                     side_effect=[search_resp, search_resp, search_resp, create_resp],
                 ),
-                patch("mnemo_mcp.sync._save_folder_id") as mock_save,
+                patch(
+                    "mnemo_mcp.sync._save_folder_id", new_callable=AsyncMock
+                ) as mock_save,
                 patch("asyncio.sleep", return_value=None),
             ):
                 result = await _find_or_create_folder(


### PR DESCRIPTION
Refactored _load_folder_id and _save_folder_id in src/mnemo_mcp/sync.py to be asynchronous, using asyncio.to_thread for disk I/O and an asyncio.Lock to prevent race conditions. Updated callers and tests accordingly.

---
*PR created automatically by Jules for task [14838222554046013006](https://jules.google.com/task/14838222554046013006) started by @n24q02m*