### PR TITLE
fix: pass MCP_TRANSPORT=stdio in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,7 +14,10 @@
         "--python",
         "3.13",
         "mnemo-mcp"
-      ]
+      ],
+      "env": {
+        "MCP_TRANSPORT": "stdio"
+      }
     }
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: ty
         name: ty type check
-        entry: uv run ty check
+        entry: uv run --no-sync ty check
         language: system
         types: [python]
         pass_filenames: false
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest (Python)
-        entry: uv run pytest --tb=short -q --timeout=30
+        entry: uv run --no-sync pytest --tb=short -q --timeout=30
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
## Summary

- Plugin manifest now passes `MCP_TRANSPORT=stdio` env var so Claude Code spawns the MCP in stdio mode (default is HTTP since 2026-04-12 commit `e9b9bed`).
- Without this flag, `main()` runs `run_http()` and starts a local HTTP server that never speaks JSON-RPC stdio. Claude Code times out waiting for the handshake -> "Failed to connect" + orphan HTTP daemons -> cumulative OOM.
- Pre-commit hooks updated to use `uv run --no-sync` to prevent uv.lock drift on repos with `[tool.uv.sources]` paths (per memory `feedback_uv_lock_docker_trap.md`).

## Test plan

- [ ] CI green
- [ ] After release: cached plugin.json refresh -> Claude Code `/mcp` shows server connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)