### PR TITLE
fix: add --frozen --no-sources to Dockerfile uv sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,20 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
-# Install dependencies first (cached when deps don't change)
+# Install dependencies first (cached when deps don't change).
+# --frozen + --no-sources: use the committed uv.lock exactly as-is and
+# ignore [tool.uv.sources] path overrides from pyproject.toml. Without
+# both flags, the dev convenience mapping `n24q02m-mcp-core = { path =
+# "../mcp-core/..." }` sneaks in and breaks the build inside the Docker
+# context where that sibling directory does not exist.
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-install-project --no-dev
+    uv sync --frozen --no-sources --no-install-project --no-dev
 
 # Copy application code and install the project
 COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-dev
+    uv sync --frozen --no-sources --no-dev
 
 # ========================
 # Stage 2: Runtime


### PR DESCRIPTION
Follow-up to the 2026-04-24 mcp-core v1.7.6 cascade. v1.22.1 Docker build still failed because `uv sync` (no --frozen) re-applied `[tool.uv.sources]` from pyproject.toml. Adding both `--frozen` and `--no-sources` locks the build to the committed PyPI-sourced uv.lock.