### PR TITLE
fix: regenerate uv.lock without [tool.uv.sources] for Docker build

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.21.3"
+version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -879,7 +879,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", editable = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.7.6" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -921,8 +921,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.7.5"
-source = { editable = "../mcp-core/packages/core-py" }
+version = "1.7.6"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -934,28 +934,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.9,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.11" },
-    { name = "ty", specifier = ">=0.0.32" },
+sdist = { url = "https://files.pythonhosted.org/packages/41/b2/ec817cfce281a2d6efe19936c74ae935a14bd734f380cee3c61ff052c6a7/n24q02m_mcp_core-1.7.6.tar.gz", hash = "sha256:939ad6c841cb8980b7b6e99937322aad18b0f488b09ed1948c09ecf67108eb62", size = 160060, upload-time = "2026-04-24T10:52:57.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/57/ba494b0bebacbeb3877eda025f4045ea37ff82bc06ffa80d688e4c51454f/n24q02m_mcp_core-1.7.6-py3-none-any.whl", hash = "sha256:3b07e254dfa50cb9561ef8f892df7d86792e5af23640dc6cb365bdf04fb94d4a", size = 99096, upload-time = "2026-04-24T10:52:56.4Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Follow-up to the v1.7.6 mcp-core cascade: `uv.lock` on main was regenerated with the `[tool.uv.sources]` path override active, so it pinned `n24q02m-mcp-core` at a local `../mcp-core/packages/core-py` directory. CI escapes with `uv sync --no-sources`, but the Dockerfile runs `uv sync --frozen` where `--no-sources` cannot override a frozen lock → every Python Docker build failed with `Distribution not found at: file:///mcp-core/packages/core-py`.

This commit regenerates the lockfile with `UV_NO_SOURCES=1 uv lock` so the committed entry for `n24q02m-mcp-core` points at `registry = "https://pypi.org/simple"`. Dev environments still transparently pick up the local path at install time through `[tool.uv.sources]`; only the lockfile stops baking the path source in.

## Test plan

- [x] `grep 'source = { registry' uv.lock` confirms PyPI source for n24q02m-mcp-core
- [ ] CD re-dispatch → Docker build succeeds → Merge Docker Manifests → MCP Registry sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)