### PR TITLE
fix: require explicit MCP_RELAY_URL for remote-relay mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.8.0",
     # Zero-env-config credential relay
-    "n24q02m-mcp-core>=1.5.1",
+    "n24q02m-mcp-core>=1.6.1",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
 ]

--- a/src/mnemo_mcp/relay_setup.py
+++ b/src/mnemo_mcp/relay_setup.py
@@ -15,7 +15,6 @@ from typing import Any
 
 from loguru import logger
 
-DEFAULT_RELAY_URL = "https://mnemo-mcp.n24q02m.com"
 SERVER_NAME = "mnemo-mcp"
 CLOUD_KEYS = [
     "JINA_AI_API_KEY",
@@ -75,10 +74,18 @@ async def ensure_config() -> dict[str, str] | None:
     if isinstance(local_res, dict):
         return local_res
 
-    # 2. No local credentials found -- trigger relay setup
-    logger.info("No cloud credentials found. Starting relay setup...")
+    # 2. No local credentials found -- trigger relay setup.
+    # Per mode-matrix 2.5, mnemo-mcp default is `http local relay`; `remote-relay`
+    # mode requires user-supplied URL (no centralized mnemo-mcp.n24q02m.com).
+    relay_url = os.environ.get("MCP_RELAY_URL")
+    if not relay_url:
+        raise RuntimeError(
+            "MCP_RELAY_URL env var is required for remote-relay mode. "
+            "mnemo-mcp default mode is 'http local relay' (no remote URL needed). "
+            "For self-host remote-relay, set MCP_RELAY_URL=https://<your-instance>."
+        )
 
-    relay_url = DEFAULT_RELAY_URL
+    logger.info("No cloud credentials found. Starting relay setup...")
     try:
         session = await _initiate_relay_session(relay_url)
     except Exception:

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -3,9 +3,10 @@
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from mnemo_mcp.relay_setup import (
     CLOUD_KEYS,
-    DEFAULT_RELAY_URL,
     apply_config,
     ensure_config,
     load_relay_config,
@@ -14,9 +15,6 @@ from mnemo_mcp.relay_setup import (
 
 class TestConstants:
     """Test module constants."""
-
-    def test_default_relay_url(self):
-        assert DEFAULT_RELAY_URL == "https://mnemo-mcp.n24q02m.com"
 
     def test_cloud_keys(self):
         assert "JINA_AI_API_KEY" in CLOUD_KEYS
@@ -138,6 +136,27 @@ class TestLoadRelayConfig:
 class TestEnsureConfig:
     """Test ensure_config async function."""
 
+    @pytest.fixture(autouse=True)
+    def _relay_url(self, monkeypatch):
+        """Set MCP_RELAY_URL for tests exercising the relay path.
+
+        Per mode-matrix 2.5, mnemo-mcp remote-relay mode requires explicit
+        MCP_RELAY_URL (no DEFAULT_RELAY_URL fallback).
+        """
+        monkeypatch.setenv("MCP_RELAY_URL", "https://relay.example.com")
+
+    async def test_missing_relay_url_raises(self, monkeypatch):
+        """Remote-relay without MCP_RELAY_URL must raise per matrix 2.5."""
+        for key in CLOUD_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.delenv("MCP_RELAY_URL", raising=False)
+
+        with (
+            patch("mcp_core.storage.config_file.read_config", return_value=None),
+            pytest.raises(RuntimeError, match="MCP_RELAY_URL"),
+        ):
+            await ensure_config()
+
     @patch("mcp_core.storage.config_file.read_config")
     async def test_returns_config_from_file(self, mock_read, monkeypatch):
         for key in CLOUD_KEYS:
@@ -166,7 +185,7 @@ class TestEnsureConfig:
             monkeypatch.delenv(key, raising=False)
         mock_read.return_value = None
         mock_session.return_value = MagicMock(
-            relay_url="https://mnemo-mcp.n24q02m.com/#k=abc&p=xyz",
+            relay_url="https://relay.example.com/#k=abc&p=xyz",
             session_id="test-session",
         )
         config = {
@@ -275,7 +294,7 @@ class TestEnsureConfig:
             monkeypatch.delenv(key, raising=False)
         mock_read.return_value = None
         mock_session.return_value = MagicMock(
-            relay_url="https://mnemo-mcp.n24q02m.com/#k=abc",
+            relay_url="https://relay.example.com/#k=abc",
             session_id="sess-123",
         )
         config = {"JINA_AI_API_KEY": "jina_test"}
@@ -299,7 +318,7 @@ class TestEnsureConfig:
 
         assert result == config
         mock_gdrive.assert_called_once_with(
-            relay_url="https://mnemo-mcp.n24q02m.com",
+            relay_url="https://relay.example.com",
             session_id="sess-123",
         )
 
@@ -316,7 +335,7 @@ class TestEnsureConfig:
             monkeypatch.delenv(key, raising=False)
         mock_read.return_value = None
         mock_session.return_value = MagicMock(
-            relay_url="https://mnemo-mcp.n24q02m.com/#k=abc",
+            relay_url="https://relay.example.com/#k=abc",
             session_id="sess-456",
         )
         config = {"GEMINI_API_KEY": "AIza_test"}
@@ -367,7 +386,7 @@ class TestEnsureConfig:
             monkeypatch.delenv(key, raising=False)
         mock_read.return_value = None
         mock_session.return_value = MagicMock(
-            relay_url="https://mnemo-mcp.n24q02m.com/#k=abc",
+            relay_url="https://relay.example.com/#k=abc",
             session_id="sess-789",
         )
         config = {"OPENAI_API_KEY": "sk_test"}

--- a/uv.lock
+++ b/uv.lock
@@ -879,7 +879,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.5.1" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.6.1" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.5.1"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -934,9 +934,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/c1/c0f689c6aadc820ee66f048951c82beb343459caf8bad6aee4970af3400a/n24q02m_mcp_core-1.5.1.tar.gz", hash = "sha256:ceb855fe1cb6d3adfadfb3beae3e85fc4e7e42ae53f41c2e8efa07843efe9a91", size = 152557, upload-time = "2026-04-21T09:04:55.008Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/bb/540eedd4c48d4ab49710613288473641480377c3c54563fa9d8d7c0a2c39/n24q02m_mcp_core-1.6.1.tar.gz", hash = "sha256:41d42df36136667ca8fcbb3762f8a6a60abb792362accee0920917096f05152e", size = 153176, upload-time = "2026-04-22T05:52:23.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/b5/5d49a292d8c68f20c13a3739f0ce0788dcd43809c637f1220ae1f44ed723/n24q02m_mcp_core-1.5.1-py3-none-any.whl", hash = "sha256:1236e9863b39230e350f5ff267c1b6b248923e0a5178eda3eed660532fda3153", size = 92864, upload-time = "2026-04-21T09:04:53.511Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c0/f54fe61ce529a2a1934a603d1d4d10da32ab8fac56291c2cd52ed54a1ac2/n24q02m_mcp_core-1.6.1-py3-none-any.whl", hash = "sha256:763c7200dd0b09d701573c57d9a8767d77bb8783168e0f4d38c2d34070f6deab", size = 93049, upload-time = "2026-04-22T05:52:24.299Z" },
 ]
 
 [[package]]
@@ -1392,7 +1392,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.8.0"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1403,9 +1403,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/8b/86679949c5ffc301c1b3cab6f085ce02a93822382bbb6e113bada22d46d6/qwen3_embed-1.8.0.tar.gz", hash = "sha256:a7a2bb99c734c0b047b3c7f7d036a17069472822037ace4e2c7b5fba2195475e", size = 180557, upload-time = "2026-04-04T06:03:26.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/0a/8aa2479f81b32783420a25cd210480385ccc33fde959be31b7c869384701/qwen3_embed-1.9.0.tar.gz", hash = "sha256:72c8c75ea912c6ccb2dcc51f369fbd16d38d5070824980c21dbdedd78152f470", size = 182123, upload-time = "2026-04-21T09:08:59.12Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/75/ba3b7c32c8fbc574cf969f9813bdd7120692835c39c4db84b10a61a79233/qwen3_embed-1.8.0-py3-none-any.whl", hash = "sha256:fc23920384cf3bb2c3d1b17a446d12a5b22fd087fa1b0a60b48542e837b41c14", size = 56294, upload-time = "2026-04-04T06:03:24.939Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/f65138f8e6224d1803e4643c6eccf2ca5e8e0610b684f865c7ba94cfb4ab/qwen3_embed-1.9.0-py3-none-any.whl", hash = "sha256:be1d2ccbc8596cc4abc6940c5746940c665564a5903e55e8f62466e92502b039", size = 58763, upload-time = "2026-04-21T09:08:58.01Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Per mode-matrix 2.5, mnemo-mcp default mode is `http local relay`. Removed DEFAULT_RELAY_URL hardcode; require MCP_RELAY_URL explicit for remote-relay mode.

763 tests pass. Ref wet-mcp#939.