### PR TITLE
fix: clarify default-local relay URL in setup docs

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -131,7 +131,7 @@ When environment variables are set, the relay is skipped entirely.
 
 No manual configuration needed. On first start:
 
-1. The server prints a setup URL to stderr (e.g., `https://mnemo-mcp.n24q02m.com/setup/...`)
+1. The server prints a setup URL to stderr (e.g., `http://127.0.0.1:<port>/authorize`). The port is allocated dynamically on each start, and `mnemo-mcp` runs the relay locally by default — no public n24q02m.com subdomain is provisioned for wet/mnemo/crg/imagine. To run a self-hosted remote relay, set `MCP_RELAY_URL=https://your-host/...`.
 2. Open the URL in any browser
 3. Fill in your API keys on the guided form:
    - **Jina AI API Key** -- enables embedding and reranking ([get key](https://jina.ai/api-key))

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -152,7 +152,7 @@ All environment variables are **optional**. The server works in local mode (ONNX
 | Variable | Required | Default | Description |
 |:---------|:---------|:--------|:------------|
 | `LOG_LEVEL` | No | `INFO` | Logging level |
-| `MCP_RELAY_URL` | No | `https://mnemo-mcp.n24q02m.com` | Relay server URL for zero-config setup |
+| `MCP_RELAY_URL` | No | _(none — local relay by default)_ | Set this to your self-hosted relay URL (e.g., `https://your-host/...`) to opt into remote-relay mode. When unset, the server boots the relay locally on a random `127.0.0.1:<port>` for the user-pastes-credentials flow. |
 
 ## Authentication
 


### PR DESCRIPTION
Replace hardcoded `https://mnemo-mcp.n24q02m.com` examples in setup-manual.md and setup-with-agent.md with the dynamic local relay URL pattern, in line with feedback_matrix_selfhost_semantics. Default-local servers (wet, mnemo, crg, imagine) do not have public n24q02m subdomains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)