### PR TITLE
[TEST] Untested get_setup_url in credential_state.py

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -162,6 +162,12 @@ def get_setup_url() -> str | None:
     return _setup_url
 
 
+def set_setup_url(url: str | None) -> None:
+    """Set current relay setup URL (for testing/init)."""
+    global _setup_url
+    _setup_url = url
+
+
 def _is_http_mode() -> bool:
     """Detect HTTP mode from CLI args + env vars.
 

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -7,6 +7,7 @@ from mnemo_mcp.credential_state import (
     CLOUD_KEYS,
     CredentialState,
     get_setup_url,
+    set_setup_url,
     get_state,
     reset_state,
     resolve_credential_state,
@@ -35,20 +36,16 @@ class TestGetState:
 
 class TestGetSetupUrl:
     def test_returns_none_by_default(self):
-        import mnemo_mcp.credential_state as cs
-
-        old = cs._setup_url
-        cs._setup_url = None
+        old = get_setup_url()
+        set_setup_url(None)
         assert get_setup_url() is None
-        cs._setup_url = old
+        set_setup_url(old)
 
     def test_returns_url_when_set(self):
-        import mnemo_mcp.credential_state as cs
-
-        old = cs._setup_url
-        cs._setup_url = "https://example.com/setup"
+        old = get_setup_url()
+        set_setup_url("https://example.com/setup")
         assert get_setup_url() == "https://example.com/setup"
-        cs._setup_url = old
+        set_setup_url(old)
 
 
 # ---------------------------------------------------------------------------
@@ -440,10 +437,8 @@ class TestGDriveTokenPoll:
 class TestResetState:
     def test_resets_state_and_url(self):
         """Resets state to AWAITING_SETUP and clears URL."""
-        import mnemo_mcp.credential_state as cs
-
         set_state(CredentialState.CONFIGURED)
-        cs._setup_url = "https://some.url"
+        set_setup_url("https://some.url")
 
         with (
             patch("mcp_core.clear_mode"),
@@ -452,7 +447,7 @@ class TestResetState:
             reset_state()
 
         assert get_state() == CredentialState.AWAITING_SETUP
-        assert cs._setup_url is None
+        assert get_setup_url() is None
 
     def test_reset_exception_nonfatal(self):
         """Exception during reset doesn't raise."""

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -7,10 +7,10 @@ from mnemo_mcp.credential_state import (
     CLOUD_KEYS,
     CredentialState,
     get_setup_url,
-    set_setup_url,
     get_state,
     reset_state,
     resolve_credential_state,
+    set_setup_url,
     set_state,
 )
 


### PR DESCRIPTION
This PR addresses the untested `get_setup_url` function in `src/mnemo_mcp/credential_state.py`.

### Changes:
- **`src/mnemo_mcp/credential_state.py`**: Added `set_setup_url(url: str | None)` to allow setting the module-level `_setup_url` variable.
- **`tests/test_credential_state.py`**:
    - Updated `TestGetSetupUrl` to use `set_setup_url` and `get_setup_url` for testing, eliminating direct access to the private `_setup_url`.
    - Updated `TestResetState.test_resets_state_and_url` to use `get_setup_url()` for verification.

### Verification:
- Verified the logic with a standalone test script that mocks necessary dependencies (`mcp_core`, `fastmcp`, `loguru`).
- Logic confirmed:
    - Default is `None`.
    - `set_setup_url` correctly updates the value returned by `get_setup_url`.
    - `reset_state` correctly clears the URL to `None`.

---
*PR created automatically by Jules for task [16873144702088526449](https://jules.google.com/task/16873144702088526449) started by @n24q02m*