### PR TITLE
fix: count GOOGLE_DRIVE_CLIENT_ID in setup-status so reported state is accurate

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -45,7 +45,7 @@ CLOUD_KEYS = [
 ]
 
 # All config keys that indicate a valid saved config (includes GDrive)
-_ALL_CONFIG_KEYS = [*CLOUD_KEYS, "GOOGLE_DRIVE_CLIENT_ID"]
+ALL_CONFIG_KEYS = [*CLOUD_KEYS, "GOOGLE_DRIVE_CLIENT_ID"]
 
 
 # Per-request JWT subject (HTTP multi-user remote mode only).
@@ -214,7 +214,7 @@ def resolve_credential_state() -> CredentialState:
             from mcp_core.storage.per_plugin_store import PerPluginStore
 
             saved = PerPluginStore("mnemo").load()
-            if saved and any(saved.get(k) for k in _ALL_CONFIG_KEYS):
+            if saved and any(saved.get(k) for k in ALL_CONFIG_KEYS):
                 # Apply to env vars
                 for key, value in saved.items():
                     if value and key not in os.environ:

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1720,6 +1720,7 @@ async def _handle_config_setup_status() -> str:
     from mcp_core.storage.per_plugin_store import PerPluginStore
 
     from mnemo_mcp.credential_state import (
+        ALL_CONFIG_KEYS,
         CLOUD_KEYS,
         CredentialState,
         credentials_for_current_request,
@@ -1735,25 +1736,29 @@ async def _handle_config_setup_status() -> str:
     if get_current_sub() is not None:
         _per_sub = credentials_for_current_request()
         _env_keys: list[str] = []
-        _store_keys = [k for k in CLOUD_KEYS if _per_sub.get(k)]
+        _store_keys = [k for k in ALL_CONFIG_KEYS if _per_sub.get(k)]
     else:
         # Derive providers_configured from live PerPluginStore load + env
         # so status is accurate even if module-level _state is stale.
         _saved = PerPluginStore("mnemo").load() or {}
-        _env_keys = [k for k in CLOUD_KEYS if os.environ.get(k)]
-        _store_keys = [k for k in CLOUD_KEYS if _saved.get(k)]
+        _env_keys = [k for k in ALL_CONFIG_KEYS if os.environ.get(k)]
+        _store_keys = [k for k in ALL_CONFIG_KEYS if _saved.get(k)]
     _providers = list(dict.fromkeys(_env_keys + _store_keys))
+    _state = get_state()
+
     if _providers:
         _derived_state = "configured"
-    elif get_state() == CredentialState.LOCAL:
+    elif _state == CredentialState.LOCAL:
         _derived_state = "local"
+    elif _state == CredentialState.SETUP_IN_PROGRESS:
+        _derived_state = "setup_in_progress"
     else:
         _derived_state = "awaiting_setup"
     return _json(
         {
             "state": _derived_state,
             "setup_url": get_setup_url(),
-            "cloud_keys_in_env": _env_keys,
+            "cloud_keys_in_env": [k for k in _env_keys if k in CLOUD_KEYS],
             "providers_configured": _providers,
         }
     )

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -120,3 +120,60 @@ class TestSetupStatusLiveDerivedState:
             result = _call_config_setup_status_sync()
 
         assert result["providers_configured"].count("GEMINI_API_KEY") == 1
+
+    def test_gdrive_only_store_counts_as_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A store with only GOOGLE_DRIVE_CLIENT_ID is reported as configured.
+
+        Pre-fix the handler counted only CLOUD_KEYS, so a GDrive-only saved
+        config wrongly reported awaiting_setup with an empty providers list.
+        The fix uses ALL_CONFIG_KEYS (incl GDrive) so the status is accurate.
+        """
+        for k in (
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "XAI_API_KEY",
+            "GOOGLE_DRIVE_CLIENT_ID",
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={"GOOGLE_DRIVE_CLIENT_ID": "client-id-123"},
+        ):
+            result = _call_config_setup_status_sync()
+
+        assert result["state"] == "configured"
+        assert "GOOGLE_DRIVE_CLIENT_ID" in result["providers_configured"]
+        # GDrive is not a cloud LLM/embedding key, so it must not leak into
+        # the cloud-keys-in-env summary even when present in the env.
+        assert "GOOGLE_DRIVE_CLIENT_ID" not in result["cloud_keys_in_env"]
+
+    def test_gdrive_env_not_listed_as_cloud_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GOOGLE_DRIVE_CLIENT_ID in env counts as a provider but is not a
+        cloud key in the ``cloud_keys_in_env`` summary."""
+        for k in (
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "XAI_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_ID", "client-id-456")
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={},
+        ):
+            result = _call_config_setup_status_sync()
+
+        assert "GOOGLE_DRIVE_CLIENT_ID" in result["providers_configured"]
+        assert "GOOGLE_DRIVE_CLIENT_ID" not in result["cloud_keys_in_env"]


### PR DESCRIPTION
## What

Re-lands the source fix from #665 cleanly on a fresh branch off current `main`, **dropping** the smuggled `uv.lock` / version-bump hunks that blocked the original PR.

## Source change

- `src/mnemo_mcp/credential_state.py` — rename module constant `_ALL_CONFIG_KEYS` -> `ALL_CONFIG_KEYS` so `server.py` can import it.
- `src/mnemo_mcp/server.py` (`_handle_config_setup_status`) — derive `providers_configured` from `ALL_CONFIG_KEYS` (which includes `GOOGLE_DRIVE_CLIENT_ID`) instead of `CLOUD_KEYS`, so a GDrive-only saved config is reported as `configured` instead of wrongly `awaiting_setup`. Keep `cloud_keys_in_env` filtered to `CLOUD_KEYS` so GDrive does not leak into the cloud-key summary. Also surface the existing `SETUP_IN_PROGRESS` state in the derived status.

## Test

- `tests/test_g6_ux_status_accuracy.py` — adds focused cases: a GDrive-only store reports `configured` + lists `GOOGLE_DRIVE_CLIENT_ID` as a provider, and GDrive is never reported as a cloud key. Mutation-checked: both new cases fail against pre-fix code.

## Diff scope

Exactly source `.py` + test `.py`. No `uv.lock` / version-bump hunks.

Supersedes #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)