### PR TITLE
[FIX] Unused import 'llama_cpp' in config.py

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -1,6 +1,7 @@
 """Configuration settings for Mnemo MCP Server."""
 
 import functools
+import importlib.util
 import os
 from pathlib import Path
 
@@ -30,12 +31,7 @@ def _detect_gpu() -> bool:
 @functools.lru_cache(maxsize=1)
 def _has_gguf_support() -> bool:
     """Check if llama-cpp-python is installed for GGUF models."""
-    try:
-        import llama_cpp  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("llama_cpp") is not None
 
 
 def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -422,13 +422,13 @@ class TestDetectGPU:
 class TestHasGGUFSupport:
     def test_llama_cpp_installed(self):
         _has_gguf_support.cache_clear()
-        mock_llama = MagicMock()
-        with patch.dict(sys.modules, {"llama_cpp": mock_llama}):
+        with patch("importlib.util.find_spec", return_value=MagicMock()):
             assert _has_gguf_support() is True
 
     def test_llama_cpp_missing(self):
         _has_gguf_support.cache_clear()
-        with patch.dict(sys.modules, {"llama_cpp": None}):
+        with patch("importlib.util.find_spec", return_value=None):
+            assert _has_gguf_support() is False
             assert _has_gguf_support() is False
 
 


### PR DESCRIPTION
Modified `_has_gguf_support` in `src/mnemo_mcp/config.py` to use `importlib.util.find_spec` instead of a try-except import block. This fixes the Ruff F401 (unused import) warning while maintaining the same functionality for detecting optional GGUF support. Updated `tests/test_config.py` to mock `find_spec` directly.

---
*PR created automatically by Jules for task [6281444300432823887](https://jules.google.com/task/6281444300432823887) started by @n24q02m*