### PR TITLE
[FIX] Overly complex memory function

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -345,13 +345,13 @@ async def _embed(
 
 
 async def _handle_add(
-    db: MemoryDB,
+    ctx: Context | None,
     content: str | None,
-    category: str | None,
-    tags: list[str] | None,
-    embedding_model: str | None,
-    embedding_dims: int,
+    category: str | None = None,
+    tags: list[str] | None = None,
 ) -> str:
+    db, embedding_model, embedding_dims = _get_ctx(ctx)
+
     if not content:
         return _json(
             {
@@ -440,14 +440,14 @@ async def _enrich_memory(db: MemoryDB, memory_id: str, content: str) -> None:
 
 
 async def _handle_search(
-    db: MemoryDB,
+    ctx: Context | None,
     query: str | None,
-    category: str | None,
-    tags: list[str] | None,
-    limit: int,
-    embedding_model: str | None,
-    embedding_dims: int,
+    category: str | None = None,
+    tags: list[str] | None = None,
+    limit: int = 5,
 ) -> str:
+    db, embedding_model, embedding_dims = _get_ctx(ctx)
+
     if not query:
         return _json(
             {
@@ -456,6 +456,8 @@ async def _handle_search(
                 "suggestion": "Provide the 'query' parameter to perform a search.",
             }
         )
+
+    db, _, _ = _get_ctx(ctx)
 
     if isinstance(limit, int):
         limit = max(1, min(limit, 100))
@@ -527,10 +529,12 @@ async def _handle_search(
 
 
 async def _handle_list(
-    db: MemoryDB,
-    category: str | None,
-    limit: int,
+    ctx: Context | None,
+    category: str | None = None,
+    limit: int = 5,
 ) -> str:
+    db, _, _ = _get_ctx(ctx)
+
     if isinstance(limit, int):
         limit = max(1, min(limit, 100))
 
@@ -556,16 +560,18 @@ async def _handle_list(
 
 
 async def _handle_update(
-    db: MemoryDB,
+    ctx: Context | None,
     memory_id: str | None,
-    content: str | None,
-    category: str | None,
-    tags: list[str] | None,
-    source: str | None,
-    importance: float | None,
-    embedding_model: str | None,
-    embedding_dims: int,
+    content: str | None = None,
+    category: str | None = None,
+    tags: list[str] | None = None,
+    source: str | None = None,
+    importance: float | None = None,
 ) -> str:
+
+    db, _, _ = _get_ctx(ctx)
+    db, embedding_model, embedding_dims = _get_ctx(ctx)
+
     if not memory_id:
         return _json(
             {
@@ -609,9 +615,12 @@ async def _handle_update(
 
 
 async def _handle_delete(
-    db: MemoryDB,
+    ctx: Context | None,
     memory_id: str | None,
 ) -> str:
+
+    db, _, _ = _get_ctx(ctx)
+
     if not memory_id:
         return _json(
             {
@@ -632,9 +641,8 @@ async def _handle_delete(
     )
 
 
-async def _handle_export(
-    db: MemoryDB,
-) -> str:
+async def _handle_export(ctx: Context | None) -> str:
+    db, _, _ = _get_ctx(ctx)
     jsonl, count = await asyncio.to_thread(db.export_jsonl)
     return _json(
         {
@@ -646,10 +654,12 @@ async def _handle_export(
 
 
 async def _handle_import(
-    db: MemoryDB,
+    ctx: Context | None,
     data: str | list | None,
-    mode: str,
+    mode: str = "merge",
 ) -> str:
+    db, _, _ = _get_ctx(ctx)
+
     if not data:
         return _json(
             {
@@ -670,11 +680,8 @@ async def _handle_import(
     )
 
 
-async def _handle_stats(
-    db: MemoryDB,
-    embedding_model: str | None,
-    embedding_dims: int,
-) -> str:
+async def _handle_stats(ctx: Context | None) -> str:
+    db, embedding_model, embedding_dims = _get_ctx(ctx)
     s = await asyncio.to_thread(db.stats)
     s["embedding_model"] = embedding_model
     s["embedding_dims"] = embedding_dims
@@ -684,9 +691,12 @@ async def _handle_stats(
 
 
 async def _handle_restore(
-    db: MemoryDB,
+    ctx: Context | None,
     memory_id: str | None,
 ) -> str:
+
+    db, _, _ = _get_ctx(ctx)
+
     if not memory_id:
         return _json(
             {
@@ -708,9 +718,11 @@ async def _handle_restore(
 
 
 async def _handle_archived(
-    db: MemoryDB,
-    limit: int,
+    ctx: Context | None,
+    limit: int = 5,
 ) -> str:
+    db, _, _ = _get_ctx(ctx)
+
     if isinstance(limit, int):
         limit = max(1, min(limit, 100))
 
@@ -727,10 +739,11 @@ async def _handle_archived(
 
 
 async def _handle_consolidate(
-    db: MemoryDB,
-    category: str | None,
+    ctx: Context | None,
+    category: str | None = None,
 ) -> str:
     """Consolidate similar memories in a category using LLM summarization."""
+    db, _, _ = _get_ctx(ctx)
     from mnemo_mcp.graph import _has_llm_provider
 
     mode = settings.resolve_provider_mode()
@@ -796,8 +809,165 @@ async def _handle_consolidate(
 
 
 @mcp.tool(
+    description="Store NEW information. Use for preferences, decisions, facts.",
+    annotations=ToolAnnotations(
+        title="Add Memory",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def add_memory(
+    content: str,
+    category: str | None = None,
+    tags: list[str] | None = None,
+    ctx: Context | None = None,
+) -> str:
+    return await _handle_add(ctx, content, category, tags)
+
+
+@mcp.tool(
+    description="Find existing memories by natural language query. Always search before adding.",
+    annotations=ToolAnnotations(
+        title="Search Memory",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
+async def search_memory(
+    query: str,
+    category: str | None = None,
+    tags: list[str] | None = None,
+    limit: int = 5,
+    ctx: Context | None = None,
+) -> str:
+    return await _handle_search(ctx, query, category, tags, limit)
+
+
+@mcp.tool(
+    description="Browse all memories, optionally filtered by category.",
+    annotations=ToolAnnotations(
+        title="List Memories",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
+async def list_memories(
+    category: str | None = None, limit: int = 5, ctx: Context | None = None
+) -> str:
+    return await _handle_list(ctx, category, limit)
+
+
+@mcp.tool(
+    description="Modify an EXISTING memory by ID. Get memory_id from search results.",
+    annotations=ToolAnnotations(
+        title="Update Memory",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def update_memory(
+    memory_id: str,
+    content: str | None = None,
+    category: str | None = None,
+    tags: list[str] | None = None,
+    source: str | None = None,
+    importance: float | None = None,
+    ctx: Context | None = None,
+) -> str:
+    return await _handle_update(
+        ctx, memory_id, content, category, tags, source, importance
+    )
+
+
+@mcp.tool(
+    description="Remove a memory by ID.",
+    annotations=ToolAnnotations(
+        title="Delete Memory",
+        readOnlyHint=False,
+        destructiveHint=True,
+    ),
+)
+async def delete_memory(memory_id: str, ctx: Context | None = None) -> str:
+    return await _handle_delete(ctx, memory_id)
+
+
+@mcp.tool(
+    description="Export all memories as JSONL.",
+    annotations=ToolAnnotations(
+        title="Export Memories",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def export_memories(ctx: Context | None = None) -> str:
+    return await _handle_export(ctx)
+
+
+@mcp.tool(
+    description="Import memories from JSONL data or a list of objects.",
+    annotations=ToolAnnotations(
+        title="Import Memories",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def import_memories(
+    data: str | list, mode: str = "merge", ctx: Context | None = None
+) -> str:
+    return await _handle_import(ctx, data, mode)
+
+
+@mcp.tool(
+    description="Show database statistics (total memories, categories, embedding status).",
+    annotations=ToolAnnotations(
+        title="Memory Stats",
+        readOnlyHint=True,
+        destructiveHint=False,
+    ),
+)
+async def memory_stats(ctx: Context | None = None) -> str:
+    return await _handle_stats(ctx)
+
+
+@mcp.tool(
+    description="Restore an archived memory by ID.",
+    annotations=ToolAnnotations(
+        title="Restore Memory",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def restore_memory(memory_id: str, ctx: Context | None = None) -> str:
+    return await _handle_restore(ctx, memory_id)
+
+
+@mcp.tool(
+    description="List archived memories.",
+    annotations=ToolAnnotations(
+        title="Archived Memories",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def archived_memories(limit: int = 5, ctx: Context | None = None) -> str:
+    return await _handle_archived(ctx, limit)
+
+
+@mcp.tool(
+    description="Summarize similar memories in a category (requires LLM API keys).",
+    annotations=ToolAnnotations(
+        title="Consolidate Memories",
+        readOnlyHint=False,
+        destructiveHint=False,
+    ),
+)
+async def consolidate_memories(category: str, ctx: Context | None = None) -> str:
+    return await _handle_consolidate(ctx, category)
+
+
+@mcp.tool(
     description=(
-        "Persistent memory store. Actions: add|search|list|update|delete|export|import|stats|restore|archived|consolidate.\n"
+        "Legacy dispatcher for backward compatibility. Use specialized tools (add_memory, search_memory, etc.) instead.\n\nPersistent memory store. Actions: add|search|list|update|delete|export|import|stats|restore|archived|consolidate.\n"
         "\n"
         "ACTION GUIDE — when to use each:\n"
         "- add: Store NEW information. Requires 'content'. Use when saving preferences, decisions, facts for the first time.\n"
@@ -853,49 +1023,36 @@ async def memory(
     - archived: List archived memories (limit optional)
     - consolidate: LLM summarize similar memories (category required)
     """
-    db, embedding_model, embedding_dims = _get_ctx(ctx)
-
     # Clamp limit to reasonable bounds to prevent DoS
+
     if isinstance(limit, int):
         limit = max(1, min(limit, 100))
 
     match action:
         case "add":
-            return await _handle_add(
-                db, content, category, tags, embedding_model, embedding_dims
-            )
+            return await _handle_add(ctx, content, category, tags)
         case "search":
-            return await _handle_search(
-                db, query, category, tags, limit, embedding_model, embedding_dims
-            )
+            return await _handle_search(ctx, query, category, tags, limit)
         case "list":
-            return await _handle_list(db, category, limit)
+            return await _handle_list(ctx, category, limit)
         case "update":
             return await _handle_update(
-                db,
-                memory_id,
-                content,
-                category,
-                tags,
-                source,
-                importance,
-                embedding_model,
-                embedding_dims,
+                ctx, memory_id, content, category, tags, source, importance
             )
         case "delete":
-            return await _handle_delete(db, memory_id)
+            return await _handle_delete(ctx, memory_id)
         case "export":
-            return await _handle_export(db)
+            return await _handle_export(ctx)
         case "import":
-            return await _handle_import(db, data, mode)
+            return await _handle_import(ctx, data, mode)
         case "stats":
-            return await _handle_stats(db, embedding_model, embedding_dims)
+            return await _handle_stats(ctx)
         case "restore":
-            return await _handle_restore(db, memory_id)
+            return await _handle_restore(ctx, memory_id)
         case "archived":
-            return await _handle_archived(db, limit)
+            return await _handle_archived(ctx, limit)
         case "consolidate":
-            return await _handle_consolidate(db, category)
+            return await _handle_consolidate(ctx, category)
         case _:
             import difflib
 
@@ -959,13 +1116,11 @@ async def config(
     - warmup: Pre-download embedding model (~570 MB) to avoid first-run delays
     - setup_sync: Authenticate Google Drive via Device Code OAuth flow
     """
-    db, embedding_model, embedding_dims = _get_ctx(ctx)
-
     match action:
         case "status":
-            return await _handle_config_status(db, embedding_model, embedding_dims)
+            return await _handle_config_status(ctx)
         case "sync":
-            return await _handle_config_sync(db)
+            return await _handle_config_sync(ctx)
         case "set":
             return await _handle_config_set(key, value)
         case "warmup":
@@ -1010,9 +1165,8 @@ async def config(
             )
 
 
-async def _handle_config_status(
-    db: MemoryDB, embedding_model: str | None, embedding_dims: int
-) -> str:
+async def _handle_config_status(ctx: Context | None) -> str:
+    db, embedding_model, embedding_dims = _get_ctx(ctx)
     s = await asyncio.to_thread(db.stats)
     return _json(
         {
@@ -1037,7 +1191,8 @@ async def _handle_config_status(
     )
 
 
-async def _handle_config_sync(db: MemoryDB) -> str:
+async def _handle_config_sync(ctx: Context | None) -> str:
+    db, _, _ = _get_ctx(ctx)
     from mnemo_mcp.sync import sync_full
 
     result = await sync_full(db)

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -10,8 +10,9 @@ load + env, and always includes providers_configured in the response.
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -22,8 +23,7 @@ def _call_config_setup_status_sync() -> dict[str, Any]:
 
     from mnemo_mcp.server import _handle_config_setup_status
 
-    ctx = MagicMock()
-    raw = asyncio.run(_handle_config_setup_status(ctx))
+    raw = asyncio.run(_handle_config_setup_status())
     return json.loads(raw)
 
 

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,7 +22,8 @@ def _call_config_setup_status_sync() -> dict[str, Any]:
 
     from mnemo_mcp.server import _handle_config_setup_status
 
-    raw = asyncio.run(_handle_config_setup_status())
+    ctx = MagicMock()
+    raw = asyncio.run(_handle_config_setup_status(ctx))
     return json.loads(raw)
 
 

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -10,7 +10,6 @@ load + env, and always includes providers_configured in the response.
 from __future__ import annotations
 
 import json
-import os
 from typing import Any
 from unittest.mock import patch
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -315,7 +315,7 @@ class TestMemoryConsolidate:
             patch("mnemo_mcp.graph._has_llm_provider", return_value=False),
         ):
             mock_settings.resolve_provider_mode.return_value = "local"
-            result = json.loads(await _handle_consolidate(db, "tech"))
+            result = json.loads(await _handle_consolidate(ctx, "tech"))
         assert "error" in result
         assert "LLM" in result["error"]
 
@@ -426,7 +426,7 @@ class TestDedupWarning:
             return_value={"similar": True, "match_id": "abc", "score": 0.85},
         ):
             result = json.loads(
-                await _handle_add(db, "Python is excellent for ML", None, None, None, 0)
+                await _handle_add(ctx, "Python is excellent for ML", None, None)
             )
         assert result["status"] == "saved"
         assert "dedup_warning" in result
@@ -439,9 +439,7 @@ class TestDedupWarning:
             "check_duplicate",
             return_value={"duplicate": True, "match_id": "abc", "score": 0.99},
         ):
-            result = json.loads(
-                await _handle_add(db, "exact duplicate", None, None, None, 0)
-            )
+            result = json.loads(await _handle_add(ctx, "exact duplicate", None, None))
         assert result["status"] == "saved"
         assert "dedup_warning" in result
 
@@ -449,9 +447,7 @@ class TestDedupWarning:
         """Cover lines 338-339: dedup exception is non-blocking."""
         ctx, db = ctx_with_db
         with patch.object(db, "check_duplicate", side_effect=RuntimeError("boom")):
-            result = json.loads(
-                await _handle_add(db, "test content", None, None, None, 0)
-            )
+            result = json.loads(await _handle_add(ctx, "test content", None, None))
         assert result["status"] == "saved"
 
 
@@ -460,7 +456,7 @@ class TestHandleAddErrors:
         """Cover lines 352-354: unexpected exception in db.add."""
         ctx, db = ctx_with_db
         with patch.object(db, "add", side_effect=RuntimeError("unexpected")):
-            result = json.loads(await _handle_add(db, "test", None, None, None, 0))
+            result = json.loads(await _handle_add(ctx, "test", None, None))
         assert "error" in result
         assert "Internal error" in result["error"]
 
@@ -472,9 +468,7 @@ class TestHandleUpdateErrors:
         mid = db.add("original")
         with patch.object(db, "update", side_effect=RuntimeError("unexpected")):
             result = json.loads(
-                await _handle_update(
-                    db, mid, "new content", None, None, None, None, None, 0
-                )
+                await _handle_update(ctx, mid, "new content", None, None, None, None)
             )
         assert "error" in result
         assert "Internal error" in result["error"]
@@ -552,9 +546,7 @@ class TestSearchRerankerAndGraph:
         mock_reranker = MagicMock()
         mock_reranker.rerank.return_value = [(1, 0.95), (0, 0.85), (2, 0.70)]
         with patch("mnemo_mcp.reranker.get_reranker", return_value=mock_reranker):
-            result = json.loads(
-                await _handle_search(db, "Python", None, None, 5, None, 0)
-            )
+            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
         assert result["reranked"] is True
         assert result["results"][0]["rerank_score"] == 0.95
 
@@ -566,9 +558,7 @@ class TestSearchRerankerAndGraph:
         mock_reranker = MagicMock()
         mock_reranker.rerank.side_effect = RuntimeError("rerank failed")
         with patch("mnemo_mcp.reranker.get_reranker", return_value=mock_reranker):
-            result = json.loads(
-                await _handle_search(db, "Python", None, None, 5, None, 0)
-            )
+            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
         assert result["reranked"] is False
 
     async def test_search_with_graph_boost(self, ctx_with_db):
@@ -577,9 +567,7 @@ class TestSearchRerankerAndGraph:
         db.add("Python for AI")
         mid2 = db.add("Python for web development")
         with patch("mnemo_mcp.graph.find_related_memory_ids", return_value=[mid2]):
-            result = json.loads(
-                await _handle_search(db, "Python", None, None, 5, None, 0)
-            )
+            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
         # At least one result should have graph_related
         related = [r for r in result["results"] if r.get("graph_related")]
         assert len(related) >= 1
@@ -592,9 +580,7 @@ class TestSearchRerankerAndGraph:
             "mnemo_mcp.graph.find_related_memory_ids",
             side_effect=RuntimeError("graph error"),
         ):
-            result = json.loads(
-                await _handle_search(db, "Python", None, None, 5, None, 0)
-            )
+            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
         assert result["count"] > 0
 
 
@@ -604,7 +590,7 @@ class TestConsolidate:
         ctx, db = ctx_with_db
         with patch("mnemo_mcp.server.settings") as mock_settings:
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            result = json.loads(await _handle_consolidate(db, None))
+            result = json.loads(await _handle_consolidate(ctx, None))
         assert "error" in result
         assert "category is required" in result["error"]
         assert "suggestion" in result
@@ -615,7 +601,7 @@ class TestConsolidate:
         db.add("only one", category="tech")
         with patch("mnemo_mcp.server.settings") as mock_settings:
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            result = json.loads(await _handle_consolidate(db, "tech"))
+            result = json.loads(await _handle_consolidate(ctx, "tech"))
         assert "error" in result
         assert "at least 2" in result["error"]
 
@@ -635,7 +621,7 @@ class TestConsolidate:
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
             mock_settings.llm_models = "gpt-4o,gemini-flash"
-            result = json.loads(await _handle_consolidate(db, "tech"))
+            result = json.loads(await _handle_consolidate(ctx, "tech"))
 
         assert result["status"] == "consolidated"
         assert result["category"] == "tech"
@@ -657,7 +643,7 @@ class TestConsolidate:
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
             mock_settings.llm_models = "gpt-4o"
-            result = json.loads(await _handle_consolidate(db, "tech"))
+            result = json.loads(await _handle_consolidate(ctx, "tech"))
         assert "error" in result
         assert "Consolidation failed" in result["error"]
 


### PR DESCRIPTION
The `memory` tool in `src/mnemo_mcp/server.py` was a "God tool" handling 11 different actions with a large number of optional parameters, making it difficult to maintain and confusing for LLM clients.

This PR:
1.  **Introduces specialized tools**: `add_memory`, `search_memory`, `list_memories`, `update_memory`, `delete_memory`, `export_memories`, `import_memories`, `memory_stats`, `restore_memory`, `archived_memories`, and `consolidate_memories`. Each tool has a minimal, focused signature.
2.  **Refactors the `memory` tool**: It now serves as a legacy dispatcher that delegates to the specialized handlers, ensuring backward compatibility while drastically reducing its internal complexity.
3.  **Modularizes internal handlers**: Functions like `_handle_add` and `_handle_search` now take a `Context` object and manage their own database and settings extraction, making them more robust and reusable.
4.  **Improves Developer Experience (DX)**: LLMs now have access to a set of clear, specific tools for memory management, leading to more reliable tool usage.

Verified registration and delegation via standalone mock verification scripts. Fixed all linting issues.

---
*PR created automatically by Jules for task [10685418270665528309](https://jules.google.com/task/10685418270665528309) started by @n24q02m*