### PR TITLE
[PERF] Synchronous file write for tokens

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -409,9 +409,9 @@ async def _gdrive_token_poll(
                 )
                 data = resp.json()
                 if "access_token" in data:
-                    from mnemo_mcp.token_store import save_token
+                    from mnemo_mcp.token_store import async_save_token
 
-                    save_token("google_drive", data)
+                    await async_save_token("google_drive", data)
                     logger.info("GDrive OAuth token saved successfully")
                     logger.info(
                         "GDrive authorized. Sync will start on next server restart."

--- a/src/mnemo_mcp/sync.py
+++ b/src/mnemo_mcp/sync.py
@@ -60,23 +60,23 @@ _folder_id_cache: dict[str, str] = {}
 # ---------------------------------------------------------------------------
 
 
-def _load_token() -> dict | None:
+async def _load_token() -> dict | None:
     """Load Google Drive OAuth token from local storage."""
-    from mnemo_mcp.token_store import load_token
+    from mnemo_mcp.token_store import async_load_token
 
-    return load_token(_TOKEN_PROVIDER)
+    return await async_load_token(_TOKEN_PROVIDER)
 
 
-def _save_token(token: dict) -> None:
+async def _save_token(token: dict) -> None:
     """Save Google Drive OAuth token to local storage."""
-    from mnemo_mcp.token_store import save_token
+    from mnemo_mcp.token_store import async_save_token
 
-    save_token(_TOKEN_PROVIDER, token)
+    await async_save_token(_TOKEN_PROVIDER, token)
 
 
-def _has_token_available() -> bool:
+async def _has_token_available() -> bool:
     """Check if a Google Drive token is available."""
-    return _load_token() is not None
+    return await _load_token() is not None
 
 
 async def _refresh_token(token: dict) -> dict | None:
@@ -121,7 +121,7 @@ async def _refresh_token(token: dict) -> dict | None:
                 "client_id": client_id,
                 "token_type": data.get("token_type", "Bearer"),
             }
-            _save_token(updated)
+            await _save_token(updated)
             logger.debug("Token refreshed successfully")
             return updated
 
@@ -135,7 +135,7 @@ async def _get_valid_token() -> dict | None:
 
     Returns token dict with valid access_token, or None.
     """
-    token = _load_token()
+    token = await _load_token()
     if not token:
         return None
 
@@ -494,7 +494,7 @@ async def sync_full(db: MemoryDB) -> dict:
         }
 
     # Check for valid token
-    if not _has_token_available():
+    if not await _has_token_available():
         return {
             "status": "error",
             "message": "No Google Drive token available. "
@@ -691,7 +691,7 @@ async def setup_google_auth(
                         "client_id": client_id,
                         "token_type": data.get("token_type", "Bearer"),
                     }
-                    _save_token(token)
+                    await _save_token(token)
                     logger.info("Google Drive authentication successful!")
                     return True
 

--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -13,6 +13,7 @@ Token lifecycle:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import stat
@@ -104,3 +105,18 @@ def delete_token(provider: str) -> bool:
         logger.info(f"Token deleted: {path}")
         return True
     return False
+
+
+async def async_load_token(provider: str) -> dict | None:
+    """Asynchronously load stored OAuth token for a provider."""
+    return await asyncio.to_thread(load_token, provider)
+
+
+async def async_save_token(provider: str, token: dict) -> None:
+    """Asynchronously save OAuth token to local storage."""
+    await asyncio.to_thread(save_token, provider, token)
+
+
+async def async_delete_token(provider: str) -> bool:
+    """Asynchronously delete a stored token."""
+    return await asyncio.to_thread(delete_token, provider)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -21,16 +21,16 @@ from mnemo_mcp.sync import (
 
 
 class TestTokenManagement:
-    def test_has_token_false_when_no_token(self):
+    async def test_has_token_false_when_no_token(self):
         with patch("mnemo_mcp.sync._load_token", return_value=None):
-            assert _has_token_available() is False
+            assert await _has_token_available() is False
 
-    def test_has_token_true_when_token_exists(self):
+    async def test_has_token_true_when_token_exists(self):
         with patch(
             "mnemo_mcp.sync._load_token",
             return_value={"access_token": "ya29.abc"},
         ):
-            assert _has_token_available() is True
+            assert await _has_token_available() is True
 
     async def test_refresh_token_success(self):
         from mnemo_mcp.sync import _refresh_token
@@ -408,7 +408,11 @@ class TestSyncFull:
         """Sync errors when no token is available."""
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
-            patch("mnemo_mcp.sync._has_token_available", return_value=False),
+            patch(
+                "mnemo_mcp.sync._has_token_available",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
         ):
             mock_settings.sync_enabled = True
             mock_settings.google_drive_client_id = "client123"
@@ -420,7 +424,11 @@ class TestSyncFull:
         """Sync errors when token refresh fails."""
         with (
             patch("mnemo_mcp.sync.settings") as mock_settings,
-            patch("mnemo_mcp.sync._has_token_available", return_value=True),
+            patch(
+                "mnemo_mcp.sync._has_token_available",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
             patch(
                 "mnemo_mcp.sync._get_valid_token",
                 new_callable=AsyncMock,

--- a/tests/test_sync_gdrive_auth.py
+++ b/tests/test_sync_gdrive_auth.py
@@ -22,20 +22,22 @@ from mnemo_mcp.sync import (
 
 
 class TestTokenWrappers:
-    def test_load_token_delegates_to_store(self):
+    async def test_load_token_delegates_to_store(self):
         """_load_token calls token_store.load_token with 'google_drive'."""
         with patch(
             "mnemo_mcp.token_store.load_token", return_value={"access_token": "abc"}
         ) as mock:
-            result = _load_token()
+            result = await _load_token()
             assert result == {"access_token": "abc"}
             mock.assert_called_once_with("google_drive")
 
-    def test_save_token_delegates_to_store(self):
+    async def test_save_token_delegates_to_store(self):
         """_save_token calls token_store.save_token with 'google_drive'."""
         token = {"access_token": "xyz"}
-        with patch("mnemo_mcp.token_store.save_token") as mock:
-            _save_token(token)
+        with patch(
+            "mnemo_mcp.token_store.async_save_token", new_callable=AsyncMock
+        ) as mock:
+            await _save_token(token)
             mock.assert_called_once_with("google_drive", token)
 
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -257,3 +257,33 @@ class TestGetTokenPath:
             m.get_data_dir.return_value = token_dir.parent
             path = get_token_path("drive")
         assert path == token_dir / "drive.json"
+
+
+@pytest.mark.asyncio
+class TestAsyncTokenStore:
+    async def test_async_save_load_token(self, token_dir):
+        from mnemo_mcp.token_store import async_load_token, async_save_token
+
+        token = {"access_token": "async_test", "token_type": "Bearer"}
+        with patch("mnemo_mcp.token_store.settings") as m:
+            m.get_data_dir.return_value = token_dir.parent
+            await async_save_token("async_drive", token)
+
+            result = await async_load_token("async_drive")
+
+        assert result == token
+
+    async def test_async_delete_token(self, token_dir):
+        from mnemo_mcp.token_store import async_delete_token, async_save_token
+
+        token = {"access_token": "to_delete"}
+        with patch("mnemo_mcp.token_store.settings") as m:
+            m.get_data_dir.return_value = token_dir.parent
+            await async_save_token("delete_me", token)
+
+            deleted = await async_delete_token("delete_me")
+            assert deleted is True
+
+            # Second delete should be False
+            deleted_again = await async_delete_token("delete_me")
+            assert deleted_again is False


### PR DESCRIPTION
Implemented asynchronous versions of token storage operations to avoid synchronous file writes in asynchronous execution contexts.

Key changes:
- Introduced `async_load_token`, `async_save_token`, and `async_delete_token` in `src/mnemo_mcp/token_store.py` using `asyncio.to_thread`.
- Converted internal token helpers in `src/mnemo_mcp/sync.py` to `async def` and updated all call sites to use `await`.
- Updated `_gdrive_token_poll` in `src/mnemo_mcp/credential_state.py` to use `await async_save_token`.
- Updated and added unit tests to verify asynchronous functionality and ensure no regressions.

---
*PR created automatically by Jules for task [8659162126331242107](https://jules.google.com/task/8659162126331242107) started by @n24q02m*