### PR TITLE
[FIX] Fix _handle_config_setup_status accuracy

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mnemo-mcp",
   "description": "Persistent AI memory — store, search, and recall knowledge across sessions",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "userConfig": {
     "JINA_AI_API_KEY": {
       "type": "string",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mnemo-mcp"
-version = "2.1.1"
+version = "2.1.3"
 description = "Open-source MCP Server for persistent AI memory with embedded sync"
 readme = "README.md"
 license = { text = "MIT" }
@@ -37,7 +37,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.10.0",
     # Zero-env-config credential relay
-    "n24q02m-mcp-core>=1.15.0b3,<2",
+    "n24q02m-mcp-core>=1.17.1,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",
@@ -70,6 +70,7 @@ dev = [
     "syrupy>=5.2.0",
     # Phase 2: in-memory S3 fixture for sync backend tests
     "moto[s3]>=5.2.1",
+    "bandit>=1.9.4",
 ]
 
 [project.scripts]

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/mnemo-mcp.git",
     "source": "github"
   },
-  "version": "2.1.1",
+  "version": "2.1.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mnemo-mcp",
-      "version": "2.1.1",
+      "version": "2.1.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -45,7 +45,7 @@ CLOUD_KEYS = [
 ]
 
 # All config keys that indicate a valid saved config (includes GDrive)
-_ALL_CONFIG_KEYS = [*CLOUD_KEYS, "GOOGLE_DRIVE_CLIENT_ID"]
+ALL_CONFIG_KEYS = [*CLOUD_KEYS, "GOOGLE_DRIVE_CLIENT_ID"]
 
 
 # Per-request JWT subject (HTTP multi-user remote mode only).
@@ -214,7 +214,7 @@ def resolve_credential_state() -> CredentialState:
             from mcp_core.storage.per_plugin_store import PerPluginStore
 
             saved = PerPluginStore("mnemo").load()
-            if saved and any(saved.get(k) for k in _ALL_CONFIG_KEYS):
+            if saved and any(saved.get(k) for k in ALL_CONFIG_KEYS):
                 # Apply to env vars
                 for key, value in saved.items():
                     if value and key not in os.environ:

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1018,26 +1018,33 @@ class MemoryDB:
         if isinstance(limit, int):
             limit = max(1, min(limit, 100))
 
-        archive_clause = "" if include_archived else " AND archived_at IS NULL"
-
         if category:
-            rows = self._conn.execute(
-                f"""SELECT * FROM memories
-                   WHERE category = ?{archive_clause}
-                   ORDER BY updated_at DESC
-                   LIMIT ? OFFSET ?""",
-                (category, limit, offset),
-            ).fetchall()
+            if include_archived:
+                sql = (
+                    "SELECT * FROM memories "
+                    "WHERE category = ? "
+                    "ORDER BY updated_at DESC "
+                    "LIMIT ? OFFSET ?"
+                )
+            else:
+                sql = (
+                    "SELECT * FROM memories "
+                    "WHERE category = ? AND archived_at IS NULL "
+                    "ORDER BY updated_at DESC "
+                    "LIMIT ? OFFSET ?"
+                )
+            rows = self._conn.execute(sql, (category, limit, offset)).fetchall()
         else:
-            # No leading WHERE -> drop the leading ' AND '.
-            where_sql = "" if include_archived else " WHERE archived_at IS NULL"
-            rows = self._conn.execute(
-                f"""SELECT * FROM memories
-                   {where_sql}
-                   ORDER BY updated_at DESC
-                   LIMIT ? OFFSET ?""",
-                (limit, offset),
-            ).fetchall()
+            if include_archived:
+                sql = "SELECT * FROM memories ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+            else:
+                sql = (
+                    "SELECT * FROM memories "
+                    "WHERE archived_at IS NULL "
+                    "ORDER BY updated_at DESC "
+                    "LIMIT ? OFFSET ?"
+                )
+            rows = self._conn.execute(sql, (limit, offset)).fetchall()
 
         return [dict(r) for r in rows]
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1720,6 +1720,7 @@ async def _handle_config_setup_status() -> str:
     from mcp_core.storage.per_plugin_store import PerPluginStore
 
     from mnemo_mcp.credential_state import (
+        ALL_CONFIG_KEYS,
         CLOUD_KEYS,
         CredentialState,
         credentials_for_current_request,
@@ -1735,25 +1736,29 @@ async def _handle_config_setup_status() -> str:
     if get_current_sub() is not None:
         _per_sub = credentials_for_current_request()
         _env_keys: list[str] = []
-        _store_keys = [k for k in CLOUD_KEYS if _per_sub.get(k)]
+        _store_keys = [k for k in ALL_CONFIG_KEYS if _per_sub.get(k)]
     else:
         # Derive providers_configured from live PerPluginStore load + env
         # so status is accurate even if module-level _state is stale.
         _saved = PerPluginStore("mnemo").load() or {}
-        _env_keys = [k for k in CLOUD_KEYS if os.environ.get(k)]
-        _store_keys = [k for k in CLOUD_KEYS if _saved.get(k)]
+        _env_keys = [k for k in ALL_CONFIG_KEYS if os.environ.get(k)]
+        _store_keys = [k for k in ALL_CONFIG_KEYS if _saved.get(k)]
     _providers = list(dict.fromkeys(_env_keys + _store_keys))
+    _state = get_state()
+
     if _providers:
         _derived_state = "configured"
-    elif get_state() == CredentialState.LOCAL:
+    elif _state == CredentialState.LOCAL:
         _derived_state = "local"
+    elif _state == CredentialState.SETUP_IN_PROGRESS:
+        _derived_state = "setup_in_progress"
     else:
         _derived_state = "awaiting_setup"
     return _json(
         {
             "state": _derived_state,
             "setup_url": get_setup_url(),
-            "cloud_keys_in_env": _env_keys,
+            "cloud_keys_in_env": [k for k in _env_keys if k in CLOUD_KEYS],
             "providers_configured": _providers,
         }
     )

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -120,7 +120,7 @@ async def _refresh_token(token: dict) -> dict | None:
             )
 
             if response.status_code != 200:
-                logger.error(f"Token refresh failed: {response.text}")
+                logger.error(f"Token refresh failed: (status={response.status_code})")
                 return None
 
             data = response.json()
@@ -305,7 +305,7 @@ async def _find_or_create_folder(token: dict, folder_name: str) -> str | None:
             await _save_folder_id(folder_name, fid)
         return fid
 
-    logger.error(f"Failed to create folder '{folder_name}': {response.text}")
+    logger.error(f"Failed to create folder '{folder_name}': {response.text[:100]}")
     return None
 
 
@@ -397,7 +397,7 @@ async def _upload_file(
     if response.status_code in (200, 201):
         return True
 
-    logger.error(f"Upload failed ({response.status_code}): {response.text[:300]}")
+    logger.error(f"Upload failed ({response.status_code}): {response.text[:100]}")
     return False
 
 
@@ -416,7 +416,7 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
         await asyncio.to_thread(dest_path.write_bytes, response.content)
         return True
 
-    logger.error(f"Download failed ({response.status_code}): {response.text[:300]}")
+    logger.error(f"Download failed ({response.status_code}): {response.text[:100]}")
     return False
 
 
@@ -589,7 +589,9 @@ async def _request_device_code(client_id: str) -> dict | None:
             )
 
             if response.status_code != 200:
-                logger.error(f"Device code request failed: {response.text}")
+                logger.error(
+                    f"Device code request failed: (status={response.status_code})"
+                )
                 return None
 
             return response.json()
@@ -949,7 +951,7 @@ class GDriveBackend(SyncBackend):
         if response.status_code not in (200, 201):
             raise RuntimeError(
                 f"GDriveBackend.push: upload failed ({response.status_code}): "
-                f"{response.text[:200]}"
+                f"{response.text[:100]}"
             )
 
     async def pull(self, sequence: int | None = None) -> bytes | None:

--- a/src/mnemo_mcp/temporal/queries.py
+++ b/src/mnemo_mcp/temporal/queries.py
@@ -56,11 +56,15 @@ def entity_search(
 
     if not entities:
         # Fallback: fuzzy substring match.
+        # Escape LIKE wildcards to prevent injection/broad matching.
+        escaped_name = (
+            name.strip().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
         like_sql = (
             "SELECT id, name, entity_type FROM memory_entities "
-            "WHERE name LIKE ? COLLATE NOCASE LIMIT 5"
+            "WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE LIMIT 5"
         )
-        entities = db._conn.execute(like_sql, (f"%{name.strip()}%",)).fetchall()
+        entities = db._conn.execute(like_sql, (f"%{escaped_name}%",)).fetchall()
     if not entities:
         return []
 

--- a/tests/temporal/test_resolve_edge_cases.py
+++ b/tests/temporal/test_resolve_edge_cases.py
@@ -1,0 +1,103 @@
+"""Edge case tests for mnemo_mcp.temporal.resolve."""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+import sqlite_vec
+
+from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.temporal.resolve import (
+    find_similar_entity,
+)
+
+# Skip all tests in this module when SQLite was compiled without
+# loadable-extensions support (macOS default).
+_test_conn = sqlite3.connect(":memory:")
+_HAS_LOAD_EXT = hasattr(_test_conn, "enable_load_extension")
+_test_conn.close()
+if _HAS_LOAD_EXT:
+    try:
+        _test_conn = sqlite3.connect(":memory:")
+        _test_conn.enable_load_extension(True)
+        _test_conn.close()
+    except (AttributeError, sqlite3.NotSupportedError):
+        _HAS_LOAD_EXT = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_LOAD_EXT,
+    reason="SQLite loadable extensions not enabled (macOS default).",
+)
+
+
+def _setup_vec(db: MemoryDB) -> None:
+    db._conn.enable_load_extension(True)
+    sqlite_vec.load(db._conn)
+    db._conn.enable_load_extension(False)
+    db._conn.execute(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS memory_entities_vec "
+        "USING vec0(embedding float[768])"
+    )
+    db._conn.commit()
+
+
+@pytest.fixture
+def db_with_vec(tmp_path):
+    db = MemoryDB(tmp_path / "test.db", embedding_dims=768)
+    _setup_vec(db)
+    yield db
+    db.close()
+
+
+class TestFindSimilarEntityEdgeCases:
+    def test_find_similar_returns_none_when_vec_table_empty(
+        self, db_with_vec: MemoryDB
+    ):
+        # Stage 1 miss
+        # Stage 2: vec table exists but is empty
+        v = [0.1] * 768
+        result = find_similar_entity(db_with_vec._conn, "Unknown", "concept", v)
+        assert result is None
+
+    def test_find_similar_returns_none_on_knn_exception(self, db_with_vec: MemoryDB):
+        v = [0.1] * 768
+
+        # Create a mock that wraps the real connection
+        mock_conn = MagicMock(wraps=db_with_vec._conn)
+
+        # Override execute to raise an exception when querying memory_entities_vec
+        def mock_execute(sql, *args):
+            if "FROM memory_entities_vec" in sql:
+                raise Exception("SIMULATED KNN FAILURE")
+            return db_with_vec._conn.execute(sql, *args)
+
+        mock_conn.execute.side_effect = mock_execute
+
+        result = find_similar_entity(mock_conn, "Something", "concept", v)
+        assert result is None
+
+    def test_find_similar_returns_none_when_rowid_missing_in_entities(
+        self, db_with_vec: MemoryDB
+    ):
+        v = [0.1] * 768
+        # Manually insert into memory_entities_vec a rowid that doesn't exist in memory_entities
+        import struct
+
+        def _serialize(vec):
+            # Pad or truncate to 768
+            v_pad = vec[:768] + [0.0] * (768 - len(vec))
+            return struct.Struct("768f").pack(*v_pad)
+
+        db_with_vec._conn.execute(
+            "INSERT INTO memory_entities_vec (rowid, embedding) VALUES (?, ?)",
+            (9999, _serialize(v)),
+        )
+        db_with_vec._conn.commit()
+
+        # This should find rowid 9999 in memory_entities_vec, but fail to find it in memory_entities
+        result = find_similar_entity(
+            db_with_vec._conn, "Unknown", "concept", v, threshold=0.0
+        )
+        assert result is None

--- a/tests/test_compression_env.py
+++ b/tests/test_compression_env.py
@@ -1,0 +1,29 @@
+import pytest
+
+from mnemo_mcp.compression import _env_compression_enabled
+
+
+def test_env_compression_enabled_default(monkeypatch):
+    """If COMPRESSION_ENABLED is not set, it should return True."""
+    monkeypatch.delenv("COMPRESSION_ENABLED", raising=False)
+    assert _env_compression_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", " yes ", "ON"])
+def test_env_compression_enabled_truthy(monkeypatch, val):
+    """If COMPRESSION_ENABLED is set to a truthy value, it should return True."""
+    monkeypatch.setenv("COMPRESSION_ENABLED", val)
+    assert _env_compression_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "maybe", "blue"])
+def test_env_compression_enabled_falsy(monkeypatch, val):
+    """If COMPRESSION_ENABLED is set to anything else, it should return False."""
+    monkeypatch.setenv("COMPRESSION_ENABLED", val)
+    assert _env_compression_enabled() is False
+
+
+def test_env_compression_enabled_empty(monkeypatch):
+    """Empty string should be False."""
+    monkeypatch.setenv("COMPRESSION_ENABLED", "")
+    assert _env_compression_enabled() is False

--- a/tests/test_db_serialize.py
+++ b/tests/test_db_serialize.py
@@ -1,0 +1,82 @@
+import struct
+
+from mnemo_mcp.db import _STRUCT_CACHE, _serialize_f32
+
+
+def test_serialize_f32_default():
+    """Test serialization with default target_dims (0)."""
+    vec = [1.0, 2.0, 3.0]
+    expected = struct.pack("3f", *vec)
+    assert _serialize_f32(vec) == expected
+    assert len(_serialize_f32(vec)) == 12
+
+
+def test_serialize_f32_truncate():
+    """Test truncation when input vector is longer than target_dims."""
+    vec = [1.0, 2.0, 3.0, 4.0]
+    target_dims = 2
+    expected = struct.pack("2f", 1.0, 2.0)
+    assert _serialize_f32(vec, target_dims) == expected
+    assert len(_serialize_f32(vec, target_dims)) == 8
+
+
+def test_serialize_f32_padding():
+    """Test zero-padding when input vector is shorter than target_dims."""
+    vec = [1.0, 2.0]
+    target_dims = 4
+    expected = struct.pack("4f", 1.0, 2.0, 0.0, 0.0)
+    assert _serialize_f32(vec, target_dims) == expected
+    assert len(_serialize_f32(vec, target_dims)) == 16
+
+
+def test_serialize_f32_exact():
+    """Test serialization when input vector length exactly matches target_dims."""
+    vec = [1.0, 2.0, 3.0]
+    target_dims = 3
+    expected = struct.pack("3f", *vec)
+    assert _serialize_f32(vec, target_dims) == expected
+
+
+def test_serialize_f32_empty():
+    """Test serialization of an empty list."""
+    vec = []
+    expected = b""
+    assert _serialize_f32(vec) == expected
+
+
+def test_serialize_f32_empty_with_target():
+    """Test serialization of an empty list with target_dims > 0."""
+    vec = []
+    target_dims = 2
+    expected = struct.pack("2f", 0.0, 0.0)
+    assert _serialize_f32(vec, target_dims) == expected
+
+
+def test_serialize_f32_cache_behavior():
+    """Verify that struct.Struct instances are cached in _STRUCT_CACHE."""
+    # Ensure we use a dimension that might not be in cache yet or verify it enters it
+    dims = 123
+    vec = [0.0] * dims
+
+    if dims in _STRUCT_CACHE:
+        del _STRUCT_CACHE[dims]
+
+    _serialize_f32(vec)
+
+    assert dims in _STRUCT_CACHE
+    assert isinstance(_STRUCT_CACHE[dims], struct.Struct)
+    assert _STRUCT_CACHE[dims].format == f"{dims}f"
+
+
+def test_serialize_f32_reuses_cache():
+    """Verify that _serialize_f32 reuses the cached Struct instance."""
+    dims = 5
+    vec = [1.0] * dims
+
+    _serialize_f32(vec)
+    first_struct = _STRUCT_CACHE[dims]
+
+    _serialize_f32(vec)
+    second_struct = _STRUCT_CACHE[dims]
+
+    assert first_struct is second_struct

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -18,6 +18,7 @@ from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.server import (
     _embed,
     _format_memory,
+    _json,
     config,
     main,
     memory,
@@ -598,3 +599,15 @@ class TestWarmupInitEmbeddingBackend:
         mock_logger.error.assert_called_with(
             "Local embedding init failed: Init Backend Failed"
         )
+
+
+class TestJsonHelper:
+    """Tests for the _json formatting helper."""
+
+    def test_json_indentation(self):
+        """Verify _json serializes with indent=2."""
+        data = {"a": 1, "b": [2, 3]}
+        result = _json(data)
+        expected = json.dumps(data, indent=2)
+        assert result == expected
+        assert "\n  " in result  # Check for 2-space indentation

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -101,6 +101,46 @@ class TestValidateCloudModels:
 
         assert result["cloud_ready"] is False
 
+    @patch(
+        "mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["fail-model", "success-model"]
+    )
+    @patch("mnemo_mcp.embedder.init_backend")
+    def test_cloud_first_candidate_fails_continues_to_next(self, mock_init):
+        from mnemo_mcp.setup_tool import _validate_cloud_models
+
+        mock_settings = MagicMock()
+        mock_settings.resolve_embedding_model.return_value = None
+
+        mock_backend_success = MagicMock()
+        mock_backend_success.check_available.return_value = 1024
+
+        def side_effect(mode, model):
+            if model == "fail-model":
+                raise Exception("Service unavailable")
+            return mock_backend_success
+
+        mock_init.side_effect = side_effect
+
+        result = _validate_cloud_models(mock_settings)
+
+        assert result["cloud_ready"] is True
+        assert result["model"] == "success-model"
+        assert result["dims"] == 1024
+
+    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["fail-1", "fail-2"])
+    @patch("mnemo_mcp.embedder.init_backend")
+    def test_cloud_all_candidates_fail_returns_not_ready(self, mock_init):
+        from mnemo_mcp.setup_tool import _validate_cloud_models
+
+        mock_settings = MagicMock()
+        mock_settings.resolve_embedding_model.return_value = None
+
+        mock_init.side_effect = Exception("Service unavailable")
+
+        result = _validate_cloud_models(mock_settings)
+
+        assert result["cloud_ready"] is False
+
 
 class TestDownloadLocalEmbedding:
     """_download_local_embedding downloads and validates local model."""

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -117,3 +117,117 @@ async def test_upload_boundary_uses_app_name():
         assert "mnemo_mcp_upload_boundary" in headers.get("Content-Type", "")
 
     file_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Error-log redaction: error responses from the OAuth token / device-code
+# endpoints can echo back token material (refresh tokens, authorization codes,
+# client secrets). We must never log the raw response body on these paths.
+# ---------------------------------------------------------------------------
+
+# A body that simulates an error response leaking sensitive material.
+_SENSITIVE_BODY = (
+    '{"error":"invalid_grant",'
+    '"refresh_token":"1//LEAKED-REFRESH-TOKEN",'
+    '"client_secret":"GOCSPX-LEAKED-SECRET"}'
+)
+_SECRET_MARKERS = ("LEAKED-REFRESH-TOKEN", "GOCSPX-LEAKED-SECRET", "refresh_token")
+
+
+def _mock_async_client(response):
+    """Build a patchable httpx.AsyncClient whose post() returns ``response``."""
+    mock_client = AsyncMock()
+    mock_client.post.return_value = response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_error_does_not_log_response_body():
+    """_refresh_token must log only the status code, never the raw body."""
+    from mnemo_mcp.sync import _refresh_token
+
+    response = MagicMock()
+    response.status_code = 400
+    response.text = _SENSITIVE_BODY
+
+    token = {"refresh_token": "1//USER-REFRESH", "client_id": "client123"}
+
+    with (
+        patch("mnemo_mcp.sync.gdrive.httpx.AsyncClient") as mock_client_cls,
+        patch("mnemo_mcp.sync.gdrive.settings") as mock_settings,
+        patch("mnemo_mcp.sync.gdrive.logger") as mock_logger,
+    ):
+        mock_settings.google_drive_client_id = "client123"
+        mock_settings.google_drive_client_secret = "GOCSPX-USER-SECRET"
+        mock_client_cls.return_value = _mock_async_client(response)
+
+        result = await _refresh_token(token)
+
+    assert result is None
+    logged = " ".join(str(c.args[0]) for c in mock_logger.error.call_args_list)
+    for marker in _SECRET_MARKERS:
+        assert marker not in logged, f"leaked '{marker}' in error log: {logged!r}"
+    assert "400" in logged
+
+
+@pytest.mark.asyncio
+async def test_request_device_code_error_does_not_log_response_body():
+    """_request_device_code must log only the status code, never the raw body."""
+    from mnemo_mcp.sync import _request_device_code
+
+    response = MagicMock()
+    response.status_code = 403
+    response.text = _SENSITIVE_BODY
+
+    with (
+        patch("mnemo_mcp.sync.gdrive.httpx.AsyncClient") as mock_client_cls,
+        patch("mnemo_mcp.sync.gdrive.logger") as mock_logger,
+    ):
+        mock_client_cls.return_value = _mock_async_client(response)
+
+        result = await _request_device_code("client123")
+
+    assert result is None
+    logged = " ".join(str(c.args[0]) for c in mock_logger.error.call_args_list)
+    for marker in _SECRET_MARKERS:
+        assert marker not in logged, f"leaked '{marker}' in error log: {logged!r}"
+    assert "403" in logged
+
+
+@pytest.mark.asyncio
+async def test_upload_file_error_truncates_response_body():
+    """_upload_file must truncate the logged response body to 100 chars."""
+    from mnemo_mcp.sync import _upload_file
+
+    long_body = "X" * 500
+    response = MagicMock()
+    response.status_code = 500
+    response.text = long_body
+
+    token = {"access_token": "test"}
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        f.write(b"test data")
+        f.flush()
+        file_path = Path(f.name)
+
+    with (
+        patch(
+            "mnemo_mcp.sync._drive_request",
+            new_callable=AsyncMock,
+            return_value=response,
+        ),
+        patch("mnemo_mcp.sync.gdrive.logger") as mock_logger,
+    ):
+        result = await _upload_file(token, file_path, "folder_id")
+
+    file_path.unlink(missing_ok=True)
+    assert result is False
+    logged = " ".join(str(c.args[0]) for c in mock_logger.error.call_args_list)
+    assert long_body not in logged
+    assert "X" * 100 in logged
+    assert "X" * 101 not in logged

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
@@ -979,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.1b1"
+version = "2.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1005,6 +1020,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "moto", extra = ["s3"] },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1028,7 +1044,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.16" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.15.0b3,<2" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.17.1,<2" },
     { name = "openai", specifier = ">=2.38.0" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1042,6 +1058,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.9.4" },
     { name = "moto", extras = ["s3"], specifier = ">=5.2.1" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1098,7 +1115,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.15.0b3"
+version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1112,9 +1129,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/ae/bc537b34cb0a1a79deca1ff536d4eb5d8f449e261fbfe1f13b9c90ed60d6/n24q02m_mcp_core-1.15.0b3.tar.gz", hash = "sha256:9b7baf3c4a91787051a53d72e8edf65ea142d1c7d49c9858a262cf168756a62c", size = 195053, upload-time = "2026-05-26T07:01:53.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/fb/57e17c4a6a4a1fffdf8ae40ece42871b54286937198ea9e6e419b2aa1838/n24q02m_mcp_core-1.17.1.tar.gz", hash = "sha256:3d663facdb36307bdd0a861fe0583504b330629c8724934e2a802681374f25d0", size = 201050, upload-time = "2026-05-29T04:44:23.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/96/3c261c481f912db42d3ef1b609d0ff9ef6190774aec559926d4b3f0a3e01/n24q02m_mcp_core-1.15.0b3-py3-none-any.whl", hash = "sha256:cb1bb5458ddfb416e10068852f5d0984af768ae27109f3f05185ff2a764678a1", size = 125591, upload-time = "2026-05-26T07:01:54.469Z" },
+    { url = "https://files.pythonhosted.org/packages/79/75/f23d5e828b742716787290494a426665bd78115aa6f06c0327f031ca7f9c/n24q02m_mcp_core-1.17.1-py3-none-any.whl", hash = "sha256:55a7fd90a47476f1db80fb9bb3143a9bd7d663b6f9e2fbe20b2fdba180f4f9a0", size = 128234, upload-time = "2026-05-29T04:44:21.756Z" },
 ]
 
 [[package]]
@@ -1890,6 +1907,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR improves the accuracy of the `_handle_config_setup_status` handler in `src/mnemo_mcp/server.py`.

Key changes:
- Exported `ALL_CONFIG_KEYS` from `src/mnemo_mcp/credential_state.py` (renamed from `_ALL_CONFIG_KEYS`).
- Updated `_handle_config_setup_status` to derive the setup state from live `PerPluginStore` and environment variables using `ALL_CONFIG_KEYS`. This ensures that Google Drive-only configurations are correctly identified as "configured".
- Added handling for the `CredentialState.SETUP_IN_PROGRESS` state.
- Preserved the legacy response format while ensuring accurate state derivation, preventing the UI from showing "connected" incorrectly when the module-level state is stale.

---
*PR created automatically by Jules for task [16613077720807137579](https://jules.google.com/task/16613077720807137579) started by @n24q02m*