### PR TITLE
fix: precompute archive cutoff and gitignore coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ venv/
 # Testing
 .coverage
 .coverage.*
+coverage.xml
+cov_annotate/
 htmlcov/
 .pytest_cache/
 

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -902,18 +902,25 @@ class MemoryDB:
     ) -> int:
         """Move old, low-importance memories to archive. Returns count archived."""
         cursor = self._conn.cursor()
+
+        # Precompute the cutoff timestamp once so SQLite does not re-evaluate
+        # datetime('now', ...) for every row in the WHERE clause.
+        cutoff_date = cursor.execute(
+            "SELECT datetime('now', ?)", (f"-{days} days",)
+        ).fetchone()[0]
+
         rows = cursor.execute(
             """SELECT id, content, category, tags, source, importance,
                       created_at, updated_at, access_count, last_accessed
                FROM memories
-               WHERE last_accessed < datetime('now', ? || ' days')
-                 AND importance < ?""",
-            (f"-{days}", importance_threshold),
+               WHERE last_accessed < ? AND importance < ?""",
+            (cutoff_date, importance_threshold),
         ).fetchall()
 
-        now = _now_iso()
         if not rows:
             return 0
+
+        now = _now_iso()
 
         insert_data = [(*row, now) for row in rows]
         delete_data = [(row[0],) for row in rows]


### PR DESCRIPTION
## Summary

- Supersedes #408 (which had a stale base and would regress unrelated fixes on main).
- Takes only the meaningful part of #408: precompute `datetime('now', '-N days')` once instead of letting SQLite evaluate it per row during the scan.
- Adds `coverage.xml` and `cov_annotate/` to `.gitignore` so test artifacts stop leaking into PRs.

## Why not rebase #408

The PR's branch forked from main ~8 commits ago. A rebase would re-apply reverts to:
- `_serialize_f32` dimension enforcement
- SQL injection guard in `_ensure_vec_table`
- CASE-WHEN based `update` method

All of which shipped on main after the Bolt branch was cut. #408 also committed a 2331-line `coverage.xml`. Re-implementing the one-line optimization on current main is the clean path.

## Test plan

- [x] Pre-commit hooks pass (ruff + format + ty + pytest)
- [ ] CI green on all three OS matrices

Closes #408.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>