### PR TITLE
[TEST] Missing try/catch coverage for bad dates in _calc_recency

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -558,7 +558,7 @@ class MemoryDB:
             updated = datetime.fromisoformat(updated_at)
             days_old = (now - updated).total_seconds() / 86400
             return 2.0 ** (-days_old / self._recency_half_life)
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, TypeError):
             return 0.0
 
     def _calc_frequency(self, access_count: int) -> float:

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -528,7 +528,7 @@ class TestScoringEdgeCases:
         now = datetime.now(UTC)
 
         # Test with None
-        assert tmp_db._calc_recency(None, now) == 0.0  # type: ignore[arg-type]
+        assert tmp_db._calc_recency(None, now) == 0.0  # ty: ignore[invalid-argument-type]
 
         # Test with naive datetime string
         assert tmp_db._calc_recency("2023-01-01T00:00:00", now) == 0.0

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -520,3 +520,15 @@ class TestScoringEdgeCases:
         results = tmp_db.search("frequent memory")
         assert len(results) > 0
         assert results[0]["score"] > 0
+
+    def test_recency_type_error_handling(self, tmp_db: MemoryDB):
+        """TypeError in _calc_recency is handled (returns 0.0)."""
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+
+        # Test with None
+        assert tmp_db._calc_recency(None, now) == 0.0  # type: ignore[arg-type]
+
+        # Test with naive datetime string
+        assert tmp_db._calc_recency("2023-01-01T00:00:00", now) == 0.0


### PR DESCRIPTION
Modified _calc_recency in src/mnemo_mcp/db.py to catch TypeError, which can occur when updated_at is None or when there is a mismatch between offset-aware and offset-naive datetimes. Added test_recency_type_error_handling to tests/test_db_coverage.py to verify that these cases return a 0.0 recency score gracefully.

---
*PR created automatically by Jules for task [5268439075973371577](https://jules.google.com/task/5268439075973371577) started by @n24q02m*