### PR TITLE
[SECURITY] Potential LIKE Injection in Substring Match Fallback

### DIFF
--- a/src/mnemo_mcp/temporal/queries.py
+++ b/src/mnemo_mcp/temporal/queries.py
@@ -56,11 +56,13 @@ def entity_search(
 
     if not entities:
         # Fallback: fuzzy substring match.
+        # Escape LIKE wildcards to prevent injection/broad matching.
+        escaped_name = name.strip().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         like_sql = (
             "SELECT id, name, entity_type FROM memory_entities "
-            "WHERE name LIKE ? COLLATE NOCASE LIMIT 5"
+            "WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE LIMIT 5"
         )
-        entities = db._conn.execute(like_sql, (f"%{name.strip()}%",)).fetchall()
+        entities = db._conn.execute(like_sql, (f"%{escaped_name}%",)).fetchall()
     if not entities:
         return []
 

--- a/src/mnemo_mcp/temporal/queries.py
+++ b/src/mnemo_mcp/temporal/queries.py
@@ -57,7 +57,9 @@ def entity_search(
     if not entities:
         # Fallback: fuzzy substring match.
         # Escape LIKE wildcards to prevent injection/broad matching.
-        escaped_name = name.strip().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        escaped_name = (
+            name.strip().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
         like_sql = (
             "SELECT id, name, entity_type FROM memory_entities "
             "WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE LIMIT 5"


### PR DESCRIPTION
Escaped \, %, and _ characters in the name parameter before wrapping it in wildcards for the LIKE query. Updated the SQL query to include the ESCAPE clause. Verified the fix with standalone tests covering special character handling and broad match prevention. Ensured no regressions in existing entity_search functionality.

---
*PR created automatically by Jules for task [127835002562926389](https://jules.google.com/task/127835002562926389) started by @n24q02m*