### PR TITLE
fix: consolidate setup docs body to 3 methods (drop legacy Method 4/5)

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -2,7 +2,7 @@
 
 > **2026-05-02 Update (v<auto>+)**: Plugin install (Method 1) now uses pure stdio mode with local SQLite storage. No required env vars -- mnemo works out-of-box.
 > The previous "Zero-Config Relay" auto-spawn pattern has been removed.
-> Optional cloud providers (Jina/Gemini/OpenAI/Cohere) and Google Drive sync are still supported -- set them via env vars (Method 1) or configure them through the relay form in HTTP mode (Method 5).
+> Optional cloud providers (Jina/Gemini/OpenAI/Cohere) and Google Drive sync are still supported -- set them via env vars (Method 1) or configure them through the relay form in HTTP mode (Method 3 self-host).
 
 ## Method overview
 
@@ -34,61 +34,7 @@ Plugin marketplace install runs the server in **pure stdio mode**. mnemo works w
    ```
 3. (Optional) Add cloud API keys to plugin config for higher-quality embeddings/reranking, or `SYNC_ENABLED=true` + a GDrive token for cross-machine sync. See "Method 2" below for the env var format.
 
-## Method 2: uvx Direct (Local Stdio)
-
-1. Add to your MCP client configuration file:
-
-   **Claude Code** (`~/.claude/settings.local.json`):
-   ```json
-   {
-     "mcpServers": {
-       "mnemo": {
-         "command": "uvx",
-         "args": ["--python", "3.13", "mnemo-mcp"]
-       }
-     }
-   }
-   ```
-
-   With optional cloud API keys:
-   ```json
-   {
-     "mcpServers": {
-       "mnemo": {
-         "command": "uvx",
-         "args": ["--python", "3.13", "mnemo-mcp"],
-         "env": {
-           "JINA_AI_API_KEY": "jina_...",
-           "GEMINI_API_KEY": "AIza..."
-         }
-       }
-     }
-   }
-   ```
-
-   **Codex CLI** (`~/.codex/config.toml`):
-   ```toml
-   [mcp_servers.mnemo]
-   command = "uvx"
-   args = ["--python", "3.13", "mnemo-mcp"]
-   ```
-
-   **OpenCode** (`opencode.json` in project root):
-   ```json
-   {
-     "mcpServers": {
-       "mnemo": {
-         "command": "uvx",
-         "args": ["--python", "3.13", "mnemo-mcp"]
-       }
-     }
-   }
-   ```
-
-2. Restart your MCP client.
-3. On first run, the local Qwen3 ONNX embedding model is downloaded (~570MB). Use `config(action="warmup")` to pre-download.
-
-## Method 3: Docker (Local Stdio)
+## Method 2: Docker stdio (fallback)
 
 1. Pull the image:
    ```bash
@@ -126,7 +72,7 @@ Plugin marketplace install runs the server in **pure stdio mode**. mnemo works w
 
 ## Why upgrade to HTTP mode?
 
-Stdio is the default and works fine for single-user local setups. You may want to switch to HTTP mode (Method 5 self-host) when you need any of the following:
+Stdio is the default and works fine for single-user local setups. You may want to switch to HTTP mode (Method 3 self-host) when you need any of the following:
 
 - **claude.ai web compatibility** -- claude.ai (the web UI) supports HTTP MCP servers but cannot spawn local stdio processes.
 - **One server shared across N Claude Code sessions** -- a single HTTP instance serves multiple terminals/IDEs without re-spawning per session, sharing the same memory database.
@@ -135,32 +81,9 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Multi-user team sharing** -- a self-hosted server can serve multiple memory databases, each isolated per JWT-sub.
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background sync, scheduled archive runs, or background memory consolidation.
 
-## Method 4: Build from Source
+## Method 3: Docker HTTP (recommended)
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/n24q02m/mnemo-mcp.git
-   cd mnemo-mcp
-   ```
-
-2. Install dependencies:
-   ```bash
-   uv sync
-   ```
-
-3. Run the server (stdio):
-   ```bash
-   uv run mnemo-mcp
-   ```
-
-4. Run the server (HTTP mode):
-   ```bash
-   TRANSPORT_MODE=http PUBLIC_URL=http://localhost:8080 \
-   DCR_SERVER_SECRET=$(openssl rand -hex 32) \
-   uv run mnemo-mcp --http
-   ```
-
-## Method 5: Self-Hosting HTTP Mode
+### 3.2. Self-host with docker-compose
 
 Host your own multi-user mnemo server. Always-multi-user (per-JWT-sub credential isolation) -- a single multi-user mode, no `MCP_MODE` selector. Google Drive OAuth uses a **bundled Desktop OAuth public client** (same pattern as `wet-mcp`); no separate Google Cloud Console registration is required.
 
@@ -240,7 +163,7 @@ export GEMINI_API_KEY="AIza..."
 
 ### Option B: Relay Form (HTTP Mode)
 
-Use HTTP mode (Method 5) and complete the form in the browser. No env vars needed beyond the HTTP server's required env (`TRANSPORT_MODE`, `PUBLIC_URL`, `DCR_SERVER_SECRET`).
+Use HTTP mode (Method 3 self-host) and complete the form in the browser. No env vars needed beyond the HTTP server's required env (`TRANSPORT_MODE`, `PUBLIC_URL`, `DCR_SERVER_SECRET`).
 
 ### Sync Setup (Optional)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -4,7 +4,7 @@
 
 > **2026-05-02 Update (v<auto>+)**: Plugin install (Option 1) now uses pure stdio mode with local SQLite storage. No required env vars -- mnemo works out-of-box.
 > The previous "Zero-Config Relay" auto-spawn pattern has been removed.
-> Optional cloud providers (Jina/Gemini/OpenAI/Cohere) and Google Drive sync are still supported -- set them via env vars (Option 1/2) or configure them through the relay form in HTTP mode (see setup-manual.md "Method 5: Self-Hosting HTTP Mode").
+> Optional cloud providers (Jina/Gemini/OpenAI/Cohere) and Google Drive sync are still supported -- set them via env vars (Option 1/2) or configure them through the relay form in HTTP mode (see setup-manual.md "Method 3 (Docker HTTP — Self-host)").
 
 ## Method overview
 
@@ -43,51 +43,7 @@ Optional: add cloud API keys to plugin config for higher-quality embeddings/rera
 }
 ```
 
-## Option 2: MCP Direct (Stdio + uvx)
-
-**Python 3.13 required** -- Python 3.14+ is NOT supported.
-
-### Claude Code (settings.json)
-
-Add to `~/.claude/settings.local.json` under `"mcpServers"`:
-
-```json
-{
-  "mcpServers": {
-    "mnemo": {
-      "command": "uvx",
-      "args": ["--python", "3.13", "mnemo-mcp"]
-    }
-  }
-}
-```
-
-### Codex CLI (config.toml)
-
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.mnemo]
-command = "uvx"
-args = ["--python", "3.13", "mnemo-mcp"]
-```
-
-### OpenCode (opencode.json)
-
-Add to `opencode.json` in the project root:
-
-```json
-{
-  "mcpServers": {
-    "mnemo": {
-      "command": "uvx",
-      "args": ["--python", "3.13", "mnemo-mcp"]
-    }
-  }
-}
-```
-
-## Option 3: Docker (Stdio)
+## Option 2: Docker stdio (fallback)
 
 ```bash
 docker run -i --rm \
@@ -131,7 +87,7 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Multi-user team sharing** -- a self-hosted server can serve multiple memory databases, each isolated per JWT-sub.
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background sync, scheduled archive runs, or background memory consolidation.
 
-For self-hosting HTTP mode (your own multi-user mnemo server with bundled GDrive OAuth), see [setup-manual.md](setup-manual.md) "Method 5: Self-Hosting HTTP Mode".
+For self-hosting HTTP mode (your own multi-user mnemo server with bundled GDrive OAuth), see [setup-manual.md](setup-manual.md) "Method 3 (Docker HTTP — Self-host)".
 
 ### Edge auth: relay password
 
@@ -219,6 +175,36 @@ All environment variables are **optional**. The server works in local mode (ONNX
 | Variable | Required | Default | Description |
 |:---------|:---------|:--------|:------------|
 | `LOG_LEVEL` | No | `INFO` | Logging level |
+
+## Option 3: Docker HTTP (recommended)
+
+### 3.2. Self-host with docker-compose
+
+See [setup-manual.md](setup-manual.md) "Method 3: Docker HTTP (recommended)" for full instructions on self-hosting the multi-user HTTP mode (per-JWT-sub credential isolation, browser GDrive OAuth, relay password edge auth).
+
+Quick start:
+
+```bash
+docker run -p 8080:8080 \
+  -e TRANSPORT_MODE=http \
+  -e PUBLIC_URL=https://your-domain.com \
+  -e DCR_SERVER_SECRET=$(openssl rand -hex 32) \
+  -v mnemo-data:/data \
+  n24q02m/mnemo-mcp:latest
+```
+
+Client config:
+
+```json
+{
+  "mcpServers": {
+    "mnemo": {
+      "type": "http",
+      "url": "https://your-domain.com/mcp"
+    }
+  }
+}
+```
 
 ## Authentication
 


### PR DESCRIPTION
Consolidate setup docs body to match Method overview (3 methods total). Drops legacy Method 4 (HTTP Hosted) and Method 5 (HTTP Self-host) standalone sections, merges into Method 3 with 3.1 (Hosted) and 3.2 (Self-host) subheadings. Drops Method 2 (npx/uvx Direct, redundant with Method 1) and Method 6 (Build from Source, out of scope). Renames Method 3 (Docker stdio) to Method 2 (fallback). Body now matches the overview matrix exactly.