### PR TITLE
[SECURITY] Path Traversal in _sub_data_dir via JWT sub Claim

### DIFF
--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -1,0 +1,37 @@
+import hashlib
+
+from mnemo_mcp.credential_state import _sub_data_dir
+from mnemo_mcp.token_store import _get_token_dir_for_sub
+
+
+def test_credential_state_sub_path_traversal(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+
+    # Malicious sub
+    malicious_sub = "../../../outside"
+    d = _sub_data_dir(malicious_sub)
+
+    # Verification
+    expected_hash = hashlib.sha256(malicious_sub.encode("utf-8")).hexdigest()
+    assert d == tmp_path / "subs" / expected_hash
+    assert "outside" not in str(d)
+    assert ".." not in str(d)
+    # Check it is truly under the expected base
+    assert str(d).startswith(str(tmp_path / "subs"))
+
+
+def test_token_store_sub_path_traversal(tmp_path, monkeypatch):
+    from mnemo_mcp.config import settings
+
+    monkeypatch.setattr(settings, "get_data_dir", lambda: tmp_path)
+
+    # Malicious sub
+    malicious_sub = "../../../outside"
+    d = _get_token_dir_for_sub(malicious_sub)
+
+    # Verification
+    expected_hash = hashlib.sha256(malicious_sub.encode("utf-8")).hexdigest()
+    assert d == tmp_path / "subs" / expected_hash / "tokens"
+    assert "outside" not in str(d)
+    assert ".." not in str(d)
+    assert str(d).startswith(str(tmp_path / "subs"))

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -23,7 +23,11 @@ def test_credential_state_sub_path_traversal(tmp_path, monkeypatch):
 def test_token_store_sub_path_traversal(tmp_path, monkeypatch):
     from mnemo_mcp.config import settings
 
-    monkeypatch.setattr(settings, "get_data_dir", lambda: tmp_path)
+    # We must not monkeypatch methods on Pydantic models with validate_assignment=True.
+    # Instead, we set the field that the method depends on.
+    # Settings.get_data_dir() returns Settings.get_db_path().parent.
+    # Settings.get_db_path() returns Path(Settings.db_path) if set.
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "fake" / "memories.db"))
 
     # Malicious sub
     malicious_sub = "../../../outside"
@@ -31,7 +35,8 @@ def test_token_store_sub_path_traversal(tmp_path, monkeypatch):
 
     # Verification
     expected_hash = hashlib.sha256(malicious_sub.encode("utf-8")).hexdigest()
-    assert d == tmp_path / "subs" / expected_hash / "tokens"
+    # d should be tmp_path / "fake" / "subs" / expected_hash / "tokens"
+    assert d == tmp_path / "fake" / "subs" / expected_hash / "tokens"
     assert "outside" not in str(d)
     assert ".." not in str(d)
-    assert str(d).startswith(str(tmp_path / "subs"))
+    assert str(d).startswith(str(tmp_path / "fake" / "subs"))


### PR DESCRIPTION
This PR adds a regression test to verify the fix for a path traversal vulnerability in `_sub_data_dir` (src/mnemo_mcp/credential_state.py) and `_get_token_dir_for_sub` (src/mnemo_mcp/token_store.py).

The vulnerability existed when unsanitized JWT `sub` claims were used directly in path construction. The fix, which is already present in the codebase, involves hashing the `sub` claim using SHA-256. This ensures that any malicious input (such as `../` sequences) is transformed into a safe, fixed-length hex string, effectively preventing directory traversal.

### Changes:
- Added `tests/test_security_path_traversal.py` with regression tests for both affected functions.
- Verified that the SHA-256 hashing correctly sanitizes malicious `sub` inputs.

---
*PR created automatically by Jules for task [2579329587585052877](https://jules.google.com/task/2579329587585052877) started by @n24q02m*