### PR TITLE
[FIX] Duplicate memory table definitions

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -84,6 +84,18 @@ def _build_fts_queries(query: str) -> list[str]:
     ]
 
 
+_MEMORY_COLUMNS_SQL = """                id TEXT PRIMARY KEY NOT NULL,
+                content TEXT NOT NULL,
+                category TEXT NOT NULL DEFAULT 'general',
+                tags TEXT NOT NULL DEFAULT '[]',
+                source TEXT,
+                importance REAL NOT NULL DEFAULT 0.5,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                access_count INTEGER NOT NULL DEFAULT 0,
+                last_accessed TEXT NOT NULL"""
+
+
 class MemoryDB:
     """SQLite database for persistent AI memories."""
 
@@ -139,17 +151,9 @@ class MemoryDB:
 
     def _init_schema(self) -> None:
         """Initialize database schema."""
-        self._conn.executescript("""
+        self._conn.executescript(f"""
             CREATE TABLE IF NOT EXISTS memories (
-                id TEXT PRIMARY KEY NOT NULL,
-                content TEXT NOT NULL,
-                category TEXT NOT NULL DEFAULT 'general',
-                tags TEXT NOT NULL DEFAULT '[]',
-                source TEXT,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL,
-                access_count INTEGER NOT NULL DEFAULT 0,
-                last_accessed TEXT NOT NULL
+                {_MEMORY_COLUMNS_SQL}
             );
 
             CREATE INDEX IF NOT EXISTS idx_memories_category
@@ -201,7 +205,7 @@ class MemoryDB:
         """)
 
         # Knowledge graph tables
-        self._conn.executescript("""
+        self._conn.executescript(f"""
             CREATE TABLE IF NOT EXISTS entities (
                 id TEXT PRIMARY KEY NOT NULL,
                 name TEXT NOT NULL,
@@ -238,16 +242,7 @@ class MemoryDB:
 
             -- Archive table
             CREATE TABLE IF NOT EXISTS archived_memories (
-                id TEXT PRIMARY KEY NOT NULL,
-                content TEXT NOT NULL,
-                category TEXT NOT NULL DEFAULT 'general',
-                tags TEXT NOT NULL DEFAULT '[]',
-                source TEXT,
-                importance REAL NOT NULL DEFAULT 0.5,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL,
-                access_count INTEGER NOT NULL DEFAULT 0,
-                last_accessed TEXT NOT NULL,
+                {_MEMORY_COLUMNS_SQL},
                 archived_at TEXT NOT NULL
             );
 


### PR DESCRIPTION
Extracted shared column definitions for `memories` and `archived_memories` tables into a `_MEMORY_COLUMNS_SQL` constant in `src/mnemo_mcp/db.py`. This improves maintainability and ensures schema consistency across active and archived records. Updated `_init_schema` to utilize f-string interpolation for these definitions.

---
*PR created automatically by Jules for task [6018283286995682380](https://jules.google.com/task/6018283286995682380) started by @n24q02m*