### PR TITLE
[TEST] Missing error test for SQLite column addition failure

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -766,3 +766,51 @@ def test_invalid_embedding_dims_bounds(tmp_path):
         assert json.loads(mem["tags"]) == ["t2"]
         assert mem["source"] == "new source"
         assert mem["importance"] == 0.1
+
+
+class TestDBMigration:
+    def test_migration_importance_column_already_exists(self, tmp_path):
+        """
+        Test that MemoryDB handles the case where the 'importance' column already exists.
+        This exercises the try-except block in _init_memory_schema.
+        """
+        import sqlite3
+
+        db_path = tmp_path / "test_migration.db"
+
+        # Manually create the table with the 'importance' column already present
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE memories (
+                id TEXT PRIMARY KEY NOT NULL,
+                content TEXT NOT NULL,
+                category TEXT NOT NULL DEFAULT 'general',
+                tags TEXT NOT NULL DEFAULT '[]',
+                source TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                access_count INTEGER NOT NULL DEFAULT 0,
+                last_accessed TEXT NOT NULL,
+                importance REAL NOT NULL DEFAULT 0.5
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # Initializing MemoryDB should not raise an exception even if the column exists
+        db = MemoryDB(db_path)
+        # Verify it works by adding a memory
+        mid = db.add("test content")
+        mem = db.get(mid)
+        assert mem["importance"] == 0.5
+        db.close()
+
+    def test_migration_idempotent(self, tmp_db):
+        """
+        Verify that _init_memory_schema can be called multiple times without error.
+        """
+        # Already initialized by fixture
+        try:
+            tmp_db._init_memory_schema()
+        except Exception as e:
+            pytest.fail(f"_init_memory_schema failed on redundant call: {e}")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -802,6 +802,7 @@ class TestDBMigration:
         # Verify it works by adding a memory
         mid = db.add("test content")
         mem = db.get(mid)
+        assert mem is not None
         assert mem["importance"] == 0.5
         db.close()
 


### PR DESCRIPTION
Added TestDBMigration class to tests/test_db.py to verify that MemoryDB gracefully handles scenarios where the 'importance' column already exists during schema initialization. This ensures the try-except block in _init_memory_schema is correctly exercised and prevents regressions during database migrations. Verified using a standalone test runner that mocks missing environment dependencies.

---
*PR created automatically by Jules for task [9296968766696070628](https://jules.google.com/task/9296968766696070628) started by @n24q02m*