### PR TITLE
[CLEANUP] Unused async_load_token_for_sub function

### DIFF
--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -202,11 +202,6 @@ async def async_save_token_for_sub(sub: str, provider: str, token: dict) -> None
     await asyncio.to_thread(save_token_for_sub, sub, provider, token)
 
 
-async def async_load_token_for_sub(sub: str, provider: str) -> dict | None:
-    """Load per-sub OAuth token asynchronously."""
-    return await asyncio.to_thread(load_token_for_sub, sub, provider)
-
-
 async def async_delete_token(provider: str) -> bool:
     """Delete a stored token asynchronously."""
     return await asyncio.to_thread(delete_token, provider)

--- a/tests/test_token_store_per_sub.py
+++ b/tests/test_token_store_per_sub.py
@@ -203,18 +203,18 @@ class TestLoadTokenForSub:
 
 
 class TestAsyncTokenForSub:
-    """async_save_token_for_sub / async_load_token_for_sub thin wrappers."""
+    """async_save_token_for_sub thin wrapper."""
 
     async def test_round_trip(self, data_dir):
         from mnemo_mcp.token_store import (
-            async_load_token_for_sub,
             async_save_token_for_sub,
+            load_token_for_sub,
         )
 
         await async_save_token_for_sub(
             "async-user", "google_drive", {"access_token": "tok"}
         )
-        result = await async_load_token_for_sub("async-user", "google_drive")
+        result = load_token_for_sub("async-user", "google_drive")
         assert result == {"access_token": "tok"}
 
 


### PR DESCRIPTION
Removed the unused `async_load_token_for_sub` function from `src/mnemo_mcp/token_store.py` and updated the corresponding tests in `tests/test_token_store_per_sub.py`. Verified that the remaining per-subject token storage logic is functional.

---
*PR created automatically by Jules for task [8812047953097257577](https://jules.google.com/task/8812047953097257577) started by @n24q02m*