### PR TITLE
feat: add ## E2E section to CLAUDE.md per Task 21 docs rollout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,25 @@ PSR v10 (workflow_dispatch) -> PyPI + Docker (amd64+arm64) + GHCR + MCP Registry
 - Dependencies: `qwen3-embed>=1.5.1`, `cohere`, `sqlite-vec`.
 - Pre-commit: ruff lint + format, ty check, pytest.
 - Secrets: skret SSM namespace `/mnemo-mcp/prod` (region `ap-southeast-1`)
+
+## E2E
+
+Driven by `mcp-core/scripts/e2e/` (matrix-locked, 15 configs). Run a single config from this repo via `make e2e` (proxy) or directly:
+
+```
+cd ../mcp-core && uv run --project scripts/e2e python -m e2e.driver <config-id>
+```
+
+Configs for this repo: `mnemo-full`.
+
+t2-interaction: GDrive device-code (900s); per-sub token storage at ``~/.mnemo-mcp/subs/<sub>/tokens/google_drive.json``.
+
+Tier policy:
+
+- **T0** (precommit + CI on PR / main push) - runs without upstream identity. Skret keys not required.
+- **T2 non-interaction** (`make e2e-config CONFIG=<id>` locally) - driver pre-fills relay form from skret AWS SSM `/mnemo-mcp/prod` (`ap-southeast-1`). No user gate.
+- **T2 interaction** - driver fills relay form, then prints upstream user-gate URL; user signs in / types OTP at provider. Driver enforces per-flow timeouts (device-code 900s, oauth-redirect 300s, browser-form 600s) and emits `[poll] elapsed=Xs remaining=Ys status=<body>` every 30s. On timeout, container logs + last `setup-status` are saved to `<tmp>/e2e-diag/` BEFORE teardown for post-mortem.
+
+Multi-user remote mode (deployment property; not a separate config) requires `MCP_DCR_SERVER_SECRET` in the same skret namespace - driver refuses to start the container without it when `PUBLIC_URL` is set.
+
+References: `mcp-core/scripts/e2e/matrix.yaml`, `~/.claude/skills/mcp-dev/references/e2e-full-matrix.md` (harness-readiness gate), `~/.claude/skills/mcp-dev/references/secrets-skret.md` (per-server credential layout), `~/.claude/skills/mcp-dev/references/multi-user-pattern.md` (per-JWT-sub isolation).


### PR DESCRIPTION
Documents T0/T2 tier policy + per-flow timeouts + skret namespace + driver diagnostic capture + harness-readiness gate. Closes Task 21 step 5 of 2026-04-25-e2e-framework-and-multi-user-migration spec.