### PR TITLE
feat: route stdio mode to FastMCP/MCP SDK direct + multi-target Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 # ========================
-# Stage 2: Runtime
+# Stage 2: Runtime base (shared by stdio + http targets)
 # ========================
-FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33
+# Multi-target Dockerfile per spec
+# `~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md`
+# section D6. Build stdio: `docker buildx build --target stdio -t <repo>:stdio .`
+# Build http:  `docker buildx build --target http  -t <repo>:http .`
+# Build latest (= http): `docker buildx build --target http -t <repo>:latest .`
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/n24q02m/mnemo-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.n24q02m/mnemo-mcp"
@@ -58,5 +63,18 @@ RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -m appuser \
 VOLUME /data
 USER appuser
 
-# Stdio transport by default
-CMD ["python", "-m", "mnemo_mcp"]
+# ========================
+# Stage 3a: stdio target (default for plugin marketplace & uvx-style usage)
+# ========================
+FROM runtime AS stdio
+ENV MCP_TRANSPORT=stdio
+ENTRYPOINT ["python", "-m", "mnemo_mcp"]
+
+# ========================
+# Stage 3b: http target (multi-user remote daemon)
+# ========================
+FROM runtime AS http
+ENV MCP_TRANSPORT=http \
+    MCP_PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["python", "-m", "mnemo_mcp"]

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1389,10 +1389,11 @@ def main() -> None:
     mode = (os.environ.get("MCP_MODE") or "").strip().lower()
 
     if "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT") == "stdio":
-        from mcp_core.transport import run_smart_stdio_proxy
-
-        daemon_cmd = [sys.executable, "-m", "mnemo_mcp"]
-        sys.exit(run_smart_stdio_proxy("mnemo-mcp", daemon_cmd))
+        # Stdio mode: run FastMCP stdio server directly. No bridge layer.
+        # Universal MCP client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
+        # See: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md
+        mcp.run(transport="stdio")
+        return
     elif mode == "remote-relay":
         raise SystemExit(
             "MCP_MODE=remote-relay is deprecated since 2026-04-25 (single-user "

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -688,19 +688,21 @@ class TestConfigSet:
 
 class TestMain:
     def test_main_invalid_log_level(self):
-        """Cover line 1001: invalid log level falls back to WARNING."""
+        """Cover line 1001: invalid log level falls back to WARNING.
+
+        main() in stdio mode runs FastMCP stdio server directly (no bridge).
+        """
+        from mnemo_mcp import server as server_mod
+
         with (
             patch("mnemo_mcp.server.logger"),
             patch("mnemo_mcp.server.settings") as mock_settings,
-            patch(
-                "mcp_core.transport.run_smart_stdio_proxy", return_value=0
-            ) as mock_proxy,
+            patch.object(server_mod.mcp, "run") as mock_run,
             patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"}),
-            pytest.raises(SystemExit, match="0"),
         ):
             mock_settings.log_level = "BOGUS"
             main()
-            mock_proxy.assert_called_once()
+            mock_run.assert_called_once_with(transport="stdio")
 
 
 class TestPrompts:

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -196,21 +196,20 @@ class TestResources:
 
 class TestMainFunction:
     def test_main_calls_mcp_run(self):
-        """main() in stdio mode configures logger and calls run_smart_stdio_proxy()."""
+        """main() in stdio mode runs FastMCP stdio server directly (no bridge)."""
+        from mnemo_mcp import server as server_mod
+
         with (
             patch("mnemo_mcp.server.logger") as mock_logger,
-            patch(
-                "mcp_core.transport.run_smart_stdio_proxy", return_value=0
-            ) as mock_proxy,
+            patch.object(server_mod.mcp, "run") as mock_run,
             patch("mnemo_mcp.server.settings") as mock_settings,
             patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"}),
-            pytest.raises(SystemExit, match="0"),
         ):
             mock_settings.log_level = "INFO"
             main()
             mock_logger.remove.assert_called_once()
             mock_logger.add.assert_called_once()
-            mock_proxy.assert_called_once()
+            mock_run.assert_called_once_with(transport="stdio")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stdio_direct.py
+++ b/tests/test_stdio_direct.py
@@ -1,0 +1,144 @@
+"""Verify mnemo-mcp runs in stdio direct mode (no smart_stdio bridge).
+
+Spawns ``python -m mnemo_mcp`` with ``MCP_TRANSPORT=stdio`` and exercises the
+JSON-RPC handshake plus ``tools/list`` to prove the FastMCP stdio server is
+wired directly (no daemon-spawn bridge layer in front of it).
+
+Marked ``live`` because it spawns a real subprocess and speaks the MCP
+protocol; excluded from the default ``pytest`` invocation but runs under
+``uv run pytest -m live``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.live, pytest.mark.timeout(60)]
+
+
+def _spawn_stdio_server() -> subprocess.Popen[str]:
+    """Start ``python -m mnemo_mcp`` with stdio transport.
+
+    Returns the running subprocess. Caller is responsible for terminating it.
+    """
+    env = {**os.environ, "MCP_TRANSPORT": "stdio"}
+    return subprocess.Popen(
+        [sys.executable, "-m", "mnemo_mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _read_response(proc: subprocess.Popen[str]) -> dict:
+    """Read one JSON-RPC line from stdout, parsed as dict."""
+    assert proc.stdout is not None and proc.stderr is not None
+    line = proc.stdout.readline()
+    if not line:
+        stderr = proc.stderr.read()
+        raise RuntimeError(
+            f"server closed stdout without sending a response. stderr=\n{stderr}"
+        )
+    return json.loads(line)
+
+
+def test_stdio_direct_init_responds():
+    """Spawn the server with MCP_TRANSPORT=stdio; verify init response shape."""
+    proc = _spawn_stdio_server()
+    assert proc.stdin is not None
+    init_request = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        )
+        + "\n"
+    )
+    try:
+        proc.stdin.write(init_request)
+        proc.stdin.flush()
+        response = _read_response(proc)
+        assert response["id"] == 1
+        assert "result" in response, f"unexpected response: {response}"
+        # FastMCP negotiates protocol version; just assert it returned one.
+        assert "protocolVersion" in response["result"]
+        # Server name is "Mnemo" per FastMCP("Mnemo", ...) in server.py.
+        assert response["result"]["serverInfo"]["name"] == "Mnemo"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_stdio_direct_tools_list_returns_expected_tools():
+    """Verify tools/list returns the expected mnemo tool set over stdio."""
+    proc = _spawn_stdio_server()
+    assert (
+        proc.stdin is not None and proc.stdout is not None and proc.stderr is not None
+    )
+    requests = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+    ]
+    try:
+        for r in requests:
+            proc.stdin.write(r + "\n")
+            proc.stdin.flush()
+        responses: dict[int, dict] = {}
+        while len(responses) < 2:
+            line = proc.stdout.readline()
+            if not line:
+                stderr = proc.stderr.read()
+                raise RuntimeError(
+                    f"server closed stdout before tools/list response. "
+                    f"stderr=\n{stderr}"
+                )
+            data = json.loads(line)
+            if "id" in data:
+                responses[data["id"]] = data
+        assert 2 in responses, f"missing tools/list response: {responses}"
+        tools = responses[2]["result"]["tools"]
+        tool_names = {t["name"] for t in tools}
+        # Core mnemo tools that must be exposed in stdio mode. Relay-only
+        # tool ``config__open_relay`` may or may not be registered depending
+        # on the relay-setup state, so we don't assert it here.
+        expected = {"memory", "config", "help"}
+        assert expected.issubset(tool_names), (
+            f"missing tools: {expected - tool_names}; got: {tool_names}"
+        )
+        assert len(tools) >= 3
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
Migrate stdio path from smart_stdio bridge to direct FastMCP/MCP SDK stdio. Universal MCP client compat. Multi-target Dockerfile (:stdio + :http). Spec: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md