### PR TITLE
[CLEANUP] Unused set_gdrive_failed_callback function

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -104,27 +104,6 @@ _on_gdrive_complete: Callable[[], None] | None = None
 _on_gdrive_failed: Callable[[str, str], None] | None = None
 
 
-def set_gdrive_complete_callback(cb: Callable[[], None]) -> None:
-    """Set callback for when GDrive OAuth completes (used by HTTP server)."""
-    global _on_gdrive_complete
-    _on_gdrive_complete = cb
-
-
-def set_gdrive_failed_callback(cb: Callable[[str, str], None]) -> None:
-    """Set callback for when GDrive OAuth fails upstream (used by HTTP server).
-
-    The callback receives ``(key, error_message)`` matching the
-    ``mark_setup_failed(key, error)`` signature exposed by mcp-core's local
-    OAuth app. It is invoked by ``_gdrive_token_poll`` whenever Google
-    returns a terminal error (``invalid_grant``, ``expired_token``,
-    ``access_denied``, etc.) or when the local ``save_token`` call raises
-    after a successful exchange -- so the browser's ``/setup-status`` poll
-    surfaces the error and stops waiting.
-    """
-    global _on_gdrive_failed
-    _on_gdrive_failed = cb
-
-
 def wire_gdrive_callbacks(
     mark_complete: Callable[[], None],
     mark_failed: Callable[..., None] | None = None,
@@ -152,9 +131,8 @@ def wire_gdrive_callbacks(
         finally:
             _schedule_spawn_cleanup()
 
-    set_gdrive_complete_callback(_complete_then_cleanup)
-
-    global _on_gdrive_failed
+    global _on_gdrive_complete, _on_gdrive_failed
+    _on_gdrive_complete = _complete_then_cleanup
 
     if mark_failed is None:
         _on_gdrive_failed = None

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -243,15 +243,6 @@ class TestGDriveFailedCallback:
     """Covers set_gdrive_failed_callback + wire_gdrive_callbacks + _notify_failed
     paths added for Bug #2 fix (ported from wet-mcp)."""
 
-    def test_set_gdrive_failed_callback_registers(self):
-        import mnemo_mcp.credential_state as cs
-        from mnemo_mcp.credential_state import set_gdrive_failed_callback
-
-        cb = MagicMock()
-        set_gdrive_failed_callback(cb)
-        assert cs._on_gdrive_failed is cb
-        cs._on_gdrive_failed = None
-
     def test_wire_gdrive_callbacks_legacy_one_arg(self):
         """Legacy mcp-core (<1.3.0) passes only mark_complete; mark_failed stays None."""
         import mnemo_mcp.credential_state as cs
@@ -313,13 +304,10 @@ class TestGDriveTokenPoll:
         """save_token raising after successful exchange -> WARNING log + notify
         failed callback + return (no retry; device_code cannot be re-exchanged)."""
         import mnemo_mcp.credential_state as cs
-        from mnemo_mcp.credential_state import (
-            _gdrive_token_poll,
-            set_gdrive_failed_callback,
-        )
+        from mnemo_mcp.credential_state import _gdrive_token_poll
 
         failed_cb = MagicMock()
-        set_gdrive_failed_callback(failed_cb)
+        cs._on_gdrive_failed = failed_cb
 
         token_response = MagicMock()
         token_response.json.return_value = {
@@ -353,13 +341,10 @@ class TestGDriveTokenPoll:
     async def test_terminal_google_error_notifies(self):
         """Terminal Google error (invalid_grant, access_denied) -> notify + return."""
         import mnemo_mcp.credential_state as cs
-        from mnemo_mcp.credential_state import (
-            _gdrive_token_poll,
-            set_gdrive_failed_callback,
-        )
+        from mnemo_mcp.credential_state import _gdrive_token_poll
 
         failed_cb = MagicMock()
-        set_gdrive_failed_callback(failed_cb)
+        cs._on_gdrive_failed = failed_cb
 
         response = MagicMock()
         response.json.return_value = {
@@ -383,13 +368,10 @@ class TestGDriveTokenPoll:
     async def test_deadline_expired_notifies(self):
         """Loop exits via deadline without success -> notify with 'expired'."""
         import mnemo_mcp.credential_state as cs
-        from mnemo_mcp.credential_state import (
-            _gdrive_token_poll,
-            set_gdrive_failed_callback,
-        )
+        from mnemo_mcp.credential_state import _gdrive_token_poll
 
         failed_cb = MagicMock()
-        set_gdrive_failed_callback(failed_cb)
+        cs._on_gdrive_failed = failed_cb
 
         # expires_in = 0 -> loop body is never entered, deadline branch fires.
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -404,13 +386,10 @@ class TestGDriveTokenPoll:
     async def test_notify_failed_swallows_callback_exception(self):
         """If _on_gdrive_failed raises, the helper logs and does not propagate."""
         import mnemo_mcp.credential_state as cs
-        from mnemo_mcp.credential_state import (
-            _gdrive_token_poll,
-            set_gdrive_failed_callback,
-        )
+        from mnemo_mcp.credential_state import _gdrive_token_poll
 
         failed_cb = MagicMock(side_effect=RuntimeError("callback boom"))
-        set_gdrive_failed_callback(failed_cb)
+        cs._on_gdrive_failed = failed_cb
 
         # Terminal error triggers _notify_failed which catches callback errors.
         with patch("httpx.AsyncClient") as mock_client_cls:
@@ -426,16 +405,12 @@ class TestGDriveTokenPoll:
     async def test_success_fires_complete_callback_no_failed(self):
         """Happy path: access_token -> save_token OK -> complete_cb fired, failed_cb NOT."""
         import mnemo_mcp.credential_state as cs
-        from mnemo_mcp.credential_state import (
-            _gdrive_token_poll,
-            set_gdrive_complete_callback,
-            set_gdrive_failed_callback,
-        )
+        from mnemo_mcp.credential_state import _gdrive_token_poll
 
         complete_cb = MagicMock()
         failed_cb = MagicMock()
-        set_gdrive_complete_callback(complete_cb)
-        set_gdrive_failed_callback(failed_cb)
+        cs._on_gdrive_complete = complete_cb
+        cs._on_gdrive_failed = failed_cb
 
         response = MagicMock()
         response.json.return_value = {"access_token": "tok"}


### PR DESCRIPTION
Removed the unused `set_gdrive_failed_callback` function and the redundant `set_gdrive_complete_callback` from `src/mnemo_mcp/credential_state.py`. Refactored `wire_gdrive_callbacks` to assign the module-level callback variables directly, simplifying the code. Updated unit tests in `tests/test_credential_state.py` to match the new implementation.

---
*PR created automatically by Jules for task [2579329587585054250](https://jules.google.com/task/2579329587585054250) started by @n24q02m*