### PR TITLE
fix: silence ty invalid-assignment on _ConnProxy test wrapper

### DIFF
--- a/tests/test_db_vec_coverage.py
+++ b/tests/test_db_vec_coverage.py
@@ -160,7 +160,7 @@ class TestInitSchemaVecCreateBranch:
             def __getattr__(self, name):
                 return getattr(self._inner, name)
 
-        db._conn = _ConnProxy(plain_conn)  # type: ignore[assignment]
+        db._conn = _ConnProxy(plain_conn)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         try:
             db._init_schema()
             assert any("CREATE VIRTUAL TABLE" in s for s in recorded_sql)
@@ -225,7 +225,7 @@ class TestSearchVecBranch:
             def __getattr__(self, name):
                 return getattr(self._inner, name)
 
-        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]
+        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         try:
             results = db.search(
                 query="alpha",
@@ -270,7 +270,7 @@ class TestSearchVecBranch:
             def __getattr__(self, name):
                 return getattr(self._inner, name)
 
-        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]
+        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         try:
             results = db.search(
                 query="alpha",
@@ -309,7 +309,7 @@ class TestSearchVecBranch:
             def __getattr__(self, name):
                 return getattr(self._inner, name)
 
-        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]
+        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         try:
             # Must not raise -- exception swallowed + logged
             results = db.search(query="alpha", embedding=[0.1, 0.2, 0.3], limit=5)


### PR DESCRIPTION
## Summary
- Four `test_db_vec_coverage.py` helpers inject a lightweight `_ConnProxy` into `MemoryDB._conn` to exercise the sqlite-vec search branch without needing the extension at runtime.
- The existing `# type: ignore[assignment]` silences mypy/pyright, but `ty` uses its own lint id `invalid-assignment` which remained active and broke `uv run ty check` on main.
- Stack both suppressions on the same line so each type checker sees the code it expects. No behaviour change.

## Test plan
- [x] `uv run ty check tests/test_db_vec_coverage.py` -> All checks passed
- [x] Pre-commit hooks all green (ruff, ty, pytest)