### PR TITLE
[FIX] Reduce parameter count for 'add_with_context_type'

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -265,8 +265,10 @@ memory(action="capture", text=..., context_type="fact")
           |
           v
 db.add_with_context_type(
-    content=<compressed>, text_raw=<original>,
-    compressed=True, compression_provider="gemini", ...
+    MemoryPayload(
+        content=<compressed>, text_raw=<original>,
+        compressed=True, compression_provider="gemini", ...
+    )
 )
 ```
 

--- a/docs/compression.md
+++ b/docs/compression.md
@@ -119,10 +119,10 @@ capture(text)
                        max_tokens=tokens_in // 2)
        -> tiktoken.encode(result) -> tokens_out
        -> {text, text_raw, compressed=True, provider, tokens_in, tokens_out}
-  -> db.add_with_context_type(content=result.text,
-                              text_raw=result.text_raw,
-                              compressed=True,
-                              compression_provider=...)
+  -> db.add_with_context_type(MemoryPayload(content=result.text,
+                                           text_raw=result.text_raw,
+                                           compressed=True,
+                                           compression_provider=...))
 ```
 
 `tiktoken cl100k_base` is the tokenizer (matches OpenAI + Anthropic

--- a/src/mnemo_mcp/capture.py
+++ b/src/mnemo_mcp/capture.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, Final
 
 from loguru import logger
 
+from mnemo_mcp.db import MemoryDB, MemoryPayload
+
 if TYPE_CHECKING:
     from mnemo_mcp.db import MemoryDB
 
@@ -163,16 +165,18 @@ async def capture(
 
     memory_id = await asyncio.to_thread(
         db.add_with_context_type,
-        content=stored_text,
-        context_type=context_type,
-        category=category,
-        tags=tags,
-        source=source,
-        embedding=embedding,
-        importance=importance,
-        text_raw=stored_text_raw,
-        compressed=stored_compressed,
-        compression_provider=stored_provider,
+        MemoryPayload(
+            content=stored_text,
+            context_type=context_type,
+            category=category,
+            tags=tags,
+            source=source,
+            embedding=embedding,
+            importance=importance,
+            text_raw=stored_text_raw,
+            compressed=stored_compressed,
+            compression_provider=stored_provider,
+        ),
     )
 
     return {

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -17,6 +17,7 @@ import sqlite3
 import struct
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -62,6 +63,24 @@ def _now_iso() -> str:
 # Maximum content length to prevent memory poisoning attacks (OWASP LLM09).
 # Limits damage from indirect prompt injection writing oversized payloads.
 MAX_CONTENT_LENGTH = 5000
+
+
+@dataclass
+class MemoryPayload:
+    """Payload for adding a new memory with rich context."""
+
+    content: str
+    context_type: str = "conversation"
+    category: str = "general"
+    tags: list[str] | None = None
+    source: str | None = None
+    embedding: list[float] | None = None
+    importance: float | None = None
+    text_raw: str | None = None
+    compressed: bool = False
+    compression_provider: str | None = None
+
+
 # Maximum tags allowed in a search filter to prevent complexity attacks.
 MAX_TAGS_FILTER = 50
 
@@ -416,17 +435,7 @@ class MemoryDB:
 
     def add_with_context_type(
         self,
-        content: str,
-        context_type: str = "conversation",
-        category: str = "general",
-        tags: list[str] | None = None,
-        source: str | None = None,
-        embedding: list[float] | None = None,
-        importance: float | None = None,
-        *,
-        text_raw: str | None = None,
-        compressed: bool = False,
-        compression_provider: str | None = None,
+        payload: MemoryPayload,
     ) -> str:
         """Add a new memory with an explicit ``context_type``.
 
@@ -462,6 +471,17 @@ class MemoryDB:
         Raises:
             ValueError: If content exceeds :data:`MAX_CONTENT_LENGTH`.
         """
+        content = payload.content
+        context_type = payload.context_type
+        category = payload.category
+        tags = payload.tags
+        source = payload.source
+        embedding = payload.embedding
+        importance = payload.importance
+        text_raw = payload.text_raw
+        compressed = payload.compressed
+        compression_provider = payload.compression_provider
+
         if len(content) > MAX_CONTENT_LENGTH:
             raise ValueError(
                 f"Content length {len(content)} exceeds limit of {MAX_CONTENT_LENGTH}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.db import MemoryDB, MemoryPayload
 
 
 @pytest.fixture
@@ -270,11 +270,13 @@ def test_mem_002_add_with_context_type_compression_columns(
     db = MemoryDB(isolated_db_path, embedding_dims=0)
     try:
         mid = db.add_with_context_type(
-            content="compressed text",
-            context_type="fact",
-            text_raw="original much longer raw text",
-            compressed=True,
-            compression_provider="gemini",
+            MemoryPayload(
+                content="compressed text",
+                context_type="fact",
+                text_raw="original much longer raw text",
+                compressed=True,
+                compression_provider="gemini",
+            )
         )
     finally:
         db.close()

--- a/tests/test_retrieval_polish.py
+++ b/tests/test_retrieval_polish.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.db import MemoryDB, MemoryPayload
 from mnemo_mcp.reranker import (
     CloudReranker,
     FallbackChainReranker,
@@ -249,10 +249,10 @@ def test_importance_boost_high_importance_higher(tmp_db: MemoryDB):
 
 def test_filter_context_type(tmp_db: MemoryDB):
     fact_id = tmp_db.add_with_context_type(
-        "users prefer light theme", context_type="fact"
+        MemoryPayload("users prefer light theme", context_type="fact")
     )
     pref_id = tmp_db.add_with_context_type(
-        "users prefer light theme", context_type="preference"
+        MemoryPayload("users prefer light theme", context_type="preference")
     )
 
     fact_only = tmp_db.search("users light theme", context_type="fact", limit=10)

--- a/uv.lock
+++ b/uv.lock
@@ -979,7 +979,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.1b1"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Refactored `MemoryDB.add_with_context_type` in `src/mnemo_mcp/db.py` to accept a single `MemoryPayload` dataclass instead of multiple individual parameters. This improves code maintainability and readability.

Key changes:
- Defined `MemoryPayload` dataclass in `src/mnemo_mcp/db.py`.
- Updated `MemoryDB.add_with_context_type` signature and implementation to use `MemoryPayload`.
- Updated all callers in `src/mnemo_mcp/capture.py`, `tests/test_retrieval_polish.py`, and `tests/test_migrations.py`.
- Updated documentation in `docs/compression.md` and `docs/ARCHITECTURE.md`.
- Verified changes with full test suite and static analysis (ruff, ty).

---
*PR created automatically by Jules for task [10699757198409991543](https://jules.google.com/task/10699757198409991543) started by @n24q02m*