### PR TITLE
[TEST] Missing test for clear_model_cache fallback logic

### DIFF
--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -29,8 +29,12 @@ def clear_model_cache(model_name: str) -> str | None:
     safe_name = model_name.replace("/", "--")
     model_cache = cache_dir / f"models--{safe_name}"
     if model_cache.exists():
-        shutil.rmtree(model_cache)
-        return str(model_cache)
+        try:
+            shutil.rmtree(model_cache)
+            return str(model_cache)
+        except OSError as e:
+            logger.warning(f"Failed to clear model cache {model_cache}: {e}")
+            return None
     return None
 
 

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -32,6 +32,20 @@ class TestClearModelCache:
 
         assert result is None
 
+    def test_returns_none_on_rmtree_error(self, tmp_path):
+        from mnemo_mcp.setup_tool import clear_model_cache
+
+        model_dir = tmp_path / "models--org--model"
+        model_dir.mkdir(parents=True)
+
+        with patch.dict("os.environ", {"QWEN3_EMBED_CACHE_PATH": str(tmp_path)}):
+            with patch("shutil.rmtree") as mock_rmtree:
+                mock_rmtree.side_effect = OSError("Permission denied")
+                result = clear_model_cache("org/model")
+
+        assert result is None
+        assert model_dir.exists()
+
 
 class TestValidateCloudModels:
     """_validate_cloud_models checks cloud embedding availability."""

--- a/uv.lock
+++ b/uv.lock
@@ -979,7 +979,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.1b1"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds test coverage for the fallback logic in `clear_model_cache`.
- Modified `src/mnemo_mcp/setup_tool.py` to wrap `shutil.rmtree` in a `try...except` block, ensuring it returns `None` and logs a warning on failure instead of raising an exception.
- Added a new test case `test_returns_none_on_rmtree_error` in `tests/test_setup_tool.py` to simulate a file system error and verify the fallback behavior.

---
*PR created automatically by Jules for task [196823969148493219](https://jules.google.com/task/196823969148493219) started by @n24q02m*