### PR TITLE
feat: declare userConfig schema and document install prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,15 @@
   "name": "mnemo-mcp",
   "description": "Persistent AI memory — store, search, and recall knowledge across sessions",
   "version": "1.25.0",
+  "userConfig": {
+    "JINA_AI_API_KEY": {
+      "type": "string",
+      "title": "Jina AI API key (optional)",
+      "description": "Optional cloud reranker key. https://jina.ai/api-dashboard/",
+      "sensitive": true,
+      "required": false
+    }
+  },
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -16,7 +25,8 @@
         "mnemo-mcp"
       ],
       "env": {
-        "MCP_TRANSPORT": "stdio"
+        "MCP_TRANSPORT": "stdio",
+        "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}"
       }
     }
   }

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -26,13 +26,29 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode**. mnemo works with **zero required env vars** -- it falls back to local SQLite + local Qwen3 ONNX embedding. Cloud providers and GDrive sync are optional.
 
-1. Open Claude Code in your terminal
-2. Install the plugin:
+### Step 0: Credential prompt
+
+When you run `/plugin install mnemo-mcp@n24q02m-plugins`, Claude Code prompts for the optional field declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Notes |
+|:------|:---------|:----------|:------|
+| `JINA_AI_API_KEY` | No | Yes | Optional cloud reranker. Without it, the server uses local ONNX. https://jina.ai/api-dashboard/ |
+
+You may leave it empty -- mnemo runs with bundled local ONNX embedding/reranking. The sensitive value is kept in the system keychain (or `~/.claude/.credentials.json` fallback) and persists across `/plugin update`. Claude Code substitutes the value into `mcpServers.mnemo.env.JINA_AI_API_KEY` via `${user_config.JINA_AI_API_KEY}` -- you do not edit `env` manually.
+
+> Other optional env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `SYNC_ENABLED`, `GOOGLE_DRIVE_CLIENT_ID`, etc.) are not part of the install prompt; if you need them, add them manually to `mcpServers.mnemo.env` in your settings.
+
+### Steps
+
+1. Open Claude Code in your terminal.
+2. Install the plugin (Claude Code prompts for `JINA_AI_API_KEY` -- press Enter to skip):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install mnemo-mcp@n24q02m-plugins
    ```
-3. (Optional) Add cloud API keys to plugin config for higher-quality embeddings/reranking, or `SYNC_ENABLED=true` + a GDrive token for cross-machine sync. See "Method 2" below for the env var format.
+3. Restart Claude Code.
+
+> **HTTP transport (Method 3)** is a separate install path; the `userConfig` prompt only covers stdio Method 1.
 
 ## Method 2: Docker stdio (fallback)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -22,26 +22,25 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode**. mnemo works with **zero required env vars** -- it falls back to local SQLite + local Qwen3 ONNX embedding. Cloud providers and GDrive sync are optional.
 
+### Step 0: Credential prompt
+
+When the install command runs, Claude Code prompts for the optional field declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Source |
+|:------|:---------|:----------|:-------|
+| `JINA_AI_API_KEY` | No | Yes | https://jina.ai/api-dashboard/ |
+
+Press Enter to skip; mnemo falls back to local ONNX. The plugin manifest substitutes the value into `mcpServers.mnemo.env.JINA_AI_API_KEY` via `${user_config.JINA_AI_API_KEY}` and keeps the sensitive value in the system keychain (persists across `/plugin update`). You do not edit `env` manually.
+
+### Steps
+
 ```bash
 # Install from marketplace (includes skills: /session-handoff, /knowledge-audit)
 /plugin marketplace add n24q02m/claude-plugins
 /plugin install mnemo-mcp@n24q02m-plugins
 ```
 
-Optional: add cloud API keys to plugin config for higher-quality embeddings/reranking:
-
-```json
-{
-  "mcpServers": {
-    "mnemo-mcp": {
-      "env": {
-        "JINA_AI_API_KEY": "jina_...",
-        "GEMINI_API_KEY": "AIza..."
-      }
-    }
-  }
-}
-```
+> Other optional env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `SYNC_ENABLED`, `GOOGLE_DRIVE_CLIENT_ID`, etc.) are not part of the `userConfig` prompt; add them manually to `mcpServers.mnemo.env` in your settings if needed.
 
 ## Option 2: Docker stdio (fallback)
 


### PR DESCRIPTION
## Summary

- Add `userConfig.JINA_AI_API_KEY` (sensitive, optional) so `/plugin install` prompts for the optional Jina reranker key. Skippable; mnemo falls back to bundled local Qwen3 ONNX.
- Substitute via `${user_config.JINA_AI_API_KEY}` into `mcpServers.mnemo.env`.
- Other optional env vars (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`, `SYNC_ENABLED`, `GOOGLE_DRIVE_CLIENT_ID`) remain manual `mcpServers` config.
- Update `setup-manual.md` and `setup-with-agent.md` Method 1 with Step 0 prompt section.

## Test plan
- [ ] CI green
- [ ] `/plugin install` prompts for `JINA_AI_API_KEY` (skippable)
- [ ] Local ONNX path works when prompt is skipped

Generated with [Claude Code](https://claude.com/claude-code)