### PR TITLE
[CLEANUP] Unused stats_resource function

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1303,11 +1303,7 @@ register_open_relay_tool(mcp, "mnemo-mcp", os.environ.get("PUBLIC_URL"))
 @mcp.resource("mnemo://stats")
 async def stats_resource(ctx: Context | None = None) -> str:
     """Database statistics and server status."""
-    db, embedding_model, embedding_dims = _get_ctx(ctx)
-    s = await asyncio.to_thread(db.stats)
-    s["embedding_model"] = embedding_model
-    s["sync_enabled"] = settings.sync_enabled
-    return _json(s)
+    return await _handle_stats(*_get_ctx(ctx))
 
 
 @mcp.resource("mnemo://recent")


### PR DESCRIPTION
Refactored the stats_resource function (exposed via mnemo://stats) to delegate to the pre-existing _handle_stats helper. This deduplicates logic between the resource and the memory stats tool, ensuring the resource output now includes embedding_dims and sync_folder. This cleanup addresses the "unused function" warning while preserving the required MCP API.

---
*PR created automatically by Jules for task [17574540245921024171](https://jules.google.com/task/17574540245921024171) started by @n24q02m*