### PR TITLE
fix: surface OAuth token save failures in GDrive device code poll

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -40,12 +40,72 @@ class CredentialState(Enum):
 _state = CredentialState.AWAITING_SETUP
 _setup_url: str | None = None
 _on_gdrive_complete: Callable[[], None] | None = None
+# Failure callback signature matches mcp-core's mark_setup_failed: optional
+# key + error message. Wired by the HTTP server so the browser's
+# /setup-status poll receives ``error:<message>`` instead of spinning forever
+# when Google rejects the device code (invalid_grant / expired_token / etc.)
+# or when save_token fails silently (ported from wet-mcp Bug #2 fix).
+_on_gdrive_failed: Callable[[str, str], None] | None = None
 
 
 def set_gdrive_complete_callback(cb: Callable[[], None]) -> None:
     """Set callback for when GDrive OAuth completes (used by HTTP server)."""
     global _on_gdrive_complete
     _on_gdrive_complete = cb
+
+
+def set_gdrive_failed_callback(cb: Callable[[str, str], None]) -> None:
+    """Set callback for when GDrive OAuth fails upstream (used by HTTP server).
+
+    The callback receives ``(key, error_message)`` matching the
+    ``mark_setup_failed(key, error)`` signature exposed by mcp-core's local
+    OAuth app. It is invoked by ``_gdrive_token_poll`` whenever Google
+    returns a terminal error (``invalid_grant``, ``expired_token``,
+    ``access_denied``, etc.) or when the local ``save_token`` call raises
+    after a successful exchange -- so the browser's ``/setup-status`` poll
+    surfaces the error and stops waiting.
+    """
+    global _on_gdrive_failed
+    _on_gdrive_failed = cb
+
+
+def wire_gdrive_callbacks(
+    mark_complete: Callable[[], None],
+    mark_failed: Callable[..., None] | None = None,
+) -> None:
+    """Wire GDrive completion + optional failure callbacks in one call.
+
+    Intended for use as ``setup_complete_hook``. mcp-core detects the hook
+    signature by arity:
+
+    - Older mcp-core (<1.3.0) passes 1 positional arg: ``hook(mark_complete)``.
+      ``mark_failed`` stays ``None`` and GDrive terminal errors go
+      server-log-only (legacy behavior).
+    - Newer mcp-core (>=1.3.0) passes 2 args: ``hook(mark_complete, mark_failed)``.
+      ``mark_failed`` wires through ``mark_setup_failed`` so the browser
+      form stops spinning and shows the error.
+
+    Making ``mark_failed`` optional here keeps mnemo-mcp forward-compatible
+    with both versions; no lock-step release required between mnemo-mcp and
+    mcp-core.
+    """
+    set_gdrive_complete_callback(mark_complete)
+
+    global _on_gdrive_failed
+
+    if mark_failed is None:
+        _on_gdrive_failed = None
+        return
+
+    def _cb(_key: str, error: str) -> None:
+        # mcp-core's mark_setup_failed(key, error) expects the key positionally.
+        # We always operate on "gdrive" so hardcode it here.
+        try:
+            mark_failed("gdrive", error)
+        except Exception:
+            logger.opt(exception=True).debug("mark_setup_failed call failed")
+
+    _on_gdrive_failed = _cb
 
 
 def get_state() -> CredentialState:
@@ -386,11 +446,35 @@ async def _gdrive_token_poll(
     interval: int,
     expires_in: int,
 ) -> None:
-    """Background poll Google OAuth for device code token completion."""
+    """Background poll Google OAuth for device code token completion.
+
+    Terminal outcomes:
+    * ``access_token`` in response  -> save token + fire complete callback.
+      If ``save_token`` raises, surface the failure via ``_notify_failed`` at
+      WARNING level so the browser form stops spinning and the user knows to
+      restart setup (the device_code cannot be re-exchanged).
+    * ``authorization_pending``     -> keep polling (user hasn't approved yet).
+    * ``slow_down``                 -> increase interval + keep polling.
+    * Any other ``error`` value (``invalid_grant``, ``expired_token``,
+      ``access_denied``, etc.) -> fire failure callback with the error
+      string and stop. The failure callback wires into mcp-core's
+      ``/setup-status`` so the browser shows the message instead of
+      waiting forever.
+    * Loop exits via ``deadline`` without success -> fire failure callback
+      with ``expired`` so the browser surfaces the timeout.
+    """
     import asyncio
     import time
 
     import httpx
+
+    def _notify_failed(error: str) -> None:
+        if _on_gdrive_failed is None:
+            return
+        try:
+            _on_gdrive_failed("gdrive", error)
+        except Exception:
+            logger.opt(exception=True).debug("GDrive failed callback raised")
 
     deadline = time.time() + expires_in
     async with httpx.AsyncClient() as client:
@@ -411,8 +495,18 @@ async def _gdrive_token_poll(
                 if "access_token" in data:
                     from mnemo_mcp.token_store import async_save_token
 
-                    await async_save_token("google_drive", data)
-                    logger.info("GDrive OAuth token saved successfully")
+                    try:
+                        await async_save_token("google_drive", data)
+                        logger.info("GDrive OAuth token saved successfully")
+                    except Exception as exc:
+                        logger.opt(exception=True).warning(
+                            "GDrive token save FAILED after successful exchange: {}. "
+                            "Token lost; device_code cannot be re-exchanged. "
+                            "User must restart setup.",
+                            exc,
+                        )
+                        _notify_failed(f"save_token failed: {exc}")
+                        return
                     logger.info(
                         "GDrive authorized. Sync will start on next server restart."
                     )
@@ -424,15 +518,27 @@ async def _gdrive_token_poll(
                                 "GDrive complete callback failed"
                             )
                     return
-                elif data.get("error") == "authorization_pending":
+                err = data.get("error")
+                if err == "authorization_pending":
                     continue
-                elif data.get("error") == "slow_down":
+                if err == "slow_down":
                     interval += 5
-                else:
-                    logger.warning("GDrive token poll error: {}", data.get("error"))
-                    return
+                    continue
+                # Any other error from Google is terminal -- stop polling AND
+                # tell the browser so the spinner stops.
+                err_desc = data.get("error_description") or err or "unknown"
+                logger.warning(
+                    "GDrive token poll terminal error: {} ({})",
+                    err,
+                    err_desc,
+                )
+                _notify_failed(str(err_desc))
+                return
             except Exception:
                 logger.opt(exception=True).debug("GDrive token poll request failed")
+        # Deadline exceeded without success -> surface timeout.
+        logger.warning("GDrive device code flow expired before user approved")
+        _notify_failed("expired")
 
 
 def set_state(state: CredentialState) -> None:

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1272,7 +1272,7 @@ async def run_http(port: int = 0) -> None:
 
     from mnemo_mcp.credential_state import (
         save_credentials,
-        set_gdrive_complete_callback,
+        wire_gdrive_callbacks,
     )
     from mnemo_mcp.relay_schema import RELAY_SCHEMA
 
@@ -1282,7 +1282,11 @@ async def run_http(port: int = 0) -> None:
         relay_schema=RELAY_SCHEMA,
         port=port,
         on_credentials_saved=save_credentials,
-        setup_complete_hook=set_gdrive_complete_callback,
+        # Use wire_gdrive_callbacks so terminal OAuth errors (invalid_grant,
+        # expired_token, save_token failures) surface to the browser's
+        # /setup-status poll instead of leaving the form stuck on
+        # "Waiting for authorization..." forever. Accepts legacy 1-arg core.
+        setup_complete_hook=wire_gdrive_callbacks,
     )
 
 

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -611,6 +611,222 @@ class TestShareCloudKeysToPeers:
 # ---------------------------------------------------------------------------
 
 
+class TestGDriveFailedCallback:
+    """Covers set_gdrive_failed_callback + wire_gdrive_callbacks + _notify_failed
+    paths added for Bug #2 fix (ported from wet-mcp)."""
+
+    def test_set_gdrive_failed_callback_registers(self):
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import set_gdrive_failed_callback
+
+        cb = MagicMock()
+        set_gdrive_failed_callback(cb)
+        assert cs._on_gdrive_failed is cb
+        cs._on_gdrive_failed = None
+
+    def test_wire_gdrive_callbacks_legacy_one_arg(self):
+        """Legacy mcp-core (<1.3.0) passes only mark_complete; mark_failed stays None."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import wire_gdrive_callbacks
+
+        complete_cb = MagicMock()
+        wire_gdrive_callbacks(complete_cb)
+
+        assert cs._on_gdrive_complete is complete_cb
+        assert cs._on_gdrive_failed is None
+        cs._on_gdrive_complete = None
+
+    def test_wire_gdrive_callbacks_modern_two_args(self):
+        """Modern mcp-core (>=1.3.0) passes both callbacks; mark_failed wraps into
+        a (key, error) -> mark_failed('gdrive', error) shim."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import wire_gdrive_callbacks
+
+        complete_cb = MagicMock()
+        mark_failed = MagicMock()
+        wire_gdrive_callbacks(complete_cb, mark_failed)
+
+        assert cs._on_gdrive_complete is complete_cb
+        shim = cs._on_gdrive_failed
+        assert shim is not None
+        # Exercise the wrapping shim
+        shim("gdrive", "invalid_grant")
+        mark_failed.assert_called_once_with("gdrive", "invalid_grant")
+        cs._on_gdrive_complete = None
+        cs._on_gdrive_failed = None
+
+    def test_wire_gdrive_callbacks_mark_failed_swallows_exception(self):
+        """If mark_failed raises, shim logs and swallows so callers don't crash."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import wire_gdrive_callbacks
+
+        mark_failed = MagicMock(side_effect=RuntimeError("boom"))
+        wire_gdrive_callbacks(MagicMock(), mark_failed)
+
+        shim = cs._on_gdrive_failed
+        assert shim is not None
+        # Should NOT raise
+        shim("gdrive", "expired")
+        cs._on_gdrive_complete = None
+        cs._on_gdrive_failed = None
+
+
+class TestGDriveTokenPoll:
+    """Covers _gdrive_token_poll error/terminal paths added for Bug #2 fix."""
+
+    async def test_save_token_failure_notifies_and_returns(self):
+        """save_token raising after successful exchange -> WARNING log + notify
+        failed callback + return (no retry; device_code cannot be re-exchanged)."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import (
+            _gdrive_token_poll,
+            set_gdrive_failed_callback,
+        )
+
+        failed_cb = MagicMock()
+        set_gdrive_failed_callback(failed_cb)
+
+        token_response = MagicMock()
+        token_response.json.return_value = {
+            "access_token": "tok",
+            "refresh_token": "refresh",
+        }
+
+        async def fake_post(*args, **kwargs):
+            return token_response
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "mnemo_mcp.token_store.async_save_token",
+                new_callable=AsyncMock,
+                side_effect=OSError("disk full"),
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=fake_post)
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            await _gdrive_token_poll("cid", "csec", "devcode", 0, 5)
+
+        failed_cb.assert_called_once()
+        args, _ = failed_cb.call_args
+        assert args[0] == "gdrive"
+        assert "save_token failed" in args[1]
+        cs._on_gdrive_failed = None
+
+    async def test_terminal_google_error_notifies(self):
+        """Terminal Google error (invalid_grant, access_denied) -> notify + return."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import (
+            _gdrive_token_poll,
+            set_gdrive_failed_callback,
+        )
+
+        failed_cb = MagicMock()
+        set_gdrive_failed_callback(failed_cb)
+
+        response = MagicMock()
+        response.json.return_value = {
+            "error": "access_denied",
+            "error_description": "user rejected",
+        }
+
+        async def fake_post(*args, **kwargs):
+            return response
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=fake_post)
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            await _gdrive_token_poll("cid", "csec", "devcode", 0, 5)
+
+        failed_cb.assert_called_once_with("gdrive", "user rejected")
+        cs._on_gdrive_failed = None
+
+    async def test_deadline_expired_notifies(self):
+        """Loop exits via deadline without success -> notify with 'expired'."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import (
+            _gdrive_token_poll,
+            set_gdrive_failed_callback,
+        )
+
+        failed_cb = MagicMock()
+        set_gdrive_failed_callback(failed_cb)
+
+        # expires_in = 0 -> loop body is never entered, deadline branch fires.
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            await _gdrive_token_poll("cid", "csec", "devcode", 0, 0)
+
+        failed_cb.assert_called_once_with("gdrive", "expired")
+        cs._on_gdrive_failed = None
+
+    async def test_notify_failed_swallows_callback_exception(self):
+        """If _on_gdrive_failed raises, the helper logs and does not propagate."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import (
+            _gdrive_token_poll,
+            set_gdrive_failed_callback,
+        )
+
+        failed_cb = MagicMock(side_effect=RuntimeError("callback boom"))
+        set_gdrive_failed_callback(failed_cb)
+
+        # Terminal error triggers _notify_failed which catches callback errors.
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            # expires_in=0 -> immediate deadline -> _notify_failed('expired')
+            await _gdrive_token_poll("cid", "csec", "devcode", 0, 0)
+
+        failed_cb.assert_called_once()
+        cs._on_gdrive_failed = None
+
+    async def test_success_fires_complete_callback_no_failed(self):
+        """Happy path: access_token -> save_token OK -> complete_cb fired, failed_cb NOT."""
+        import mnemo_mcp.credential_state as cs
+        from mnemo_mcp.credential_state import (
+            _gdrive_token_poll,
+            set_gdrive_complete_callback,
+            set_gdrive_failed_callback,
+        )
+
+        complete_cb = MagicMock()
+        failed_cb = MagicMock()
+        set_gdrive_complete_callback(complete_cb)
+        set_gdrive_failed_callback(failed_cb)
+
+        response = MagicMock()
+        response.json.return_value = {"access_token": "tok"}
+
+        async def fake_post(*args, **kwargs):
+            return response
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "mnemo_mcp.token_store.async_save_token",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=fake_post)
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            await _gdrive_token_poll("cid", "csec", "devcode", 0, 5)
+
+        complete_cb.assert_called_once()
+        failed_cb.assert_not_called()
+        cs._on_gdrive_complete = None
+        cs._on_gdrive_failed = None
+
+
 class TestResetState:
     def test_resets_state_and_url(self):
         """Resets state to AWAITING_SETUP and clears URL."""


### PR DESCRIPTION
## Summary

Port wet-mcp's Bug #2 fix to mnemo-mcp. `_gdrive_token_poll` previously swallowed `save_token` exceptions into a DEBUG-level generic handler ("GDrive token poll request failed") -- so a failed token save after a successful Google device-code exchange appeared as "already exchanged" on the next poll iteration and the browser form stayed stuck on "Waiting for authorization..." forever.

### Changes

- Wrap `async_save_token` in try/except with WARNING-level log explaining the device_code cannot be re-exchanged and the user must restart setup.
- Add `_on_gdrive_failed` callback + `set_gdrive_failed_callback` + `wire_gdrive_callbacks` helper mirroring wet-mcp's exact pattern. Hooks into mcp-core's `mark_setup_failed` so the browser `/setup-status` poll surfaces the error instead of spinning forever.
- Terminal Google errors (`invalid_grant`, `expired_token`, `access_denied`, deadline expired) now call `_notify_failed` with a descriptive message.
- `server.py` uses `wire_gdrive_callbacks` as `setup_complete_hook` (forward-compatible with mcp-core <1.3.0 via arity detection).

### Bug #1 (icacls grant probe) — N/A

mnemo-mcp's `token_store.py` skips secure permissions on Windows entirely (`if os.name != "nt"`), with silent OSError fallback everywhere else. No `icacls` subprocess call exists, so the empty-principal bug cannot occur here. Verified by `grep -rn "icacls" src/` returning zero matches.

## Test plan

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes
- [x] `uv run pytest` passes (763 tests, 74 deselected)
- [ ] CI green
- [ ] E2E verify device-code save failure surfaces in browser form (follow-up in Phase M E2E)

Reference: wet-mcp fix in `wet-mcp/src/wet_mcp/credential_state.py:_gdrive_token_poll` (same session, 2026-04-18/19).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>