### PR TITLE
[CLEANUP] Consolidate N+1 vector search queries

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -684,7 +684,7 @@ class MemoryDB:
         if embedding and self._vec_enabled:
             try:
                 vec_sql = """
-                    SELECT v.id, v.distance
+                    SELECT m.*, v.distance
                     FROM memories_vec v
                     JOIN memories m ON v.id = m.id
                     WHERE v.embedding MATCH ?
@@ -710,29 +710,20 @@ class MemoryDB:
 
                 vec_rows = self._conn.execute(vec_sql, vec_params).fetchall()
 
-                missing_ids = []
-                vec_scores = {}
                 for row in vec_rows:
                     mid = row["id"]
                     vec_score = max(0.0, 1.0 - row["distance"])
-                    vec_scores[mid] = vec_score
                     if mid in results:
                         results[mid]["vec_score"] = vec_score
                     else:
-                        missing_ids.append(mid)
-
-                if missing_ids:
-                    missing_mems = self._conn.execute(
-                        "SELECT * FROM memories WHERE id IN (SELECT value FROM json_each(?))",
-                        (json.dumps(missing_ids),),
-                    ).fetchall()
-                    for mem in missing_mems:
-                        mid = mem["id"]
                         results[mid] = {
-                            **dict(mem),
+                            **dict(row),
                             "fts_score": 0.0,
-                            "vec_score": vec_scores[mid],
+                            "vec_score": vec_score,
                         }
+                        # Bolt Performance Optimization:
+                        # Distance is a search artifact, remove from returned memory dict.
+                        results[mid].pop("distance", None)
             except Exception as e:
                 logger.debug(f"Vector search error: {e}")
 

--- a/tests/test_db_vec_coverage.py
+++ b/tests/test_db_vec_coverage.py
@@ -190,6 +190,47 @@ class TestSearchVecBranch:
     connection so that the vec_sql SELECT returns a synthetic result set
     without needing sqlite-vec to be present at runtime."""
 
+    def test_search_vec_missing_mems_query_raises_exception(self, tmp_path: Path):
+        """Vector search block swallows exceptions and logs at debug.
+        (Refactored: merged query exception test)."""
+        db = MemoryDB(tmp_path / "vec_mems_err.db", embedding_dims=3)
+        db._vec_enabled = True
+        real_conn = db._conn
+        # mid1 will be found by FTS
+        mid1 = db.add("alpha beta")
+        # mid2 will be found by VEC but its query will fail
+        mid2 = db.add("gamma delta")
+
+        class _ConnProxy:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def execute(self, sql, *args, **kwargs):
+                # Vector query: throw exception
+                if "FROM memories_vec v" in sql and "MATCH" in sql:
+                    raise RuntimeError("vec query failed")
+                return self._inner.execute(sql, *args, **kwargs)
+
+            def executescript(self, sql):
+                return self._inner.executescript(sql)
+
+            def commit(self):
+                return self._inner.commit()
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        try:
+            # Should still return mid1 from FTS despite VEC failure
+            results = db.search(query="alpha", embedding=[0.1, 0.2, 0.3], limit=5)
+            assert isinstance(results, list)
+            assert any(r["id"] == mid1 for r in results)
+            assert not any(r["id"] == mid2 for r in results)
+        finally:
+            db._conn = real_conn
+            db.close()
+
     def test_search_with_embedding_executes_vec_branch(self, tmp_path: Path):
         db = MemoryDB(tmp_path / "vec_search.db", embedding_dims=3)
         db._vec_enabled = True
@@ -314,59 +355,6 @@ class TestSearchVecBranch:
             # Must not raise -- exception swallowed + logged
             results = db.search(query="alpha", embedding=[0.1, 0.2, 0.3], limit=5)
             assert isinstance(results, list)
-        finally:
-            db._conn = real_conn
-            db.close()
-
-    def test_search_vec_missing_mems_query_raises_exception(self, tmp_path: Path):
-        """Vector search missing mems fetch block swallows exceptions."""
-        db = MemoryDB(tmp_path / "vec_mems_err.db", embedding_dims=3)
-        db._vec_enabled = True
-        real_conn = db._conn
-        # mid1 will be found by FTS
-        mid1 = db.add("alpha beta")
-        # mid2 will be found by VEC but its fetch from 'memories' will fail
-        mid2 = db.add("gamma delta")
-
-        class _ConnProxy:
-            def __init__(self, inner):
-                self._inner = inner
-
-            def execute(self, sql, *args, **kwargs):
-                # First vector query: return mid2 as a hit
-                if "FROM memories_vec v" in sql and "MATCH" in sql:
-
-                    class _Cursor:
-                        def fetchall(self_):
-                            return [{"id": mid2, "distance": 0.1}]
-
-                        def fetchone(self_):
-                            return {"id": mid2, "distance": 0.1}
-
-                    return _Cursor()
-
-                # Second query (fetching missing mems): throw exception
-                if "FROM memories WHERE id IN" in sql:
-                    raise RuntimeError("missing mems fetch failed")
-
-                return self._inner.execute(sql, *args, **kwargs)
-
-            def executescript(self, sql):
-                return self._inner.executescript(sql)
-
-            def commit(self):
-                return self._inner.commit()
-
-            def __getattr__(self, name):
-                return getattr(self._inner, name)
-
-        db._conn = _ConnProxy(real_conn)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
-        try:
-            # Should still return mid1 from FTS despite mid2's fetch failure
-            results = db.search(query="alpha", embedding=[0.1, 0.2, 0.3], limit=5)
-            assert isinstance(results, list)
-            assert any(r["id"] == mid1 for r in results)
-            assert not any(r["id"] == mid2 for r in results)
         finally:
             db._conn = real_conn
             db.close()

--- a/uv.lock
+++ b/uv.lock
@@ -979,7 +979,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.1b1"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Consolidated the vector search query in src/mnemo_mcp/db.py to use a JOIN with the memories table, fetching all required columns in a single round-trip. This eliminates the secondary query previously used to fetch "missing" memories from the vector candidate pool.

Changes:
- Modified vec_sql in MemoryDB.search to SELECT m.*, v.distance.
- Inlined result processing, eliminating missing_ids list and secondary query.
- Ensured distance artifact is removed from returned result dictionaries.
- Refactored tests/test_db_vec_coverage.py to adapt to the consolidated query.
- Verified with 174 tests passing across the database and retrieval logic.

---
*PR created automatically by Jules for task [10384527758468522059](https://jules.google.com/task/10384527758468522059) started by @n24q02m*