### PR TITLE
[FIX] Wrap vec_db._conn to fix the vec SQL for testing.

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -411,7 +411,7 @@ class MemoryDB:
                     vec_sql += " AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN (SELECT value FROM json_each(?)))"
                     vec_params.append(json.dumps(tags))
 
-                vec_sql += " ORDER BY distance LIMIT ?"
+                vec_sql += " AND k = ? ORDER BY distance"
                 vec_params.append(limit * 3)
 
                 vec_rows = self._conn.execute(vec_sql, vec_params).fetchall()

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -36,55 +36,7 @@ def vec_db(tmp_path: Path):
 
 @pytest.fixture
 def mock_db_with_fixed_sql(vec_db: MemoryDB):
-    """Wrap vec_db._conn to fix the vec SQL for testing.
-
-    sqlite-vec requires parameters to be bound, but sometimes our code
-    might pass things differently. This wrapper ensures tests pass.
-    """
-    original_conn = vec_db._conn
-
-    class ConnProxy:
-        """Proxy that intercepts execute() and cursor() to rewrite vec queries."""
-
-        def __getattr__(self, name):
-            return getattr(original_conn, name)
-
-        def cursor(self):
-            return CursorProxy(original_conn.cursor())
-
-        def execute(self, sql, params=None):
-            return _execute_fixed(original_conn, sql, params)
-
-    def _execute_fixed(target, sql, params=None):
-        if (
-            "memories_vec" in sql
-            and "MATCH" in sql
-            and "ORDER BY distance LIMIT ?" in sql
-        ):
-            fixed_sql = sql.replace(
-                "ORDER BY distance LIMIT ?",
-                "AND k = ? ORDER BY distance",
-            )
-            if params:
-                return target.execute(fixed_sql, params)
-            return target.execute(fixed_sql)
-        if params:
-            return target.execute(sql, params)
-        return target.execute(sql)
-
-    class CursorProxy:
-        """Proxy that intercepts execute() for cursors."""
-
-        def __init__(self, original_cursor):
-            self._cursor = original_cursor
-
-        def __getattr__(self, name):
-            return getattr(self._cursor, name)
-
-        def execute(self, sql, params=None):
-            return _execute_fixed(self._cursor, sql, params)
-
-    vec_db._conn = ConnProxy()
+    """MemoryDB fixture for testing."""
     return vec_db
 
 


### PR DESCRIPTION
Fixed an issue where vector search queries using `sqlite-vec` would fail with "A LIMIT or 'k = ?' constraint is required" when combined with a JOIN. The fix was to use the more robust `AND k = ?` syntax instead of `ORDER BY distance LIMIT ?`. This change improves the reliability of semantic search and allows for cleaner test code by removing a complex SQL-rewriting proxy workaround.

Key changes:
- Updated `MemoryDB.search` in `src/mnemo_mcp/db.py` to use the `k` constraint.
- Simplified `mock_db_with_fixed_sql` fixture in `tests/test_db_coverage.py` by removing the `ConnProxy` logic.

---
*PR created automatically by Jules for task [15068543175469587307](https://jules.google.com/task/15068543175469587307) started by @n24q02m*