### PR TITLE
[CLEANUP] Unused check_embedding_available function

### DIFF
--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -565,11 +565,3 @@ async def embed_single(
     """Embed a single text (legacy interface)."""
     backend = CloudEmbeddingBackend(model, api_base=api_base, api_key=api_key)
     return await backend.embed_single(text, dimensions)
-
-
-def check_embedding_available(
-    model: str, api_base: str | None = None, api_key: str | None = None
-) -> int:
-    """Check if an embedding model is available (legacy interface)."""
-    backend = CloudEmbeddingBackend(model, api_base=api_base, api_key=api_key)
-    return backend.check_available()

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -8,7 +8,6 @@ from mnemo_mcp.embedder import (
     CloudEmbeddingBackend,
     LiteLLMBackend,
     Qwen3EmbedBackend,
-    check_embedding_available,
     embed_single,
     get_backend,
     init_backend,
@@ -425,13 +424,3 @@ class TestLegacyCompat:
 
         result = await embed_single("test", "embed-multilingual-v3.0", api_key="key")
         assert result == [0.1, 0.2]
-
-    @patch("cohere.ClientV2")
-    def test_check_available_legacy(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        assert check_embedding_available("embed-multilingual-v3.0", api_key="key") == 1


### PR DESCRIPTION
This PR removes the `check_embedding_available` function from `src/mnemo_mcp/embedder.py`. 
The function was explicitly marked as a legacy interface and a search of the codebase confirmed it was no longer in use.
The associated test case `test_check_available_legacy` in `tests/test_embedder.py` was also removed to keep the test suite clean.

---
*PR created automatically by Jules for task [15957092571996167716](https://jules.google.com/task/15957092571996167716) started by @n24q02m*