### PR TITLE
[PERF] Suboptimal PRAGMA loop inside backfill migration

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1674,8 +1674,7 @@ class MemoryDB:
             if cursor is None:
                 return
             cols = {
-                row[1]
-                for row in self._conn.execute("PRAGMA table_info(memories)").fetchall()
+                row["name"] for row in self._conn.execute("PRAGMA table_info(memories)")
             }
             if "commit_sha" not in cols or "valid_from" not in cols:
                 # Phase 3 columns missing -- migration did not run.

--- a/uv.lock
+++ b/uv.lock
@@ -979,7 +979,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.1b1"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR optimizes the schema inspection loop in the `_backfill_phase3_temporal` migration.

Specifically:
- It removes the redundant `.fetchall()` call when iterating over the results of `PRAGMA table_info(memories)`. This allows for lazy iteration over the cursor, avoiding the creation of an intermediate list.
- It updates the column access from `row[1]` to `row["name"]`, leveraging the fact that `row_factory` is set to `sqlite3.Row` for better readability.
- It ensures the file `src/mnemo_mcp/db.py` is formatted correctly according to the project's Ruff configuration.

These changes improve memory efficiency during database initialization and enhance code maintainability. All existing tests passed, including a specific check for the backfill logic.

---
*PR created automatically by Jules for task [2925349163022480084](https://jules.google.com/task/2925349163022480084) started by @n24q02m*