### PR TITLE
[FIX] Unused import 'mcp' in __init__.py

### DIFF
--- a/src/mnemo_mcp/__init__.py
+++ b/src/mnemo_mcp/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import version
 
-from mnemo_mcp.server import main, mcp
+from mnemo_mcp.server import main
 
 __version__ = version("mnemo-mcp")
-__all__ = ["mcp", "main", "__version__"]
+__all__ = ["main", "__version__"]


### PR DESCRIPTION
Removed the unused 'mcp' (FastMCP instance) import and export from 'src/mnemo_mcp/__init__.py'. Verified that 'main' and '__version__' remain available while 'mcp' is no longer exposed at the package root.

---
*PR created automatically by Jules for task [18329838338361370456](https://jules.google.com/task/18329838338361370456) started by @n24q02m*