### PR TITLE
🎨 Palette: Add Anthropic and xAI to Relay Form

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -40,6 +40,8 @@ CLOUD_KEYS = [
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
     "COHERE_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "XAI_API_KEY",
 ]
 
 # All config keys that indicate a valid saved config (includes GDrive)

--- a/src/mnemo_mcp/relay_schema.py
+++ b/src/mnemo_mcp/relay_schema.py
@@ -65,6 +65,24 @@ RELAY_SCHEMA: dict[str, Any] = {
             "helpText": "Embedding + Reranking.",
             "required": False,
         },
+        {
+            "key": "ANTHROPIC_API_KEY",
+            "label": "Anthropic API Key",
+            "type": "password",
+            "placeholder": "sk-ant-...",
+            "helpUrl": "https://console.anthropic.com/settings/keys",
+            "helpText": "LLM (lower priority than OpenAI).",
+            "required": False,
+        },
+        {
+            "key": "XAI_API_KEY",
+            "label": "xAI API Key",
+            "type": "password",
+            "placeholder": "xai-...",
+            "helpUrl": "https://console.x.ai/",
+            "helpText": "LLM (lower priority than Anthropic).",
+            "required": False,
+        },
     ],
     "capabilityInfo": [
         {
@@ -79,7 +97,7 @@ RELAY_SCHEMA: dict[str, Any] = {
         },
         {
             "label": "LLM",
-            "priority": "Gemini > OpenAI",
+            "priority": "Gemini > OpenAI > Anthropic > xAI",
             "description": "Used for memory importance scoring and graph analysis. Without a key, basic heuristics are used.",
         },
         {

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -22,7 +22,7 @@ class TestRelaySchema:
         assert "modes" not in RELAY_SCHEMA
 
     def test_schema_has_provider_fields_only(self):
-        """Relay form scope: 4 API key provider fields ONLY.
+        """Relay form scope: 6 API key provider fields ONLY.
 
         S3 + passphrase are operator env config (docker spawn), NOT
         per-user relay fields. See docs/passport.md for the runbook
@@ -30,7 +30,7 @@ class TestRelaySchema:
         XOR semantics.
         """
         fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 4
+        assert len(fields) == 6
         keys = [f["key"] for f in fields]
         assert all(k.endswith("_API_KEY") for k in keys), (
             f"non-API-key fields in relay form: {keys}"
@@ -42,6 +42,8 @@ class TestRelaySchema:
         assert "GEMINI_API_KEY" in keys
         assert "OPENAI_API_KEY" in keys
         assert "COHERE_API_KEY" in keys
+        assert "ANTHROPIC_API_KEY" in keys
+        assert "XAI_API_KEY" in keys
 
     def test_all_fields_optional(self):
         for f in RELAY_SCHEMA["fields"]:
@@ -59,6 +61,8 @@ class TestRelaySchema:
             "GEMINI_API_KEY",
             "OPENAI_API_KEY",
             "COHERE_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "XAI_API_KEY",
         }
         for f in RELAY_SCHEMA["fields"]:
             if f["key"] not in provider_keys:


### PR DESCRIPTION
This PR adds support for configuring Anthropic and xAI API keys directly from the relay web UI.

Previously, these LLM providers were supported via environment variables (seen in `src/mnemo_mcp/llm.py`), but users were forced to configure them out-of-band because they were missing from the configuration schema. This small UX enhancement makes the initial setup experience more intuitive.

---
*PR created automatically by Jules for task [14954203601390230005](https://jules.google.com/task/14954203601390230005) started by @n24q02m*