### PR TITLE
[CLEANUP] Remove unused recent_resource function

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ mcp-name: io.github.n24q02m/mnemo-mcp
 | URI | Description |
 |:----|:------------|
 | `mnemo://stats` | Database statistics and server status |
-| `mnemo://recent` | 10 most recently updated memories |
 
 ### MCP Prompts
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -4,7 +4,7 @@ MCP Interface:
 - memory tool: add/search/list/update/delete/export/import/stats
 - config tool: status/sync/set/warmup/setup_sync
 - help tool: full documentation on demand
-- Resources: mnemo://stats, mnemo://recent
+- Resources: mnemo://stats
 - Prompts: save_summary, recall_context
 """
 
@@ -1308,14 +1308,6 @@ async def stats_resource(ctx: Context | None = None) -> str:
     s["embedding_model"] = embedding_model
     s["sync_enabled"] = settings.sync_enabled
     return _json(s)
-
-
-@mcp.resource("mnemo://recent")
-async def recent_resource(ctx: Context | None = None) -> str:
-    """10 most recently updated memories."""
-    db, _, _ = _get_ctx(ctx)
-    results = await asyncio.to_thread(db.list_memories, limit=10)
-    return _json(results)
 
 
 # --- Prompts ---

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -2,7 +2,7 @@
 
 Targets: _embed backend is None, _format_memory tags parse error,
 config sync action, config set sync_interval, config set generic,
-stats_resource, recent_resource, main function, _init_embedding_backend
+stats_resource, main function, _init_embedding_backend
 candidate exception.
 """
 
@@ -21,7 +21,6 @@ from mnemo_mcp.server import (
     config,
     main,
     memory,
-    recent_resource,
     stats_resource,
 )
 
@@ -179,14 +178,6 @@ class TestResources:
         assert result["total_memories"] == 1
         assert "embedding_model" in result
         assert "sync_enabled" in result
-
-    async def test_recent_resource(self, ctx_with_db):
-        """recent_resource returns recent memories."""
-        ctx, db = ctx_with_db
-        db.add("memory 1")
-        db.add("memory 2")
-        result = json.loads(await recent_resource(ctx=ctx))
-        assert len(result) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR removes the `recent_resource` function and its associated MCP resource `mnemo://recent` from the server. The function was identified as unused.

Changes:
- Deleted `recent_resource` and `@mcp.resource("mnemo://recent")` from `src/mnemo_mcp/server.py`.
- Removed `mnemo://recent` from the module-level docstring in `src/mnemo_mcp/server.py`.
- Removed the `mnemo://recent` entry from the `MCP Resources` table in `README.md`.
- Removed the `test_recent_resource` test case and its import from `tests/test_server_coverage.py`.
- Verified that no references to the resource or function remain in the codebase.
- Ran core tests with mocked dependencies to ensure no regressions.

---
*PR created automatically by Jules for task [13766399306220741602](https://jules.google.com/task/13766399306220741602) started by @n24q02m*