### PR TITLE
[FIX] Reduce parameter count for "__init__" in S3Backend

### DIFF
--- a/src/mnemo_mcp/sync/__init__.py
+++ b/src/mnemo_mcp/sync/__init__.py
@@ -156,7 +156,7 @@ def get(name: str) -> SyncBackend:
         _REGISTRY["gdrive"] = GDriveBackend()
     if name == "s3" and "s3" not in _REGISTRY:
         from mnemo_mcp.config import settings
-        from mnemo_mcp.sync.s3 import S3Backend
+        from mnemo_mcp.sync.s3 import S3Backend, S3Config
 
         if not settings.sync_s3_bucket:
             raise KeyError(
@@ -165,12 +165,14 @@ def get(name: str) -> SyncBackend:
                 "MinIO) before requesting the S3 backend."
             )
         _REGISTRY["s3"] = S3Backend(
-            bucket=settings.sync_s3_bucket,
-            region=settings.sync_s3_region or "us-east-1",
-            access_key_id=settings.sync_s3_access_key_id or None,
-            secret_access_key=settings.sync_s3_secret_access_key or None,
-            endpoint_url=settings.sync_s3_endpoint or None,
-            prefix=settings.sync_s3_prefix or "passport/",
+            S3Config(
+                bucket=settings.sync_s3_bucket,
+                region=settings.sync_s3_region or "us-east-1",
+                access_key_id=settings.sync_s3_access_key_id or None,
+                secret_access_key=settings.sync_s3_secret_access_key or None,
+                endpoint_url=settings.sync_s3_endpoint or None,
+                prefix=settings.sync_s3_prefix or "passport/",
+            )
         )
     if name not in _REGISTRY:
         raise KeyError(

--- a/src/mnemo_mcp/sync/s3.py
+++ b/src/mnemo_mcp/sync/s3.py
@@ -20,6 +20,7 @@ Spec reference: ``2026-04-19-mnemo-v2-design.md`` section 4.4.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 
 import boto3
 from botocore.exceptions import ClientError
@@ -31,6 +32,18 @@ from mnemo_mcp.sync.base import SyncBackend
 def _bundle_key(prefix: str, sequence: int) -> str:
     """Return the S3 object key for a passport bundle at ``sequence``."""
     return f"{prefix.rstrip('/')}/seq-{sequence:06d}.bin"
+
+
+@dataclass
+class S3Config:
+    """Configuration for S3-compatible backend."""
+
+    bucket: str
+    region: str = "us-east-1"
+    access_key_id: str | None = None
+    secret_access_key: str | None = None
+    endpoint_url: str | None = None
+    prefix: str = "passport/"
 
 
 def _parse_sequence(key: str, prefix: str) -> int | None:
@@ -60,24 +73,16 @@ class S3Backend(SyncBackend):
 
     name = "s3"
 
-    def __init__(
-        self,
-        bucket: str,
-        region: str = "us-east-1",
-        access_key_id: str | None = None,
-        secret_access_key: str | None = None,
-        endpoint_url: str | None = None,
-        prefix: str = "passport/",
-    ) -> None:
-        self._bucket = bucket
-        self._prefix = prefix.rstrip("/") + "/"
-        self._endpoint_url = endpoint_url
+    def __init__(self, config: S3Config) -> None:
+        self._bucket = config.bucket
+        self._prefix = config.prefix.rstrip("/") + "/"
+        self._endpoint_url = config.endpoint_url
         self._client = boto3.client(
             "s3",
-            region_name=region,
-            endpoint_url=endpoint_url,
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key,
+            region_name=config.region,
+            endpoint_url=config.endpoint_url,
+            aws_access_key_id=config.access_key_id,
+            aws_secret_access_key=config.secret_access_key,
         )
 
     async def push(self, bundle: bytes, sequence: int) -> None:

--- a/tests/sync/test_delta.py
+++ b/tests/sync/test_delta.py
@@ -34,7 +34,7 @@ from mnemo_mcp.sync.delta import (
     build_full_bundle,
     sync_now,
 )
-from mnemo_mcp.sync.s3 import S3Backend
+from mnemo_mcp.sync.s3 import S3Backend, S3Config
 
 _BUCKET = "mnemo-test-delta"
 _PASS = "delta-test-passphrase"
@@ -60,10 +60,12 @@ def s3_backend() -> Iterator[S3Backend]:
         client = boto3.client("s3", region_name="us-east-1")
         client.create_bucket(Bucket=_BUCKET)
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="testing",
-            secret_access_key="testing",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="testing",
+                secret_access_key="testing",
+            )
         )
         sync_pkg.register("s3", backend)
         yield backend

--- a/tests/sync/test_s3_backend.py
+++ b/tests/sync/test_s3_backend.py
@@ -23,7 +23,7 @@ import boto3
 import pytest
 from moto import mock_aws
 
-from mnemo_mcp.sync.s3 import S3Backend, _bundle_key, _parse_sequence
+from mnemo_mcp.sync.s3 import S3Backend, S3Config, _bundle_key, _parse_sequence
 
 _BUCKET = "mnemo-test-bucket"
 _PREFIX = "passport/"
@@ -41,11 +41,13 @@ def s3_client() -> Iterator[object]:
 @pytest.fixture
 def backend(s3_client) -> S3Backend:  # noqa: ARG001 - s3_client patches boto3
     return S3Backend(
-        bucket=_BUCKET,
-        region="us-east-1",
-        access_key_id="testing",
-        secret_access_key="testing",
-        prefix=_PREFIX,
+        S3Config(
+            bucket=_BUCKET,
+            region="us-east-1",
+            access_key_id="testing",
+            secret_access_key="testing",
+            prefix=_PREFIX,
+        )
     )
 
 
@@ -149,10 +151,12 @@ async def test_s3_health_check_returns_true_on_existing_bucket(
 
 async def test_s3_health_check_returns_false_on_missing_bucket(s3_client) -> None:
     bad_backend = S3Backend(
-        bucket="nonexistent-bucket-zzz",
-        region="us-east-1",
-        access_key_id="testing",
-        secret_access_key="testing",
+        S3Config(
+            bucket="nonexistent-bucket-zzz",
+            region="us-east-1",
+            access_key_id="testing",
+            secret_access_key="testing",
+        )
     )
     assert await bad_backend.health_check() is False
 
@@ -161,11 +165,13 @@ def test_s3_custom_endpoint_passed_to_boto3() -> None:
     """R2 / B2 / MinIO endpoint forwarded so boto3 hits the right host."""
     with mock_aws():
         backend = S3Backend(
-            bucket="bucket",
-            region="auto",
-            access_key_id="k",
-            secret_access_key="s",
-            endpoint_url="https://accountid.r2.cloudflarestorage.com",
+            S3Config(
+                bucket="bucket",
+                region="auto",
+                access_key_id="k",
+                secret_access_key="s",
+                endpoint_url="https://accountid.r2.cloudflarestorage.com",
+            )
         )
         assert backend._client.meta.endpoint_url == (
             "https://accountid.r2.cloudflarestorage.com"
@@ -185,10 +191,12 @@ async def test_s3_push_propagates_unknown_client_error() -> None:
 
     with mock_aws():
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         backend._client = MagicMock()
         backend._client.put_object.side_effect = ClientError(
@@ -208,10 +216,12 @@ async def test_s3_pull_propagates_unknown_client_error() -> None:
 
     with mock_aws():
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         backend._client = MagicMock()
         backend._client.get_object.side_effect = ClientError(
@@ -229,10 +239,12 @@ async def test_s3_last_remote_sequence_propagates_client_error() -> None:
 
     with mock_aws():
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         backend._client = MagicMock()
         backend._client.list_objects_v2.side_effect = ClientError(
@@ -248,10 +260,12 @@ async def test_s3_last_remote_sequence_pagination(s3_client) -> None:
     from unittest.mock import MagicMock
 
     backend = S3Backend(
-        bucket=_BUCKET,
-        region="us-east-1",
-        access_key_id="t",
-        secret_access_key="t",
+        S3Config(
+            bucket=_BUCKET,
+            region="us-east-1",
+            access_key_id="t",
+            secret_access_key="t",
+        )
     )
     backend._client = MagicMock()
     backend._client.list_objects_v2.side_effect = [
@@ -275,10 +289,12 @@ async def test_s3_health_check_returns_false_on_generic_exception() -> None:
 
     with mock_aws():
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         backend._client = MagicMock()
         backend._client.head_bucket.side_effect = TimeoutError("network down")

--- a/tests/test_passport_actions.py
+++ b/tests/test_passport_actions.py
@@ -31,7 +31,7 @@ from mnemo_mcp.server import (
     _handle_config_sync_now,
     _handle_memory_compress,
 )
-from mnemo_mcp.sync.s3 import S3Backend
+from mnemo_mcp.sync.s3 import S3Backend, S3Config
 
 _BUCKET = "mnemo-test-passport-actions"
 
@@ -106,10 +106,12 @@ async def test_sync_now_delta_push_end_to_end(
         client = boto3.client("s3", region_name="us-east-1")
         client.create_bucket(Bucket=_BUCKET)
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         sync_pkg.register("s3", backend)
 
@@ -201,10 +203,12 @@ async def test_import_passport_no_bundle_returns_status(
         client = boto3.client("s3", region_name="us-east-1")
         client.create_bucket(Bucket=_BUCKET)
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         sync_pkg.register("s3", backend)
 
@@ -240,10 +244,12 @@ async def test_import_passport_round_trip(
         client = boto3.client("s3", region_name="us-east-1")
         client.create_bucket(Bucket=_BUCKET)
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         await backend.push(bundle, sequence=1)
         sync_pkg.register("s3", backend)
@@ -388,10 +394,12 @@ async def test_import_passport_decryption_failure(
         client = boto3.client("s3", region_name="us-east-1")
         client.create_bucket(Bucket=_BUCKET)
         backend = S3Backend(
-            bucket=_BUCKET,
-            region="us-east-1",
-            access_key_id="t",
-            secret_access_key="t",
+            S3Config(
+                bucket=_BUCKET,
+                region="us-east-1",
+                access_key_id="t",
+                secret_access_key="t",
+            )
         )
         await backend.push(bundle, sequence=1)
         sync_pkg.register("s3", backend)

--- a/uv.lock
+++ b/uv.lock
@@ -979,7 +979,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.1b1"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR reduces the parameter count for the `S3Backend.__init__` method by introducing a new `S3Config` dataclass. 

Related parameters like `bucket`, `region`, `access_key_id`, etc., are now grouped into `S3Config`, making the constructor signature cleaner and easier to manage.

All call sites in the production code and tests have been updated to use the new configuration object. Tests passed successfully.

---
*PR created automatically by Jules for task [4727693329237074014](https://jules.google.com/task/4727693329237074014) started by @n24q02m*