### PR TITLE
[CLEANUP] Unused async_delete_token function

### DIFF
--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -205,8 +205,3 @@ async def async_save_token_for_sub(sub: str, provider: str, token: dict) -> None
 async def async_load_token_for_sub(sub: str, provider: str) -> dict | None:
     """Load per-sub OAuth token asynchronously."""
     return await asyncio.to_thread(load_token_for_sub, sub, provider)
-
-
-async def async_delete_token(provider: str) -> bool:
-    """Delete a stored token asynchronously."""
-    return await asyncio.to_thread(delete_token, provider)

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -283,13 +283,3 @@ class TestAsyncTokenStore:
 
         saved = json.loads((token_dir / "async_drive_save.json").read_text())
         assert saved["access_token"] == "async_save"
-
-    @pytest.mark.asyncio
-    async def test_async_delete_existing(self, token_dir):
-        from mnemo_mcp.token_store import async_delete_token
-
-        (token_dir / "async_delete.json").write_text("{}")
-        with patch("mnemo_mcp.token_store.settings") as m:
-            m.get_data_dir.return_value = token_dir.parent
-            assert await async_delete_token("async_delete") is True
-        assert not (token_dir / "async_delete.json").exists()


### PR DESCRIPTION
The async_delete_token function in src/mnemo_mcp/token_store.py was an unused async wrapper around delete_token. This commit removes the function and its associated test case to clean up the codebase.

---
*PR created automatically by Jules for task [4896569025217346615](https://jules.google.com/task/4896569025217346615) started by @n24q02m*