### PR TITLE
🎨 Palette: Add helpful empty states to list actions

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -536,12 +536,13 @@ async def _handle_list(
         category=category,
         limit=limit,
     )
-    return _json(
-        {
-            "count": len(results),
-            "results": [_format_memory(r) for r in results],
-        }
-    )
+    response = {
+        "count": len(results),
+        "results": [_format_memory(r) for r in results],
+    }
+    if len(results) == 0:
+        response["suggestion"] = "No memories found. Use action='add' to create some!"
+    return _json(response)
 
 
 async def _handle_update(
@@ -683,12 +684,13 @@ async def _handle_archived(
         limit = max(1, min(limit, 100))
 
     results = await asyncio.to_thread(db.list_archived, limit)
-    return _json(
-        {
-            "count": len(results),
-            "results": results,
-        }
-    )
+    response = {
+        "count": len(results),
+        "results": results,
+    }
+    if len(results) == 0:
+        response["suggestion"] = "No archived memories found."
+    return _json(response)
 
 
 async def _handle_consolidate(

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -536,7 +536,7 @@ async def _handle_list(
         category=category,
         limit=limit,
     )
-    response = {
+    response: dict = {
         "count": len(results),
         "results": [_format_memory(r) for r in results],
     }
@@ -684,7 +684,7 @@ async def _handle_archived(
         limit = max(1, min(limit, 100))
 
     results = await asyncio.to_thread(db.list_archived, limit)
-    response = {
+    response: dict = {
         "count": len(results),
         "results": results,
     }


### PR DESCRIPTION
💡 **What**: Added a `"suggestion"` string to the JSON response of list and archived actions when they return an empty array.
🎯 **Why**: Bare empty arrays can confuse AI agents interacting with the MCP server. Adding an empty state with a helpful call-to-action (like "Use action='add' to create some!") provides critical context and guides the agent's next logical action.
📸 **Before/After**:
Before: `{"count": 0, "results": []}`
After: `{"count": 0, "results": [], "suggestion": "No memories found. Use action='add' to create some!"}`
♿ **Accessibility/UX**: This improves the "developer/agent UX" by making the API more conversational and intuitive.

---
*PR created automatically by Jules for task [4430686538075529928](https://jules.google.com/task/4430686538075529928) started by @n24q02m*