### PR TITLE
feat: multi-user remote mode (PUBLIC_URL + per-JWT-sub)

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -20,9 +20,11 @@ that is reserved for explicit ``MCP_MODE`` HTTP deployments. See
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from collections.abc import Callable
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -307,18 +309,55 @@ def _share_cloud_keys_to_peers(config: dict[str, str]) -> None:
         logger.debug("_share_cloud_keys_to_peers failed (non-fatal): {}", e)
 
 
-def save_credentials(config: dict[str, str], _context: dict[str, str]) -> dict | None:
+def _sub_data_dir(sub: str) -> Path:
+    """Return per-subject data dir for multi-user remote mode.
+
+    Layout: ``$MNEMO_DATA_DIR/subs/<sub>/`` (default base
+    ``~/.mnemo-mcp``). Each per-authorize JWT ``sub`` gets its own
+    directory so credentials never bleed across users.
+    """
+    base = Path(os.environ.get("MNEMO_DATA_DIR", str(Path.home() / ".mnemo-mcp")))
+    d = base / "subs" / sub
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def store_for_sub(sub: str, config: dict[str, str]) -> None:
+    """Persist a config dict for a single JWT subject (multi-user remote mode)."""
+    (_sub_data_dir(sub) / "config.json").write_text(json.dumps(config))
+
+
+def read_for_sub(sub: str) -> dict[str, str]:
+    """Load the config dict for a single JWT subject (empty if missing)."""
+    p = _sub_data_dir(sub) / "config.json"
+    return json.loads(p.read_text()) if p.exists() else {}
+
+
+def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
     """Save credentials from OAuth form to config.enc and apply to environment.
 
-    ``_context`` carries the per-authorize ``sub`` (for future multi-user
-    extensions). Mnemo-mcp is single-user by design — the SQLite memory DB and
-    optional API keys live in one shared ``config.enc`` on the host, so the
-    subject is intentionally unused here.
+    ``context`` carries the per-authorize ``sub``. In multi-user remote mode
+    (``PUBLIC_URL`` set), credentials are scoped per-subject under
+    ``$MNEMO_DATA_DIR/subs/<sub>/config.json`` and we skip the shared
+    single-user state machine + GDrive device-code flow (each subject runs
+    their own OAuth via the relay form). In single-user local mode, the
+    SQLite memory DB and optional API keys live in one shared ``config.enc``
+    on the host so the subject is intentionally unused.
 
     Called by the local OAuth AS when the user submits API keys via the
     browser form. Returns optional dict with next_step info.
     """
     global _state
+
+    # Multi-user remote mode: per-subject credential storage. Skip the shared
+    # config.enc + module-level state to keep subjects fully isolated.
+    if os.environ.get("PUBLIC_URL"):
+        sub = context.get("sub") if context else None
+        if not sub:
+            raise RuntimeError("multi-user mode: SubjectContext sub required")
+        store_for_sub(sub, config)
+        logger.info("Credentials saved for sub={} (multi-user remote mode)", sub)
+        return None
 
     from mcp_core.storage.config_file import write_config
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1284,7 +1284,18 @@ def recall_context(topic: str) -> str:
 
 
 async def run_http(port: int = 0) -> None:
-    """Run as HTTP server with local OAuth 2.1 AS."""
+    """Run as HTTP server with local OAuth 2.1 AS.
+
+    Single-user mode (default): bind ``127.0.0.1`` and persist credentials
+    to one shared ``config.enc`` on the host.
+
+    Multi-user remote mode (``PUBLIC_URL`` set): bind ``0.0.0.0:8080`` (or
+    ``MCP_PORT``) and scope credential storage per-JWT-sub via
+    ``save_credentials``. The ``MCP_DCR_SERVER_SECRET`` env var is required
+    as proof of intentional multi-user deployment -- without it, refuse to
+    start so a misconfigured single-user instance never accidentally
+    accepts other users' OAuth flows into the same shared ``config.enc``.
+    """
     from mcp_core.transport.local_server import run_local_server
 
     from mnemo_mcp.credential_state import (
@@ -1293,11 +1304,26 @@ async def run_http(port: int = 0) -> None:
     )
     from mnemo_mcp.relay_schema import RELAY_SCHEMA
 
+    public_url = os.environ.get("PUBLIC_URL")
+    if public_url:
+        if not os.environ.get("MCP_DCR_SERVER_SECRET"):
+            raise SystemExit(
+                "mnemo-mcp refuses to start: PUBLIC_URL set but "
+                "MCP_DCR_SERVER_SECRET missing. Multi-user remote mode "
+                "requires the DCR secret as proof of intentional multi-user "
+                "deployment (prevents accidental single-user credential leak)."
+            )
+        host = "0.0.0.0"
+        port = int(os.environ.get("MCP_PORT", "8080"))
+    else:
+        host = "127.0.0.1"
+
     await run_local_server(
         mcp,  # ty: ignore[invalid-argument-type]
         server_name="mnemo-mcp",
         relay_schema=RELAY_SCHEMA,
         port=port,
+        host=host,
         on_credentials_saved=save_credentials,
         # Use wire_gdrive_callbacks so terminal OAuth errors (invalid_grant,
         # expired_token, save_token failures) surface to the browser's
@@ -1317,10 +1343,18 @@ def main() -> None:
     logger.add(sys.stderr, level=level)
     logger.info("Starting Mnemo MCP Server...")
 
+    mode = (os.environ.get("MCP_MODE") or "").strip().lower()
+
     if "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT") == "stdio":
         from mcp_core.transport import run_smart_stdio_proxy
 
         daemon_cmd = [sys.executable, "-m", "mnemo_mcp"]
         sys.exit(run_smart_stdio_proxy("mnemo-mcp", daemon_cmd))
+    elif mode == "remote-relay":
+        raise SystemExit(
+            "MCP_MODE=remote-relay is deprecated since 2026-04-25 (single-user "
+            "MCP_RELAY_URL pattern). For multi-user remote: set PUBLIC_URL + "
+            "MCP_DCR_SERVER_SECRET and run with default mode."
+        )
     else:
         asyncio.run(run_http())

--- a/tests/integration/test_multi_user_remote.py
+++ b/tests/integration/test_multi_user_remote.py
@@ -1,0 +1,31 @@
+"""Per-sub credential isolation in mnemo-mcp remote multi-user mode."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_two_subs_isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import read_for_sub, store_for_sub
+
+    store_for_sub("user_a", {"JINA_AI_API_KEY": "key_a"})
+    store_for_sub("user_b", {"JINA_AI_API_KEY": "key_b"})
+
+    assert read_for_sub("user_a") == {"JINA_AI_API_KEY": "key_a"}
+    assert read_for_sub("user_b") == {"JINA_AI_API_KEY": "key_b"}
+    assert read_for_sub("user_a") != read_for_sub("user_b")
+
+
+@pytest.mark.integration
+def test_save_credentials_uses_sub_when_public_url_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example.com")
+    from mnemo_mcp.credential_state import read_for_sub, save_credentials
+
+    save_credentials({"JINA_AI_API_KEY": "k1"}, {"sub": "user_a"})
+    save_credentials({"JINA_AI_API_KEY": "k2"}, {"sub": "user_b"})
+
+    assert read_for_sub("user_a")["JINA_AI_API_KEY"] == "k1"
+    assert read_for_sub("user_b")["JINA_AI_API_KEY"] == "k2"

--- a/tests/test_credential_state_multi_user.py
+++ b/tests/test_credential_state_multi_user.py
@@ -1,0 +1,57 @@
+"""Unit tests for the multi-user remote helpers in credential_state.
+
+Mirrors ``tests/integration/test_multi_user_remote.py`` but without the
+``integration`` marker so the per-subject file IO and PUBLIC_URL branch
+counts toward the default coverage gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_sub_data_dir_creates_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import _sub_data_dir
+
+    d = _sub_data_dir("sub_xyz")
+    assert d == tmp_path / "subs" / "sub_xyz"
+    assert d.exists() and d.is_dir()
+
+
+def test_store_and_read_for_sub_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import read_for_sub, store_for_sub
+
+    store_for_sub("alice", {"JINA_AI_API_KEY": "key_a"})
+    store_for_sub("bob", {"JINA_AI_API_KEY": "key_b"})
+
+    assert read_for_sub("alice") == {"JINA_AI_API_KEY": "key_a"}
+    assert read_for_sub("bob") == {"JINA_AI_API_KEY": "key_b"}
+
+
+def test_read_for_sub_missing_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import read_for_sub
+
+    assert read_for_sub("never_seen") == {}
+
+
+def test_save_credentials_multi_user_branch(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example.com")
+    from mnemo_mcp.credential_state import read_for_sub, save_credentials
+
+    result = save_credentials({"JINA_AI_API_KEY": "k1"}, {"sub": "alice"})
+
+    assert result is None
+    assert read_for_sub("alice")["JINA_AI_API_KEY"] == "k1"
+
+
+def test_save_credentials_multi_user_requires_sub(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example.com")
+    from mnemo_mcp.credential_state import save_credentials
+
+    with pytest.raises(RuntimeError, match="sub required"):
+        save_credentials({"JINA_AI_API_KEY": "k1"}, {})

--- a/uv.lock
+++ b/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.22.0"
+version = "1.22.3"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -879,7 +879,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.7.6" },
+    { name = "n24q02m-mcp-core", editable = "../mcp-core/packages/core-py" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -922,7 +922,7 @@ wheels = [
 [[package]]
 name = "n24q02m-mcp-core"
 version = "1.7.6"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../mcp-core/packages/core-py" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -934,9 +934,28 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/b2/ec817cfce281a2d6efe19936c74ae935a14bd734f380cee3c61ff052c6a7/n24q02m_mcp_core-1.7.6.tar.gz", hash = "sha256:939ad6c841cb8980b7b6e99937322aad18b0f488b09ed1948c09ecf67108eb62", size = 160060, upload-time = "2026-04-24T10:52:57.975Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/57/ba494b0bebacbeb3877eda025f4045ea37ff82bc06ffa80d688e4c51454f/n24q02m_mcp_core-1.7.6-py3-none-any.whl", hash = "sha256:3b07e254dfa50cb9561ef8f892df7d86792e5af23640dc6cb365bdf04fb94d4a", size = 99096, upload-time = "2026-04-24T10:52:56.4Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "authlib", specifier = ">=1.7.0" },
+    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "platformdirs", specifier = ">=4.9.6" },
+    { name = "pydantic", specifier = ">=2.9,<2.13" },
+    { name = "starlette", specifier = ">=1.0.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.15.11" },
+    { name = "ty", specifier = ">=0.0.32" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Multi-user remote mode via \`PUBLIC_URL\` env switch
- Per-JWT-sub credential storage
- Refuses to start in remote mode without \`MCP_DCR_SERVER_SECRET\`

## Test plan
- [x] Unit tests pass
- [ ] T2 mnemo-full live verification post-CI image build

🤖 Generated with [Claude Code](https://claude.com/claude-code)