### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Multi-User Config Storage

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import hashlib
 import json
 import os
 import sys
@@ -306,7 +307,8 @@ def _sub_data_dir(sub: str) -> Path:
     directory so credentials never bleed across users.
     """
     base = Path(os.environ.get("MNEMO_DATA_DIR", str(Path.home() / ".mnemo-mcp")))
-    d = base / "subs" / sub
+    hashed_sub = hashlib.sha256(sub.encode("utf-8")).hexdigest()
+    d = base / "subs" / hashed_sub
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -14,6 +14,7 @@ Token lifecycle:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import stat
@@ -46,7 +47,8 @@ def _get_token_dir_for_sub(sub: str) -> Path:
     JWT ``sub`` so user A's GDrive refresh-token is not visible to
     user B sharing the same mnemo-mcp deployment.
     """
-    return settings.get_data_dir() / "subs" / sub / "tokens"
+    hashed_sub = hashlib.sha256(sub.encode("utf-8")).hexdigest()
+    return settings.get_data_dir() / "subs" / hashed_sub / "tokens"
 
 
 def get_token_path_for_sub(sub: str, provider: str) -> Path:

--- a/tests/test_credential_state_multi_user.py
+++ b/tests/test_credential_state_multi_user.py
@@ -12,10 +12,13 @@ import pytest
 
 def test_sub_data_dir_creates_path(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    import hashlib
+
     from mnemo_mcp.credential_state import _sub_data_dir
 
     d = _sub_data_dir("sub_xyz")
-    assert d == tmp_path / "subs" / "sub_xyz"
+    expected_hash = hashlib.sha256(b"sub_xyz").hexdigest()
+    assert d == tmp_path / "subs" / expected_hash
     assert d.exists() and d.is_dir()
 
 

--- a/tests/test_token_store_per_sub.py
+++ b/tests/test_token_store_per_sub.py
@@ -27,16 +27,24 @@ def data_dir(tmp_path):
 
 class TestPerSubPaths:
     def test_token_dir_for_sub_uses_subs_layout(self, data_dir):
+        import hashlib
+
         from mnemo_mcp.token_store import _get_token_dir_for_sub
 
         path = _get_token_dir_for_sub("sub-abc")
-        assert path == data_dir / "subs" / "sub-abc" / "tokens"
+        expected_hash = hashlib.sha256(b"sub-abc").hexdigest()
+        assert path == data_dir / "subs" / expected_hash / "tokens"
 
     def test_token_path_for_sub_includes_provider(self, data_dir):
+        import hashlib
+
         from mnemo_mcp.token_store import get_token_path_for_sub
 
         path = get_token_path_for_sub("sub-abc", "google_drive")
-        assert path == data_dir / "subs" / "sub-abc" / "tokens" / "google_drive.json"
+        expected_hash = hashlib.sha256(b"sub-abc").hexdigest()
+        assert (
+            path == data_dir / "subs" / expected_hash / "tokens" / "google_drive.json"
+        )
 
 
 class TestSaveTokenForSub:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `sub` parameter used to scope credentials in `src/mnemo_mcp/credential_state.py` and `src/mnemo_mcp/token_store.py` was directly concatenated into filesystem paths. A malicious `sub` (e.g. `../../../tmp`) could read or write files outside the intended data directory.
🎯 Impact: This could lead to a compromise of user isolation in multi-user remote setups, allowing users to access or overwrite others' sensitive API keys and tokens.
🔧 Fix: Used `hashlib.sha256` to securely hash the `sub` identifier before using it as a directory name, completely preventing path traversal strings from reaching the filesystem APIs.
✅ Verification: Ran and updated `tests/test_credential_state_multi_user.py` and `tests/test_token_store_per_sub.py` to expect the SHA256 hashed directory name.

---
*PR created automatically by Jules for task [11985235866100790415](https://jules.google.com/task/11985235866100790415) started by @n24q02m*