### PR TITLE
[TEST] Untested Cloud Reranker API error fallback

### DIFF
--- a/tests/test_reranker_error_fallback.py
+++ b/tests/test_reranker_error_fallback.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from mnemo_mcp.reranker import CloudReranker
+
+
+class TestCloudRerankerErrorFallback:
+    def test_rerank_jina_exception_logs_and_returns_empty(self):
+        """Verify that an exception in _rerank_jina is caught, logged, and returns []."""
+        with patch("mnemo_mcp.reranker.CloudReranker._rerank_jina") as mock_jina:
+            mock_jina.side_effect = Exception("Mock Jina Failure")
+            reranker = CloudReranker(model="jina-reranker-v3")
+
+            with patch("mnemo_mcp.reranker.logger") as mock_logger:
+                results = reranker.rerank("test query", ["doc1"])
+
+                assert results == []
+                mock_logger.warning.assert_called_once()
+                args, _ = mock_logger.warning.call_args
+                assert "Cloud reranking failed (jina): Mock Jina Failure" in args[0]
+
+    def test_rerank_cohere_exception_logs_and_returns_empty(self):
+        """Verify that an exception in _rerank_cohere is caught, logged, and returns []."""
+        with patch("mnemo_mcp.reranker.CloudReranker._rerank_cohere") as mock_cohere:
+            mock_cohere.side_effect = Exception("Mock Cohere Failure")
+            reranker = CloudReranker(model="rerank-v4.0-pro")
+
+            with patch("mnemo_mcp.reranker.logger") as mock_logger:
+                results = reranker.rerank("test query", ["doc1"])
+
+                assert results == []
+                mock_logger.warning.assert_called_once()
+                args, _ = mock_logger.warning.call_args
+                assert "Cloud reranking failed (cohere): Mock Cohere Failure" in args[0]


### PR DESCRIPTION
Added `tests/test_reranker_error_fallback.py` to verify that `CloudReranker.rerank`
correctly handles exceptions from both Jina and Cohere providers by logging
a warning and returning an empty list.

The tests use mocking to simulate provider failures and verify the resilience
of the reranking pipeline.

---
*PR created automatically by Jules for task [1049664982649114336](https://jules.google.com/task/1049664982649114336) started by @n24q02m*