### PR TITLE
feat: add Method overview section (3 vs 1 method clarification)

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -4,6 +4,18 @@
 > The previous "Zero-Config Relay" auto-spawn pattern has been removed.
 > Optional cloud providers (Jina/Gemini/OpenAI/Cohere) and Google Drive sync are still supported -- set them via env vars (Method 1) or configure them through the relay form in HTTP mode (Method 5).
 
+## Method overview
+
+This plugin supports 3 install methods. Pick the one that matches your use case:
+
+| Priority | Method | Transport | Best for |
+|---|---|---|---|
+| **1. Default** | Plugin install (`uvx`/`npx`) | stdio | Quick local start, single workstation, no OAuth/HTTP needed. |
+| **2. Fallback** | Docker stdio (`docker run -i --rm`) | stdio | Windows/macOS where native uvx/npx hits PATH or Python version issues. |
+| **3. Recommended** | Docker HTTP (`docker run -p 8080:8080`) | HTTP | Multi-device, OAuth/relay-form auth, team self-host, claude.ai web compatibility. |
+
+All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
+
 ## Prerequisites
 
 - **Python 3.13** (3.14+ is NOT supported)

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -6,6 +6,18 @@
 > The previous "Zero-Config Relay" auto-spawn pattern has been removed.
 > Optional cloud providers (Jina/Gemini/OpenAI/Cohere) and Google Drive sync are still supported -- set them via env vars (Option 1/2) or configure them through the relay form in HTTP mode (see setup-manual.md "Method 5: Self-Hosting HTTP Mode").
 
+## Method overview
+
+This plugin supports 3 install methods. Pick the one that matches your use case:
+
+| Priority | Method | Transport | Best for |
+|---|---|---|---|
+| **1. Default** | Plugin install (`uvx`/`npx`) | stdio | Quick local start, single workstation, no OAuth/HTTP needed. |
+| **2. Fallback** | Docker stdio (`docker run -i --rm`) | stdio | Windows/macOS where native uvx/npx hits PATH or Python version issues. |
+| **3. Recommended** | Docker HTTP (`docker run -p 8080:8080`) | HTTP | Multi-device, OAuth/relay-form auth, team self-host, claude.ai web compatibility. |
+
+All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
+
 ## Option 1: Claude Code Plugin (Recommended)
 
 Plugin marketplace install runs the server in **pure stdio mode**. mnemo works with **zero required env vars** -- it falls back to local SQLite + local Qwen3 ONNX embedding. Cloud providers and GDrive sync are optional.


### PR DESCRIPTION
User feedback 2026-05-04: docs list Method 1/2/3 in detail but never state up-front the priority hierarchy or which plugins are stdio-only. Adds an explicit overview table near the top of each setup doc making the 6-vs-2 split + default/fallback/recommended ordering clear at a glance.