### PR TITLE
[TEST] Missing error path test for invalid JSON string in database bulk import

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -389,6 +389,15 @@ class TestExportImport:
         assert result["imported"] == 3
         assert tmp_db.stats()["total_memories"] == 3
 
+    def test_import_invalid_json_string(self, tmp_db: MemoryDB):
+        """Invalid JSON lines are counted as rejected."""
+        data = '{"id":"ok1","content":"valid"}\nnot-json\n{"id":"ok2","content":"also valid"}'
+        result = tmp_db.import_jsonl(data, mode="merge")
+        assert result["imported"] == 2
+        assert result["rejected"] == 1
+        assert tmp_db.get("ok1") is not None
+        assert tmp_db.get("ok2") is not None
+
     def test_import_preserves_metadata(self, tmp_db: MemoryDB):
         data = json.dumps(
             {


### PR DESCRIPTION
This PR adds a missing test case to verify that the `import_jsonl` method in `MemoryDB` correctly handles invalid JSON strings by incrementing the `rejected` counter instead of failing. 

The new test `test_import_invalid_json_string` was added to `TestExportImport` in `tests/test_db.py`. This ensures that even if one or more lines in a bulk import string are malformed, the system gracefully skips them and continues processing valid entries, which is a critical error path for database robustness.

Verified by running the specific test case with a mocked environment to ensure the targeted code path is exercised and assertions pass.

---
*PR created automatically by Jules for task [10730622119653264680](https://jules.google.com/task/10730622119653264680) started by @n24q02m*