### PR TITLE
[TEST] Missing tests for _env_compression_enabled

### DIFF
--- a/tests/test_compression_env.py
+++ b/tests/test_compression_env.py
@@ -1,0 +1,29 @@
+import pytest
+
+from mnemo_mcp.compression import _env_compression_enabled
+
+
+def test_env_compression_enabled_default(monkeypatch):
+    """If COMPRESSION_ENABLED is not set, it should return True."""
+    monkeypatch.delenv("COMPRESSION_ENABLED", raising=False)
+    assert _env_compression_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", " yes ", "ON"])
+def test_env_compression_enabled_truthy(monkeypatch, val):
+    """If COMPRESSION_ENABLED is set to a truthy value, it should return True."""
+    monkeypatch.setenv("COMPRESSION_ENABLED", val)
+    assert _env_compression_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "maybe", "blue"])
+def test_env_compression_enabled_falsy(monkeypatch, val):
+    """If COMPRESSION_ENABLED is set to anything else, it should return False."""
+    monkeypatch.setenv("COMPRESSION_ENABLED", val)
+    assert _env_compression_enabled() is False
+
+
+def test_env_compression_enabled_empty(monkeypatch):
+    """Empty string should be False."""
+    monkeypatch.setenv("COMPRESSION_ENABLED", "")
+    assert _env_compression_enabled() is False


### PR DESCRIPTION
This PR adds a new test file `tests/test_compression_env.py` to provide full test coverage for the `_env_compression_enabled` function in `src/mnemo_mcp/compression.py`.

The tests cover:
- Default behavior (returns True when env var is unset)
- Truthy values (1, true, yes, on) with various casings and whitespace
- Falsy values (0, false, no, off, arbitrary strings)
- Empty string behavior (returns False)

All tests passed using a standalone runner.

---
*PR created automatically by Jules for task [4647389221924107354](https://jules.google.com/task/4647389221924107354) started by @n24q02m*