### PR TITLE
fix: G6 UX status accuracy — derive state from live PerPluginStore

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1114,23 +1114,28 @@ async def _handle_config_setup_sync() -> str:
 
 
 async def _handle_config_setup_status() -> str:
-    from mnemo_mcp.credential_state import get_setup_url, get_state
+    from mcp_core.storage.per_plugin_store import PerPluginStore
 
-    state = get_state()
+    from mnemo_mcp.credential_state import CLOUD_KEYS, CredentialState, get_setup_url, get_state
+
+    # Derive providers_configured from live PerPluginStore load + env
+    # so status is accurate even if module-level _state is stale.
+    _saved = PerPluginStore("mnemo").load() or {}
+    _env_keys = [k for k in CLOUD_KEYS if os.environ.get(k)]
+    _store_keys = [k for k in CLOUD_KEYS if _saved.get(k)]
+    _providers = list(dict.fromkeys(_env_keys + _store_keys))
+    if _providers:
+        _derived_state = "configured"
+    elif get_state() == CredentialState.LOCAL:
+        _derived_state = "local"
+    else:
+        _derived_state = "awaiting_setup"
     return _json(
         {
-            "state": state.value,
+            "state": _derived_state,
             "setup_url": get_setup_url(),
-            "cloud_keys_in_env": [
-                k
-                for k in (
-                    "JINA_AI_API_KEY",
-                    "GEMINI_API_KEY",
-                    "OPENAI_API_KEY",
-                    "COHERE_API_KEY",
-                )
-                if os.environ.get(k)
-            ],
+            "cloud_keys_in_env": _env_keys,
+            "providers_configured": _providers,
         }
     )
 

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -1,0 +1,116 @@
+"""G6 UX bug fixes — _handle_config_setup_status accuracy for mnemo-mcp.
+
+Bug: setup_status returned stale module-level _state even when no
+credentials were actually loadable via PerPluginStore.
+
+Fix: _handle_config_setup_status now derives state from live PerPluginStore
+load + env, and always includes providers_configured in the response.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _call_config_setup_status_sync() -> dict[str, Any]:
+    """Invoke the async setup_status handler and return parsed dict."""
+    import asyncio
+
+    from mnemo_mcp.server import _handle_config_setup_status
+
+    raw = asyncio.run(_handle_config_setup_status())
+    return json.loads(raw)
+
+
+class TestSetupStatusLiveDerivedState:
+    """setup_status derives state from live PerPluginStore, not stale _state."""
+
+    def test_returns_configured_when_store_has_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """setup_status returns configured when PerPluginStore has cloud keys."""
+        monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={"GEMINI_API_KEY": "test-key-123"},
+        ):
+            result = _call_config_setup_status_sync()
+
+        assert result["state"] == "configured"
+        assert "GEMINI_API_KEY" in result["providers_configured"]
+
+    def test_returns_needs_setup_when_store_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """setup_status returns awaiting_setup when store empty and no env vars."""
+        monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+
+        # Force module-level state to CONFIGURED (stale) to reproduce the bug
+        import mnemo_mcp.credential_state as cs
+
+        cs.set_state(cs.CredentialState.CONFIGURED)
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={},
+        ):
+            result = _call_config_setup_status_sync()
+
+        # State must be derived from live creds, NOT stale _state
+        assert result["state"] != "configured"
+        assert result["providers_configured"] == []
+
+        # Restore state
+        cs.set_state(cs.CredentialState.AWAITING_SETUP)
+
+    def test_env_vars_take_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """setup_status includes env-var keys in providers_configured."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={},
+        ):
+            result = _call_config_setup_status_sync()
+
+        assert result["state"] == "configured"
+        assert "OPENAI_API_KEY" in result["providers_configured"]
+        assert "OPENAI_API_KEY" in result["cloud_keys_in_env"]
+
+    def test_response_includes_providers_configured_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """setup_status always includes providers_configured key in response."""
+        monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={},
+        ):
+            result = _call_config_setup_status_sync()
+
+        assert "providers_configured" in result
+        assert isinstance(result["providers_configured"], list)
+
+    def test_no_duplicate_providers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If same key appears in both env and store, it should appear only once."""
+        monkeypatch.setenv("GEMINI_API_KEY", "key-from-env")
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={"GEMINI_API_KEY": "key-from-store"},
+        ):
+            result = _call_config_setup_status_sync()
+
+        assert result["providers_configured"].count("GEMINI_API_KEY") == 1


### PR DESCRIPTION
## Summary
- `setup_status` now reads `PerPluginStore("mnemo").load()` + `os.environ` on every call instead of returning stale module-level `_state`
- If no live credentials found, returns `awaiting_setup` (never leaks stale `configured` state from prior session)
- Adds 5 regression tests in `tests/test_g6_ux_status_accuracy.py`

## Bug reproduced
`cs.set_state(CredentialState.CONFIGURED)` + empty store → old code returned `state=configured`, new code returns `state=awaiting_setup`

## Test plan
- [ ] 5/5 tests pass: `uv run pytest tests/test_g6_ux_status_accuracy.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)