### PR TITLE
[TEST] Missing tests for _detect_rerank_provider

### DIFF
--- a/tests/test_reranker_provider_detection.py
+++ b/tests/test_reranker_provider_detection.py
@@ -1,0 +1,42 @@
+import pytest
+import os
+from mnemo_mcp.reranker import _detect_rerank_provider
+
+@pytest.mark.parametrize("model, expected", [
+    ("jina_ai/jina-reranker-v3", "jina"),
+    ("jina-reranker-v3", "jina"),
+    ("JINA-RERANKER-V3", "jina"),
+    ("jina_ai/custom", "jina"),
+    ("rerank-v4.0-pro", "cohere"),
+    ("cohere/rerank-v4.0-pro", "cohere"),
+    ("RERANK-V4.0-PRO", "cohere"),
+    ("cohere/custom", "cohere"),
+])
+def test_detect_rerank_provider_explicit(model, expected):
+    """Test explicit provider prefixes."""
+    assert _detect_rerank_provider(model) == expected
+
+def test_detect_rerank_provider_fallback_jina(monkeypatch):
+    """Test fallback to Jina when unknown model and JINA_AI_API_KEY is set."""
+    monkeypatch.setenv("JINA_AI_API_KEY", "test-key")
+    assert _detect_rerank_provider("unknown-model") == "jina"
+
+def test_detect_rerank_provider_fallback_cohere(monkeypatch):
+    """Test fallback to Cohere when unknown model and JINA_AI_API_KEY is not set."""
+    monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+    assert _detect_rerank_provider("unknown-model") == "cohere"
+
+def test_detect_rerank_provider_cohere_prefix_ignores_jina_env(monkeypatch):
+    """Test that explicit cohere prefix ignores JINA_AI_API_KEY env var."""
+    monkeypatch.setenv("JINA_AI_API_KEY", "test-key")
+    assert _detect_rerank_provider("rerank-v4.0-pro") == "cohere"
+    assert _detect_rerank_provider("cohere/any-model") == "cohere"
+
+@pytest.mark.parametrize("model", [
+    "jina_ai/foo",
+    "jina-bar",
+])
+def test_detect_rerank_provider_jina_prefix_ignores_missing_env(model, monkeypatch):
+    """Test that explicit jina prefix works even if env var is missing."""
+    monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
+    assert _detect_rerank_provider(model) == "jina"


### PR DESCRIPTION
This PR adds comprehensive tests for the `_detect_rerank_provider` function in `src/mnemo_mcp/reranker.py`. 

The new test file `tests/test_reranker_provider_detection.py` covers:
- Explicit provider prefixes (jina_ai/, jina, rerank, cohere/) with case-insensitivity.
- Environment variable fallback logic (JINA_AI_API_KEY).
- Precedence of explicit prefixes over environment variables.

All 13 new test cases pass alongside existing reranker tests.

---
*PR created automatically by Jules for task [12364240241508559920](https://jules.google.com/task/12364240241508559920) started by @n24q02m*