### PR TITLE
[FIX] Sensitive Information Logged on Error

### DIFF
--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -120,7 +120,7 @@ async def _refresh_token(token: dict) -> dict | None:
             )
 
             if response.status_code != 200:
-                logger.error(f"Token refresh failed: {response.text}")
+                logger.error(f"Token refresh failed: (status={response.status_code})")
                 return None
 
             data = response.json()
@@ -305,7 +305,7 @@ async def _find_or_create_folder(token: dict, folder_name: str) -> str | None:
             await _save_folder_id(folder_name, fid)
         return fid
 
-    logger.error(f"Failed to create folder '{folder_name}': {response.text}")
+    logger.error(f"Failed to create folder '{folder_name}': {response.text[:100]}")
     return None
 
 
@@ -397,7 +397,7 @@ async def _upload_file(
     if response.status_code in (200, 201):
         return True
 
-    logger.error(f"Upload failed ({response.status_code}): {response.text[:300]}")
+    logger.error(f"Upload failed ({response.status_code}): {response.text[:100]}")
     return False
 
 
@@ -416,7 +416,7 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
         await asyncio.to_thread(dest_path.write_bytes, response.content)
         return True
 
-    logger.error(f"Download failed ({response.status_code}): {response.text[:300]}")
+    logger.error(f"Download failed ({response.status_code}): {response.text[:100]}")
     return False
 
 
@@ -589,7 +589,9 @@ async def _request_device_code(client_id: str) -> dict | None:
             )
 
             if response.status_code != 200:
-                logger.error(f"Device code request failed: {response.text}")
+                logger.error(
+                    f"Device code request failed: (status={response.status_code})"
+                )
                 return None
 
             return response.json()
@@ -949,7 +951,7 @@ class GDriveBackend(SyncBackend):
         if response.status_code not in (200, 201):
             raise RuntimeError(
                 f"GDriveBackend.push: upload failed ({response.status_code}): "
-                f"{response.text[:200]}"
+                f"{response.text[:100]}"
             )
 
     async def pull(self, sequence: int | None = None) -> bytes | None:

--- a/uv.lock
+++ b/uv.lock
@@ -979,7 +979,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.1b1"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Redacted sensitive information in Google Drive sync logs in `src/mnemo_mcp/sync/gdrive.py`.

- Modified token refresh and device code request failure logs to only include the HTTP status code, preventing exposure of raw error payloads which might contain secrets.
- Truncated `response.text` to 100 characters for other Drive API operations (folder creation, upload, download) to provide debugging context without risking large-scale data exposure.
- Standardized error message formatting across legacy and Phase 2 backend implementations.
- Verified changes via manual inspection, `ruff format`, `ruff check`, and `ty check`.

---
*PR created automatically by Jules for task [3454821968012440581](https://jules.google.com/task/3454821968012440581) started by @n24q02m*