### PR TITLE
[PERF] Synchronous httpx.post inside check_jina

### DIFF
--- a/src/mnemo_mcp/reranker.py
+++ b/src/mnemo_mcp/reranker.py
@@ -6,6 +6,7 @@ for better precision. Pipeline: retrieve top-N*3 -> rerank -> return top-N.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Protocol
 
@@ -37,7 +38,7 @@ def _strip_provider(model: str) -> str:
 class RerankerBackend(Protocol):
     """Protocol for reranker backends."""
 
-    def rerank(
+    async def rerank(
         self, query: str, documents: list[str], top_n: int = 10
     ) -> list[tuple[int, float]]:
         """Rerank documents by relevance to query.
@@ -46,7 +47,7 @@ class RerankerBackend(Protocol):
         """
         ...
 
-    def check_available(self) -> bool:
+    async def check_available(self) -> bool:
         """Check if the reranker backend is available."""
         ...
 
@@ -66,7 +67,7 @@ class CloudReranker:
         self._provider = _detect_rerank_provider(self.model)
         self._bare_model = _strip_provider(self.model)
 
-    def rerank(
+    async def rerank(
         self, query: str, documents: list[str], top_n: int = 10
     ) -> list[tuple[int, float]]:
         """Rerank documents via cloud API (Jina or Cohere)."""
@@ -74,13 +75,13 @@ class CloudReranker:
             return []
         try:
             if self._provider == "jina":
-                return self._rerank_jina(query, documents, top_n)
-            return self._rerank_cohere(query, documents, top_n)
+                return await self._rerank_jina(query, documents, top_n)
+            return await self._rerank_cohere(query, documents, top_n)
         except Exception as e:
             logger.warning(f"Cloud reranking failed ({self._provider}): {e}")
             return []
 
-    def _rerank_jina(
+    async def _rerank_jina(
         self, query: str, documents: list[str], top_n: int
     ) -> list[tuple[int, float]]:
         """Rerank via Jina AI REST API."""
@@ -94,15 +95,16 @@ class CloudReranker:
             "top_n": top_n,
         }
 
-        response = httpx.post(
-            "https://api.jina.ai/v1/rerank",
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {key}",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.jina.ai/v1/rerank",
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=60,
+            )
         response.raise_for_status()
         data = response.json()["results"]
 
@@ -112,7 +114,7 @@ class CloudReranker:
         results.sort(key=lambda x: x[1], reverse=True)
         return results[:top_n]
 
-    def _rerank_cohere(
+    async def _rerank_cohere(
         self, query: str, documents: list[str], top_n: int
     ) -> list[tuple[int, float]]:
         """Rerank via Cohere SDK."""
@@ -121,8 +123,8 @@ class CloudReranker:
         key = (
             self.api_key or os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or ""
         )
-        client = cohere.ClientV2(api_key=key)
-        response = client.rerank(
+        client = cohere.AsyncClientV2(api_key=key)
+        response = await client.rerank(
             model=self._bare_model,
             query=query,
             documents=documents,
@@ -137,12 +139,12 @@ class CloudReranker:
         results.sort(key=lambda x: x[1], reverse=True)
         return results[:top_n]
 
-    def check_available(self) -> bool:
+    async def check_available(self) -> bool:
         """Check if the cloud reranker model is reachable."""
         try:
             if self._provider == "jina":
-                return self._check_jina()
-            return self._check_cohere()
+                return await self._check_jina()
+            return await self._check_cohere()
         except Exception as e:
             msg = str(e).lower()
             if any(
@@ -153,37 +155,38 @@ class CloudReranker:
                 logger.debug(f"Reranker {self.model} not available: {e}")
             return False
 
-    def _check_jina(self) -> bool:
+    async def _check_jina(self) -> bool:
         """Check Jina reranker availability."""
         import httpx
 
         key = self.api_key or os.getenv("JINA_AI_API_KEY") or ""
-        response = httpx.post(
-            "https://api.jina.ai/v1/rerank",
-            json={
-                "model": self._bare_model,
-                "query": "test",
-                "documents": ["test"],
-                "top_n": 1,
-            },
-            headers={
-                "Authorization": f"Bearer {key}",
-                "Content-Type": "application/json",
-            },
-            timeout=30,
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.jina.ai/v1/rerank",
+                json={
+                    "model": self._bare_model,
+                    "query": "test",
+                    "documents": ["test"],
+                    "top_n": 1,
+                },
+                headers={
+                    "Authorization": f"Bearer {key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=30,
+            )
         response.raise_for_status()
         return bool(response.json().get("results"))
 
-    def _check_cohere(self) -> bool:
+    async def _check_cohere(self) -> bool:
         """Check Cohere reranker availability."""
         import cohere
 
         key = (
             self.api_key or os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or ""
         )
-        client = cohere.ClientV2(api_key=key)
-        response = client.rerank(
+        client = cohere.AsyncClientV2(api_key=key)
+        response = await client.rerank(
             model=self._bare_model,
             query="test",
             documents=["test"],
@@ -192,7 +195,6 @@ class CloudReranker:
         return bool(response.results)
 
 
-# Backward compatibility aliases
 CohereReranker = CloudReranker
 LiteLLMReranker = CloudReranker
 
@@ -222,36 +224,40 @@ class Qwen3Reranker:
             logger.info("Local reranker model loaded")
         return self._model
 
-    def rerank(
+    async def rerank(
         self, query: str, documents: list[str], top_n: int = 10
     ) -> list[tuple[int, float]]:
         """Rerank documents using local cross-encoder."""
         if not documents:
             return []
-        try:
+
+        def _rerank():
             model = self._get_model()
             scores = list(model.rerank(query, documents))
             results = list(enumerate(scores))
             results.sort(key=lambda x: x[1], reverse=True)
             return results[:top_n]
+
+        try:
+            return await asyncio.to_thread(_rerank)
         except Exception as e:
             logger.warning(f"Local reranking failed: {e}")
             return []
 
-    def check_available(self) -> bool:
+    async def check_available(self) -> bool:
         """Check if the local reranker model is available."""
-        try:
+
+        def _check():
             model = self._get_model()
             scores = list(model.rerank("test", ["test document"]))
             return len(scores) > 0
+
+        try:
+            return await asyncio.to_thread(_check)
         except Exception as e:
             logger.debug(f"Local reranker not available: {e}")
             return False
 
-
-# ---------------------------------------------------------------------------
-# Factory + module-level state
-# ---------------------------------------------------------------------------
 
 _backend: RerankerBackend | None = None
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -146,7 +146,7 @@ async def _init_reranker_backend(mode: str) -> None:
         local_model = settings.resolve_local_rerank_model()
         try:
             backend = await asyncio.to_thread(init_reranker, "local", local_model)
-            available = await asyncio.to_thread(backend.check_available)
+            available = await backend.check_available()
             if available:
                 logger.info(f"Reranker: local {local_model}")
             else:
@@ -161,7 +161,7 @@ async def _init_reranker_backend(mode: str) -> None:
         if model:
             try:
                 backend = await asyncio.to_thread(init_reranker, "cloud", model)
-                available = await asyncio.to_thread(backend.check_available)
+                available = await backend.check_available()
                 if available:
                     logger.info(f"Reranker: {model}")
                     return
@@ -478,9 +478,7 @@ async def _handle_search(
     if reranker and len(results) > 1:
         documents = [r["content"] for r in results]
         try:
-            ranked = await asyncio.to_thread(
-                reranker.rerank, query, documents, top_n=limit
-            )
+            ranked = await reranker.rerank(query, documents, top_n=limit)
             if ranked:
                 reranked_results = []
                 for idx, score in ranked:

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,6 +1,6 @@
 """Tests for mnemo_mcp.reranker -- dual-backend reranking."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -25,7 +25,8 @@ def _reset_reranker_backend():
 
 
 class TestCohereReranker:
-    def test_rerank_success(self):
+    @pytest.mark.asyncio
+    async def test_rerank_success(self):
         """Cohere reranker returns sorted (index, score) tuples."""
         reranker = CohereReranker(api_key="test-key")
 
@@ -44,18 +45,21 @@ class TestCohereReranker:
         mock_response = MagicMock()
         mock_response.results = [mock_result_0, mock_result_1, mock_result_2]
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
+        with patch("cohere.AsyncClientV2") as mock_client_cls:
+            mock_client = AsyncMock()
             mock_client.rerank.return_value = mock_response
             mock_client_cls.return_value = mock_client
 
-            results = reranker.rerank("test query", ["doc0", "doc1", "doc2"], top_n=2)
+            results = await reranker.rerank(
+                "test query", ["doc0", "doc1", "doc2"], top_n=2
+            )
 
         assert len(results) == 2
         assert results[0] == (1, 0.9)
         assert results[1] == (2, 0.6)
 
-    def test_rerank_with_dict_results(self):
+    @pytest.mark.asyncio
+    async def test_rerank_with_dict_results(self):
         """Cohere reranker handles dict-style results."""
         reranker = CohereReranker(api_key="test-key")
 
@@ -65,70 +69,75 @@ class TestCohereReranker:
             {"index": 1, "relevance_score": 0.5},
         ]
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
+        with patch("cohere.AsyncClientV2") as mock_client_cls:
+            mock_client = AsyncMock()
             mock_client.rerank.return_value = mock_response
             mock_client_cls.return_value = mock_client
 
-            results = reranker.rerank("query", ["doc0", "doc1"])
+            results = await reranker.rerank("query", ["doc0", "doc1"])
 
         assert results[0] == (0, 0.8)
         assert results[1] == (1, 0.5)
 
-    def test_rerank_empty_docs(self):
+    @pytest.mark.asyncio
+    async def test_rerank_empty_docs(self):
         """Empty documents list returns empty results."""
         reranker = CohereReranker(api_key="test-key")
-        results = reranker.rerank("query", [])
+        results = await reranker.rerank("query", [])
         assert results == []
 
-    def test_rerank_failure_returns_empty(self):
+    @pytest.mark.asyncio
+    async def test_rerank_failure_returns_empty(self):
         """Reranker returns empty list on failure (never raises)."""
         reranker = CohereReranker(api_key="test-key")
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
+        with patch("cohere.AsyncClientV2") as mock_client_cls:
+            mock_client = AsyncMock()
             mock_client.rerank.side_effect = Exception("API error")
             mock_client_cls.return_value = mock_client
 
-            results = reranker.rerank("query", ["doc"])
+            results = await reranker.rerank("query", ["doc"])
 
         assert results == []
 
-    def test_check_available_success(self):
+    @pytest.mark.asyncio
+    async def test_check_available_success(self):
         """check_available returns True when API responds."""
         reranker = CohereReranker(api_key="test-key")
 
         mock_response = MagicMock()
         mock_response.results = [MagicMock()]
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
+        with patch("cohere.AsyncClientV2") as mock_client_cls:
+            mock_client = AsyncMock()
             mock_client.rerank.return_value = mock_response
             mock_client_cls.return_value = mock_client
 
-            assert reranker.check_available() is True
+            assert await reranker.check_available() is True
 
-    def test_check_available_failure(self):
+    @pytest.mark.asyncio
+    async def test_check_available_failure(self):
         """check_available returns False on API failure."""
         reranker = CohereReranker(api_key="test-key")
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
+        with patch("cohere.AsyncClientV2") as mock_client_cls:
+            mock_client = AsyncMock()
             mock_client.rerank.side_effect = Exception("connection error")
             mock_client_cls.return_value = mock_client
 
-            assert reranker.check_available() is False
+            assert await reranker.check_available() is False
 
-    def test_check_available_auth_error(self):
+    @pytest.mark.asyncio
+    async def test_check_available_auth_error(self):
         """check_available logs warning for auth errors."""
         reranker = CohereReranker(api_key="bad-key")
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
+        with patch("cohere.AsyncClientV2") as mock_client_cls:
+            mock_client = AsyncMock()
             mock_client.rerank.side_effect = Exception("401 unauthorized")
             mock_client_cls.return_value = mock_client
 
-            assert reranker.check_available() is False
+            assert await reranker.check_available() is False
 
     def test_litellm_backward_compat_alias(self):
         """LiteLLMReranker is an alias for CloudReranker."""
@@ -140,7 +149,8 @@ class TestCohereReranker:
 
 
 class TestQwen3Reranker:
-    def test_rerank_success(self):
+    @pytest.mark.asyncio
+    async def test_rerank_success(self):
         """Local reranker returns sorted (index, score) tuples."""
         reranker = Qwen3Reranker()
 
@@ -148,19 +158,21 @@ class TestQwen3Reranker:
         mock_model.rerank.return_value = [0.3, 0.9, 0.6]
 
         with patch.object(reranker, "_get_model", return_value=mock_model):
-            results = reranker.rerank("query", ["doc0", "doc1", "doc2"], top_n=2)
+            results = await reranker.rerank("query", ["doc0", "doc1", "doc2"], top_n=2)
 
         assert len(results) == 2
         assert results[0] == (1, 0.9)
         assert results[1] == (2, 0.6)
 
-    def test_rerank_empty_docs(self):
+    @pytest.mark.asyncio
+    async def test_rerank_empty_docs(self):
         """Empty documents list returns empty results."""
         reranker = Qwen3Reranker()
-        results = reranker.rerank("query", [])
+        results = await reranker.rerank("query", [])
         assert results == []
 
-    def test_rerank_failure_returns_empty(self):
+    @pytest.mark.asyncio
+    async def test_rerank_failure_returns_empty(self):
         """Local reranker returns empty list on failure."""
         reranker = Qwen3Reranker()
 
@@ -168,11 +180,12 @@ class TestQwen3Reranker:
         mock_model.rerank.side_effect = RuntimeError("ONNX error")
 
         with patch.object(reranker, "_get_model", return_value=mock_model):
-            results = reranker.rerank("query", ["doc"])
+            results = await reranker.rerank("query", ["doc"])
 
         assert results == []
 
-    def test_check_available_success(self):
+    @pytest.mark.asyncio
+    async def test_check_available_success(self):
         """check_available returns True when model loads."""
         reranker = Qwen3Reranker()
 
@@ -180,16 +193,17 @@ class TestQwen3Reranker:
         mock_model.rerank.return_value = [0.5]
 
         with patch.object(reranker, "_get_model", return_value=mock_model):
-            assert reranker.check_available() is True
+            assert await reranker.check_available() is True
 
-    def test_check_available_failure(self):
+    @pytest.mark.asyncio
+    async def test_check_available_failure(self):
         """check_available returns False when model fails."""
         reranker = Qwen3Reranker()
 
         with patch.object(
             reranker, "_get_model", side_effect=ImportError("no qwen3_embed")
         ):
-            assert reranker.check_available() is False
+            assert await reranker.check_available() is False
 
     def test_custom_model_name(self):
         """Custom model name is stored."""

--- a/tests/test_reranker_coverage.py
+++ b/tests/test_reranker_coverage.py
@@ -5,7 +5,7 @@ _strip_provider, CloudReranker Jina backend, CloudReranker._check_jina,
 CloudReranker._check_cohere, Qwen3Reranker lazy load.
 """
 
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 

--- a/tests/test_reranker_coverage.py
+++ b/tests/test_reranker_coverage.py
@@ -5,7 +5,9 @@ _strip_provider, CloudReranker Jina backend, CloudReranker._check_jina,
 CloudReranker._check_cohere, Qwen3Reranker lazy load.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
 
 from mnemo_mcp.reranker import (
     CloudReranker,
@@ -57,8 +59,9 @@ class TestStripProviderReranker:
 
 
 class TestCloudRerankerJina:
-    @patch("httpx.post")
-    def test_rerank_jina_success(self, mock_post):
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_rerank_jina_success(self, mock_client_cls):
         """Jina reranker returns sorted results."""
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -70,28 +73,37 @@ class TestCloudRerankerJina:
                 {"index": 2, "relevance_score": 0.6},
             ]
         }
-        mock_post.return_value = mock_response
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
 
         reranker = CloudReranker(
             model="jina_ai/jina-reranker-v3",
             api_key="jina_test",
         )
-        results = reranker.rerank("query", ["doc0", "doc1", "doc2"], top_n=2)
+        results = await reranker.rerank("query", ["doc0", "doc1", "doc2"], top_n=2)
 
         assert len(results) == 2
         assert results[0] == (1, 0.9)
         assert results[1] == (2, 0.6)
 
-    @patch("httpx.post")
-    def test_rerank_jina_failure(self, mock_post):
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_rerank_jina_failure(self, mock_client_cls):
         """Jina reranker returns empty on failure."""
-        mock_post.side_effect = Exception("API error")
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(side_effect=Exception("API error"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
 
         reranker = CloudReranker(
             model="jina_ai/jina-reranker-v3",
             api_key="jina_test",
         )
-        results = reranker.rerank("query", ["doc0"])
+        results = await reranker.rerank("query", ["doc0"])
         assert results == []
 
 
@@ -101,35 +113,46 @@ class TestCloudRerankerJina:
 
 
 class TestCheckAvailableReranker:
-    @patch("httpx.post")
-    def test_check_jina_available(self, mock_post):
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_check_jina_available(self, mock_client_cls):
         """Jina check_available returns True on success."""
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = {
             "results": [{"index": 0, "relevance_score": 0.5}]
         }
-        mock_post.return_value = mock_response
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
 
         reranker = CloudReranker(
             model="jina_ai/jina-reranker-v3",
             api_key="jina_test",
         )
-        assert reranker.check_available() is True
+        assert await reranker.check_available() is True
 
-    @patch("httpx.post")
-    def test_check_jina_api_key_invalid(self, mock_post):
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_check_jina_api_key_invalid(self, mock_client_cls):
         """Jina check_available returns False and logs warning on 401."""
-        mock_post.side_effect = Exception("401 Unauthorized")
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(side_effect=Exception("401 Unauthorized"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
 
         reranker = CloudReranker(
             model="jina_ai/jina-reranker-v3",
             api_key="bad_key",
         )
-        assert reranker.check_available() is False
+        assert await reranker.check_available() is False
 
-    @patch("cohere.ClientV2")
-    def test_check_cohere_available(self, mock_client_cls):
+    @pytest.mark.asyncio
+    @patch("cohere.AsyncClientV2")
+    async def test_check_cohere_available(self, mock_client_cls):
         """Cohere check_available returns True on success."""
         mock_result = MagicMock()
         mock_result.index = 0
@@ -138,7 +161,7 @@ class TestCheckAvailableReranker:
         mock_response = MagicMock()
         mock_response.results = [mock_result]
 
-        mock_client = MagicMock()
+        mock_client = AsyncMock()
         mock_client.rerank.return_value = mock_response
         mock_client_cls.return_value = mock_client
 
@@ -146,10 +169,11 @@ class TestCheckAvailableReranker:
             model="rerank-v4.0-pro",
             api_key="co_test",
         )
-        assert reranker.check_available() is True
+        assert await reranker.check_available() is True
 
-    @patch("cohere.ClientV2")
-    def test_check_cohere_non_auth_error(self, mock_client_cls):
+    @pytest.mark.asyncio
+    @patch("cohere.AsyncClientV2")
+    async def test_check_cohere_non_auth_error(self, mock_client_cls):
         """Cohere check_available returns False on non-auth error."""
         mock_client = MagicMock()
         mock_client.rerank.side_effect = Exception("Model not found")
@@ -159,7 +183,7 @@ class TestCheckAvailableReranker:
             model="rerank-v4.0-pro",
             api_key="co_test",
         )
-        assert reranker.check_available() is False
+        assert await reranker.check_available() is False
 
 
 # ---------------------------------------------------------------------------
@@ -193,11 +217,12 @@ class TestQwen3RerankerLazyLoad:
 
         mock_ce.assert_called_once()
 
-    def test_check_available_empty_scores(self):
+    @pytest.mark.asyncio
+    async def test_check_available_empty_scores(self):
         """check_available returns False when rerank returns empty."""
         reranker = Qwen3Reranker()
         mock_model = MagicMock()
         mock_model.rerank.return_value = []
 
         with patch.object(reranker, "_get_model", return_value=mock_model):
-            assert reranker.check_available() is False
+            assert await reranker.check_available() is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -549,7 +549,7 @@ class TestSearchRerankerAndGraph:
         db.add("Python for AI")
         db.add("Python for web")
         db.add("Python for data")
-        mock_reranker = MagicMock()
+        mock_reranker = AsyncMock()
         mock_reranker.rerank.return_value = [(1, 0.95), (0, 0.85), (2, 0.70)]
         with patch("mnemo_mcp.reranker.get_reranker", return_value=mock_reranker):
             result = json.loads(

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -317,7 +317,7 @@ class TestInitRerankerBackend:
         mock_settings.resolve_local_rerank_model.return_value = "local/r"
 
         mock_backend = MagicMock()
-        mock_backend.check_available.return_value = False
+        mock_backend.check_available = AsyncMock(return_value=False)
         mock_init.return_value = mock_backend
 
         with patch("mnemo_mcp.server.logger") as mock_logger:

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -53,7 +53,7 @@ class TestInitRerankerBackend:
         mock_settings.resolve_rerank_model.return_value = "rerank-v4.0-pro"
 
         mock_backend = MagicMock()
-        mock_backend.check_available.return_value = True
+        mock_backend.check_available = AsyncMock(return_value=True)
 
         with patch("mnemo_mcp.reranker.init_reranker", return_value=mock_backend):
             await _init_reranker_backend("sdk")
@@ -71,7 +71,7 @@ class TestInitRerankerBackend:
         mock_settings.resolve_rerank_model.return_value = "rerank-v4.0-pro"
 
         cloud_backend = MagicMock()
-        cloud_backend.check_available.return_value = False
+        cloud_backend.check_available = AsyncMock(return_value=False)
 
         call_count = 0
 
@@ -132,7 +132,7 @@ class TestInitRerankerBackend:
         mock_settings.resolve_local_rerank_model.return_value = "local/reranker"
 
         local_backend = MagicMock()
-        local_backend.check_available.return_value = False
+        local_backend.check_available = AsyncMock(return_value=False)
 
         with patch("mnemo_mcp.reranker.init_reranker", return_value=local_backend):
             await _init_reranker_backend("local")


### PR DESCRIPTION
Refactored the reranker architecture to be fully asynchronous. This optimization replaces blocking synchronous HTTP calls with non-blocking async calls using httpx.AsyncClient and cohere.AsyncClientV2. Local reranking is wrapped in asyncio.to_thread to maintain event loop responsiveness. All call sites in server.py and relevant unit tests have been updated to support the new async interface.

---
*PR created automatically by Jules for task [15138420371515535155](https://jules.google.com/task/15138420371515535155) started by @n24q02m*