### PR TITLE
[CLEANUP] Unused read_for_sub function

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -81,7 +81,8 @@ def credentials_for_current_request() -> dict[str, str]:
     sub = _current_sub.get()
     if sub is None:
         return {k: v for k, v in os.environ.items() if k in CLOUD_KEYS and v}
-    return read_for_sub(sub)
+    p = _sub_data_dir(sub) / "config.json"
+    return json.loads(p.read_text()) if p.exists() else {}
 
 
 class CredentialState(Enum):
@@ -317,12 +318,6 @@ def _sub_data_dir(sub: str) -> Path:
 def store_for_sub(sub: str, config: dict[str, str]) -> None:
     """Persist a config dict for a single JWT subject (multi-user remote mode)."""
     (_sub_data_dir(sub) / "config.json").write_text(json.dumps(config))
-
-
-def read_for_sub(sub: str) -> dict[str, str]:
-    """Load the config dict for a single JWT subject (empty if missing)."""
-    p = _sub_data_dir(sub) / "config.json"
-    return json.loads(p.read_text()) if p.exists() else {}
 
 
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:

--- a/tests/integration/test_multi_user_remote.py
+++ b/tests/integration/test_multi_user_remote.py
@@ -5,27 +5,41 @@ from __future__ import annotations
 import pytest
 
 
+def _read_for_sub(sub: str) -> dict[str, str]:
+    from mnemo_mcp.credential_state import _current_sub, credentials_for_current_request
+
+    token = _current_sub.set(sub)
+    try:
+        return credentials_for_current_request()
+    finally:
+        _current_sub.reset(token)
+
+
 @pytest.mark.integration
 def test_two_subs_isolated(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
-    from mnemo_mcp.credential_state import read_for_sub, store_for_sub
+    from mnemo_mcp.credential_state import (
+        store_for_sub,
+    )
 
     store_for_sub("user_a", {"JINA_AI_API_KEY": "key_a"})
     store_for_sub("user_b", {"JINA_AI_API_KEY": "key_b"})
 
-    assert read_for_sub("user_a") == {"JINA_AI_API_KEY": "key_a"}
-    assert read_for_sub("user_b") == {"JINA_AI_API_KEY": "key_b"}
-    assert read_for_sub("user_a") != read_for_sub("user_b")
+    assert _read_for_sub("user_a") == {"JINA_AI_API_KEY": "key_a"}
+    assert _read_for_sub("user_b") == {"JINA_AI_API_KEY": "key_b"}
+    assert _read_for_sub("user_a") != _read_for_sub("user_b")
 
 
 @pytest.mark.integration
 def test_save_credentials_uses_sub_when_public_url_set(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example.com")
-    from mnemo_mcp.credential_state import read_for_sub, save_credentials
+    from mnemo_mcp.credential_state import (
+        save_credentials,
+    )
 
     save_credentials({"JINA_AI_API_KEY": "k1"}, {"sub": "user_a"})
     save_credentials({"JINA_AI_API_KEY": "k2"}, {"sub": "user_b"})
 
-    assert read_for_sub("user_a")["JINA_AI_API_KEY"] == "k1"
-    assert read_for_sub("user_b")["JINA_AI_API_KEY"] == "k2"
+    assert _read_for_sub("user_a")["JINA_AI_API_KEY"] == "k1"
+    assert _read_for_sub("user_b")["JINA_AI_API_KEY"] == "k2"

--- a/tests/test_credential_state_multi_user.py
+++ b/tests/test_credential_state_multi_user.py
@@ -12,6 +12,16 @@ import hashlib
 import pytest
 
 
+def _read_for_sub(sub: str) -> dict[str, str]:
+    from mnemo_mcp.credential_state import _current_sub, credentials_for_current_request
+
+    token = _current_sub.set(sub)
+    try:
+        return credentials_for_current_request()
+    finally:
+        _current_sub.reset(token)
+
+
 def test_sub_data_dir_creates_path(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
     from mnemo_mcp.credential_state import _sub_data_dir
@@ -24,20 +34,21 @@ def test_sub_data_dir_creates_path(tmp_path, monkeypatch):
 
 def test_store_and_read_for_sub_round_trip(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
-    from mnemo_mcp.credential_state import read_for_sub, store_for_sub
+    from mnemo_mcp.credential_state import (
+        store_for_sub,
+    )
 
     store_for_sub("alice", {"JINA_AI_API_KEY": "key_a"})
     store_for_sub("bob", {"JINA_AI_API_KEY": "key_b"})
 
-    assert read_for_sub("alice") == {"JINA_AI_API_KEY": "key_a"}
-    assert read_for_sub("bob") == {"JINA_AI_API_KEY": "key_b"}
+    assert _read_for_sub("alice") == {"JINA_AI_API_KEY": "key_a"}
+    assert _read_for_sub("bob") == {"JINA_AI_API_KEY": "key_b"}
 
 
 def test_read_for_sub_missing_returns_empty(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
-    from mnemo_mcp.credential_state import read_for_sub
 
-    assert read_for_sub("never_seen") == {}
+    assert _read_for_sub("never_seen") == {}
 
 
 def test_save_credentials_multi_user_branch(tmp_path, monkeypatch):
@@ -50,12 +61,14 @@ def test_save_credentials_multi_user_branch(tmp_path, monkeypatch):
     monkeypatch.setattr(s, "google_drive_client_id", "", raising=False)
     monkeypatch.setattr(s, "google_drive_client_secret", "", raising=False)
 
-    from mnemo_mcp.credential_state import read_for_sub, save_credentials
+    from mnemo_mcp.credential_state import (
+        save_credentials,
+    )
 
     result = save_credentials({"JINA_AI_API_KEY": "k1"}, {"sub": "alice"})
 
     assert result is None
-    assert read_for_sub("alice")["JINA_AI_API_KEY"] == "k1"
+    assert _read_for_sub("alice")["JINA_AI_API_KEY"] == "k1"
 
 
 def test_save_credentials_multi_user_requires_sub(tmp_path, monkeypatch):


### PR DESCRIPTION
This PR removes the `read_for_sub` function in `src/mnemo_mcp/credential_state.py` as it was considered unused dead code.

Changes:
- Inlined the logic of `read_for_sub` into its only production caller, `credentials_for_current_request`.
- Removed the standalone `read_for_sub` function from `src/mnemo_mcp/credential_state.py`.
- Updated `tests/test_credential_state_multi_user.py` and `tests/integration/test_multi_user_remote.py` to use a local helper that bridges to the public `credentials_for_current_request` API, ensuring that per-subject configuration loading is still thoroughly tested without relying on private function exports.
- Verified changes with `ruff` for linting and formatting compliance.

---
*PR created automatically by Jules for task [11958689374537699210](https://jules.google.com/task/11958689374537699210) started by @n24q02m*