### PR TITLE
fix: regenerate uv.lock UV_NO_SOURCES=1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "1.25.0b1"
+version = "1.25.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -879,7 +879,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", editable = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b1" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -922,7 +922,7 @@ wheels = [
 [[package]]
 name = "n24q02m-mcp-core"
 version = "1.13.0b1"
-source = { editable = "../mcp-core/packages/core-py" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -935,29 +935,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=47.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "filelock", specifier = ">=3.16.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.33" },
+sdist = { url = "https://files.pythonhosted.org/packages/f8/33/4c95c7e2387d3561101e831ef6a631b5a8ac981ab2e26d212b67a46cb2a4/n24q02m_mcp_core-1.13.0b1.tar.gz", hash = "sha256:738d997a7dbf7abd22f6cee307bf9e1d163dd08c29437aabb9a6325d8f30f81c", size = 211627, upload-time = "2026-04-30T13:59:39.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/ae/899110854eacd4b4900ebccc9d6e8e5674389dd2a89e87e45e2626949999/n24q02m_mcp_core-1.13.0b1-py3-none-any.whl", hash = "sha256:ea477a35e0e2dc7861e47617732e91f81ee876dcb5bf22af211b9cdc62f31bf6", size = 132218, upload-time = "2026-04-30T13:59:38.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Docker build fail: uv.lock has local path source references (per feedback_uv_lock_docker_trap.md).