### PR TITLE
[TEST] Missing tests for _json formatting helper

### DIFF
--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -18,6 +18,7 @@ from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.server import (
     _embed,
     _format_memory,
+    _json,
     config,
     main,
     memory,
@@ -598,3 +599,15 @@ class TestWarmupInitEmbeddingBackend:
         mock_logger.error.assert_called_with(
             "Local embedding init failed: Init Backend Failed"
         )
+
+
+class TestJsonHelper:
+    """Tests for the _json formatting helper."""
+
+    def test_json_indentation(self):
+        """Verify _json serializes with indent=2."""
+        data = {"a": 1, "b": [2, 3]}
+        result = _json(data)
+        expected = json.dumps(data, indent=2)
+        assert result == expected
+        assert "\n  " in result  # Check for 2-space indentation


### PR DESCRIPTION
This PR adds unit tests for the `_json` formatting helper in `src/mnemo_mcp/server.py`. The tests ensure that the helper correctly serializes objects to JSON with a 2-space indentation, as intended. These tests are added to `tests/test_server_coverage.py` which follows the project's 1:1 mapping convention.

---
*PR created automatically by Jules for task [8964223372448347687](https://jules.google.com/task/8964223372448347687) started by @n24q02m*