### PR TITLE
[CLEANUP] Unused archive_old_memories function

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -910,51 +910,6 @@ class MemoryDB:
             logger.info(f"[AUDIT] import count={imported} mode={mode}")
         return {"imported": imported, "skipped": skipped, "rejected": rejected}
 
-    def archive_old_memories(
-        self, days: int = 90, importance_threshold: float = 0.3
-    ) -> int:
-        """Move old, low-importance memories to archive. Returns count archived."""
-        cursor = self._conn.cursor()
-
-        # Precompute the cutoff timestamp once so SQLite does not re-evaluate
-        # datetime('now', ...) for every row in the WHERE clause.
-        cutoff_date = cursor.execute(
-            "SELECT datetime('now', ?)", (f"-{days} days",)
-        ).fetchone()[0]
-
-        rows = cursor.execute(
-            """SELECT id, content, category, tags, source, importance,
-                      created_at, updated_at, access_count, last_accessed
-               FROM memories
-               WHERE last_accessed < ? AND importance < ?""",
-            (cutoff_date, importance_threshold),
-        ).fetchall()
-
-        if not rows:
-            return 0
-
-        now = _now_iso()
-
-        insert_data = [(*row, now) for row in rows]
-        delete_data = [(row[0],) for row in rows]
-
-        cursor.executemany(
-            """INSERT OR REPLACE INTO archived_memories
-               (id, content, category, tags, source, importance,
-                created_at, updated_at, access_count, last_accessed, archived_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            insert_data,
-        )
-        cursor.executemany(
-            "DELETE FROM memories WHERE id = ?",
-            delete_data,
-        )
-
-        count = len(rows)
-        self._conn.commit()
-        logger.info(f"[AUDIT] archived count={count}")
-        return count
-
     def restore_memory(self, memory_id: str) -> bool:
         """Restore archived memory back to active."""
         cursor = self._conn.cursor()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -598,47 +598,17 @@ class TestImportanceColumn:
 
 
 class TestArchive:
-    def test_archive_old_memories(self, tmp_db: MemoryDB):
-        # Add a memory with old last_accessed
-        mid = tmp_db.add("old memory", category="test")
-        tmp_db._conn.execute(
-            "UPDATE memories SET last_accessed = datetime('now', '-100 days'), importance = 0.1 WHERE id = ?",
-            (mid,),
-        )
-        tmp_db._conn.commit()
-
-        count = tmp_db.archive_old_memories(days=90, importance_threshold=0.3)
-        assert count == 1
-        assert tmp_db.get(mid) is None  # Removed from active
-
-    def test_archive_keeps_recent(self, tmp_db: MemoryDB):
-        mid = tmp_db.add("recent memory")
-        count = tmp_db.archive_old_memories(days=90, importance_threshold=0.3)
-        assert count == 0
-        assert tmp_db.get(mid) is not None
-
-    def test_archive_keeps_important(self, tmp_db: MemoryDB):
-        mid = tmp_db.add("important memory")
-        tmp_db.update_importance(mid, 0.9)
-        tmp_db._conn.execute(
-            "UPDATE memories SET last_accessed = datetime('now', '-100 days') WHERE id = ?",
-            (mid,),
-        )
-        tmp_db._conn.commit()
-
-        count = tmp_db.archive_old_memories(days=90, importance_threshold=0.3)
-        assert count == 0
-        assert tmp_db.get(mid) is not None
-
     def test_restore_memory(self, tmp_db: MemoryDB):
-        mid = tmp_db.add("to archive")
+        # Manually insert into archived_memories
+        mid = "test-archive-id"
+        now = "2024-01-01T00:00:00Z"
         tmp_db._conn.execute(
-            "UPDATE memories SET last_accessed = datetime('now', '-100 days'), importance = 0.1 WHERE id = ?",
-            (mid,),
+            """INSERT INTO archived_memories
+               (id, content, category, tags, source, importance, created_at, updated_at, access_count, last_accessed, archived_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (mid, "to archive", "general", "[]", None, 0.1, now, now, 0, now, now),
         )
         tmp_db._conn.commit()
-
-        tmp_db.archive_old_memories(days=90, importance_threshold=0.3)
         assert tmp_db.get(mid) is None
 
         ok = tmp_db.restore_memory(mid)
@@ -652,16 +622,29 @@ class TestArchive:
         assert ok is False
 
     def test_list_archived(self, tmp_db: MemoryDB):
-        mid1 = tmp_db.add("old1")
-        mid2 = tmp_db.add("old2")
-        for mid in (mid1, mid2):
+        now = "2024-01-01T00:00:00Z"
+        for i in range(2):
+            mid = f"old{i}"
             tmp_db._conn.execute(
-                "UPDATE memories SET last_accessed = datetime('now', '-100 days'), importance = 0.1 WHERE id = ?",
-                (mid,),
+                """INSERT INTO archived_memories
+                   (id, content, category, tags, source, importance, created_at, updated_at, access_count, last_accessed, archived_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    mid,
+                    f"old content {i}",
+                    "general",
+                    "[]",
+                    None,
+                    0.1,
+                    now,
+                    now,
+                    0,
+                    now,
+                    now,
+                ),
             )
         tmp_db._conn.commit()
 
-        tmp_db.archive_old_memories(days=90, importance_threshold=0.3)
         archived = tmp_db.list_archived()
         assert len(archived) == 2
         assert all("archived_at" in a for a in archived)
@@ -671,15 +654,29 @@ class TestArchive:
         assert tmp_db.list_archived() == []
 
     def test_list_archived_limit(self, tmp_db: MemoryDB):
+        now = "2024-01-01T00:00:00Z"
         for i in range(5):
-            mid = tmp_db.add(f"old {i}")
+            mid = f"limit{i}"
             tmp_db._conn.execute(
-                "UPDATE memories SET last_accessed = datetime('now', '-100 days'), importance = 0.1 WHERE id = ?",
-                (mid,),
+                """INSERT INTO archived_memories
+                   (id, content, category, tags, source, importance, created_at, updated_at, access_count, last_accessed, archived_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    mid,
+                    f"old content {i}",
+                    "general",
+                    "[]",
+                    None,
+                    0.1,
+                    now,
+                    now,
+                    0,
+                    now,
+                    now,
+                ),
             )
         tmp_db._conn.commit()
 
-        tmp_db.archive_old_memories(days=90, importance_threshold=0.3)
         archived = tmp_db.list_archived(limit=2)
         assert len(archived) == 2
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -256,12 +256,25 @@ class TestMemoryRestore:
     async def test_restore(self, ctx_with_db):
         ctx, db = ctx_with_db
         mid = db.add("to archive and restore")
+        mid = "test-restore-id"
+        now = "2024-01-01T00:00:00Z"
         db._conn.execute(
-            "UPDATE memories SET last_accessed = datetime('now', '-100 days'), importance = 0.1 WHERE id = ?",
-            (mid,),
+            "INSERT INTO archived_memories (id, content, category, tags, source, importance, created_at, updated_at, access_count, last_accessed, archived_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                mid,
+                "to archive and restore",
+                "general",
+                "[]",
+                None,
+                0.1,
+                now,
+                now,
+                0,
+                now,
+                now,
+            ),
         )
         db._conn.commit()
-        db.archive_old_memories(days=90, importance_threshold=0.3)
         assert db.get(mid) is None
 
         result = json.loads(await memory(action="restore", memory_id=mid, ctx=ctx))
@@ -291,13 +304,13 @@ class TestMemoryArchived:
 
     async def test_archived_with_data(self, ctx_with_db):
         ctx, db = ctx_with_db
-        mid = db.add("old memory")
+        mid = "test-archived-data-id"
+        now = "2024-01-01T00:00:00Z"
         db._conn.execute(
-            "UPDATE memories SET last_accessed = datetime('now', '-100 days'), importance = 0.1 WHERE id = ?",
-            (mid,),
+            "INSERT INTO archived_memories (id, content, category, tags, source, importance, created_at, updated_at, access_count, last_accessed, archived_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (mid, "old memory", "general", "[]", None, 0.1, now, now, 0, now, now),
         )
         db._conn.commit()
-        db.archive_old_memories(days=90, importance_threshold=0.3)
 
         result = json.loads(await memory(action="archived", ctx=ctx))
         assert result["count"] == 1
@@ -320,10 +333,12 @@ class TestMemoryConsolidate:
         assert "LLM" in result["error"]
 
     async def test_consolidate_no_category(self, ctx_with_db):
-        ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="consolidate", ctx=ctx))
-        assert "error" in result
-        assert "suggestion" in result
+        ctx, db = ctx_with_db
+        with patch("mnemo_mcp.server.settings") as mock_settings:
+            mock_settings.resolve_provider_mode.return_value = "sdk"
+            result = json.loads(await memory(action="consolidate", ctx=ctx))
+            assert "error" in result
+            assert "suggestion" in result
 
 
 class TestMemoryUnknownAction:


### PR DESCRIPTION
This PR removes the unused `archive_old_memories` function from the `MemoryDB` class in `src/mnemo_mcp/db.py`. 

Key changes:
- Deleted the `archive_old_memories` method.
- Updated unit tests in `tests/test_db.py` and `tests/test_server.py` to use direct SQL `INSERT` statements into the `archived_memories` table instead of relying on the removed function for test setup.
- Fixed a minor bug in `tests/test_server.py::TestMemoryConsolidate::test_consolidate_no_category` where a mock was missing, causing a test failure.

Verification:
- Ran `pytest` for `tests/test_db.py` and `tests/test_server.py` using a mock environment to bypass local dependency issues. All 157 tests passed.
- Verified linting and formatting with `ruff`.

---
*PR created automatically by Jules for task [9218951324103969043](https://jules.google.com/task/9218951324103969043) started by @n24q02m*