### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Per-Subject Directories

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import hashlib
 import json
 import os
 import sys
@@ -301,12 +302,14 @@ def _schedule_spawn_cleanup(grace_s: float = _SPAWN_CLEANUP_S) -> None:
 def _sub_data_dir(sub: str) -> Path:
     """Return per-subject data dir for multi-user remote mode.
 
-    Layout: ``$MNEMO_DATA_DIR/subs/<sub>/`` (default base
+    Layout: ``$MNEMO_DATA_DIR/subs/<hashed_sub>/`` (default base
     ``~/.mnemo-mcp``). Each per-authorize JWT ``sub`` gets its own
-    directory so credentials never bleed across users.
+    directory so credentials never bleed across users. The sub is hashed to
+    prevent path traversal vulnerabilities.
     """
     base = Path(os.environ.get("MNEMO_DATA_DIR", str(Path.home() / ".mnemo-mcp")))
-    d = base / "subs" / sub
+    safe_sub = hashlib.sha256(sub.encode("utf-8")).hexdigest()
+    d = base / "subs" / safe_sub
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -14,6 +14,7 @@ Token lifecycle:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import stat
@@ -40,13 +41,15 @@ def get_token_path(provider: str) -> Path:
 
 
 def _get_token_dir_for_sub(sub: str) -> Path:
-    """Per-sub token directory (``$MNEMO_DATA_DIR/subs/<sub>/tokens``).
+    """Per-sub token directory (``$MNEMO_DATA_DIR/subs/<hashed_sub>/tokens``).
 
     Multi-user remote mode (``PUBLIC_URL`` set) keys every artifact by
     JWT ``sub`` so user A's GDrive refresh-token is not visible to
-    user B sharing the same mnemo-mcp deployment.
+    user B sharing the same mnemo-mcp deployment. The sub is hashed to
+    prevent path traversal vulnerabilities.
     """
-    return settings.get_data_dir() / "subs" / sub / "tokens"
+    safe_sub = hashlib.sha256(sub.encode("utf-8")).hexdigest()
+    return settings.get_data_dir() / "subs" / safe_sub / "tokens"
 
 
 def get_token_path_for_sub(sub: str, provider: str) -> Path:

--- a/tests/test_credential_state_multi_user.py
+++ b/tests/test_credential_state_multi_user.py
@@ -7,6 +7,8 @@ counts toward the default coverage gate.
 
 from __future__ import annotations
 
+import hashlib
+
 import pytest
 
 
@@ -15,7 +17,8 @@ def test_sub_data_dir_creates_path(tmp_path, monkeypatch):
     from mnemo_mcp.credential_state import _sub_data_dir
 
     d = _sub_data_dir("sub_xyz")
-    assert d == tmp_path / "subs" / "sub_xyz"
+    expected_hash = hashlib.sha256(b"sub_xyz").hexdigest()
+    assert d == tmp_path / "subs" / expected_hash
     assert d.exists() and d.is_dir()
 
 

--- a/tests/test_token_store_per_sub.py
+++ b/tests/test_token_store_per_sub.py
@@ -26,8 +26,6 @@ def data_dir(tmp_path):
         yield tmp_path
 
 
-
-
 class TestPerSubPaths:
     def test_token_dir_for_sub_uses_subs_layout(self, data_dir):
         from mnemo_mcp.token_store import _get_token_dir_for_sub
@@ -41,7 +39,9 @@ class TestPerSubPaths:
 
         path = get_token_path_for_sub("sub-abc", "google_drive")
         expected_hash = hashlib.sha256(b"sub-abc").hexdigest()
-        assert path == data_dir / "subs" / expected_hash / "tokens" / "google_drive.json"
+        assert (
+            path == data_dir / "subs" / expected_hash / "tokens" / "google_drive.json"
+        )
 
 
 class TestSaveTokenForSub:

--- a/tests/test_token_store_per_sub.py
+++ b/tests/test_token_store_per_sub.py
@@ -8,6 +8,7 @@ path layout.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import stat
@@ -25,18 +26,22 @@ def data_dir(tmp_path):
         yield tmp_path
 
 
+
+
 class TestPerSubPaths:
     def test_token_dir_for_sub_uses_subs_layout(self, data_dir):
         from mnemo_mcp.token_store import _get_token_dir_for_sub
 
         path = _get_token_dir_for_sub("sub-abc")
-        assert path == data_dir / "subs" / "sub-abc" / "tokens"
+        expected_hash = hashlib.sha256(b"sub-abc").hexdigest()
+        assert path == data_dir / "subs" / expected_hash / "tokens"
 
     def test_token_path_for_sub_includes_provider(self, data_dir):
         from mnemo_mcp.token_store import get_token_path_for_sub
 
         path = get_token_path_for_sub("sub-abc", "google_drive")
-        assert path == data_dir / "subs" / "sub-abc" / "tokens" / "google_drive.json"
+        expected_hash = hashlib.sha256(b"sub-abc").hexdigest()
+        assert path == data_dir / "subs" / expected_hash / "tokens" / "google_drive.json"
 
 
 class TestSaveTokenForSub:


### PR DESCRIPTION
Fixes a path traversal vulnerability in the multi-user remote mode where the user-supplied \`sub\` (subject) string from the JWT was used directly to construct file system paths for credentials and token storage. By hashing the \`sub\` string with SHA-256, directory names are guaranteed to be safe, fixed-length, and non-traversable.

---
*PR created automatically by Jules for task [17887547952576012611](https://jules.google.com/task/17887547952576012611) started by @n24q02m*