### PR TITLE
feat: align userConfig with relay_schema fields

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,6 +9,27 @@
       "description": "Optional cloud reranker key. https://jina.ai/api-dashboard/",
       "sensitive": true,
       "required": false
+    },
+    "GEMINI_API_KEY": {
+      "type": "string",
+      "title": "Gemini API key (optional)",
+      "description": "Optional cloud embedding + LLM. Free tier available. https://aistudio.google.com/apikey",
+      "sensitive": true,
+      "required": false
+    },
+    "OPENAI_API_KEY": {
+      "type": "string",
+      "title": "OpenAI API key (optional)",
+      "description": "Optional cloud embedding + LLM (lower priority than Gemini). https://platform.openai.com/api-keys",
+      "sensitive": true,
+      "required": false
+    },
+    "COHERE_API_KEY": {
+      "type": "string",
+      "title": "Cohere API key (optional)",
+      "description": "Optional cloud embedding + reranking. https://dashboard.cohere.com/api-keys",
+      "sensitive": true,
+      "required": false
     }
   },
   "author": {
@@ -26,7 +47,10 @@
       ],
       "env": {
         "MCP_TRANSPORT": "stdio",
-        "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}"
+        "JINA_AI_API_KEY": "${user_config.JINA_AI_API_KEY}",
+        "GEMINI_API_KEY": "${user_config.GEMINI_API_KEY}",
+        "OPENAI_API_KEY": "${user_config.OPENAI_API_KEY}",
+        "COHERE_API_KEY": "${user_config.COHERE_API_KEY}"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add GEMINI_API_KEY, OPENAI_API_KEY, COHERE_API_KEY to .claude-plugin/plugin.json userConfig + mcpServers.mnemo.env.
- Was missing 3 of 4 provider fields declared in src/mnemo_mcp/relay_schema.py — now 1:1 parity.

## Test plan
- [x] pre-commit hooks pass
- [ ] CI green