### PR TITLE
⚡ Bolt: Optimize sqlite-vec search query to avoid N+1

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -684,7 +684,7 @@ class MemoryDB:
         if embedding and self._vec_enabled:
             try:
                 vec_sql = """
-                    SELECT v.id, v.distance
+                    SELECT m.*, v.distance
                     FROM memories_vec v
                     JOIN memories m ON v.id = m.id
                     WHERE v.embedding MATCH ?
@@ -710,28 +710,18 @@ class MemoryDB:
 
                 vec_rows = self._conn.execute(vec_sql, vec_params).fetchall()
 
-                missing_ids = []
-                vec_scores = {}
                 for row in vec_rows:
                     mid = row["id"]
                     vec_score = max(0.0, 1.0 - row["distance"])
-                    vec_scores[mid] = vec_score
                     if mid in results:
                         results[mid]["vec_score"] = vec_score
                     else:
-                        missing_ids.append(mid)
-
-                if missing_ids:
-                    missing_mems = self._conn.execute(
-                        "SELECT * FROM memories WHERE id IN (SELECT value FROM json_each(?))",
-                        (json.dumps(missing_ids),),
-                    ).fetchall()
-                    for mem in missing_mems:
-                        mid = mem["id"]
+                        mem_dict = dict(row)
+                        mem_dict.pop("distance", None)
                         results[mid] = {
-                            **dict(mem),
+                            **mem_dict,
                             "fts_score": 0.0,
-                            "vec_score": vec_scores[mid],
+                            "vec_score": vec_score,
                         }
             except Exception as e:
                 logger.debug(f"Vector search error: {e}")

--- a/tests/test_db_vec_coverage.py
+++ b/tests/test_db_vec_coverage.py
@@ -333,21 +333,9 @@ class TestSearchVecBranch:
                 self._inner = inner
 
             def execute(self, sql, *args, **kwargs):
-                # First vector query: return mid2 as a hit
+                # We simulate a failure in the vector search query itself
                 if "FROM memories_vec v" in sql and "MATCH" in sql:
-
-                    class _Cursor:
-                        def fetchall(self_):
-                            return [{"id": mid2, "distance": 0.1}]
-
-                        def fetchone(self_):
-                            return {"id": mid2, "distance": 0.1}
-
-                    return _Cursor()
-
-                # Second query (fetching missing mems): throw exception
-                if "FROM memories WHERE id IN" in sql:
-                    raise RuntimeError("missing mems fetch failed")
+                    raise RuntimeError("vector search failed")
 
                 return self._inner.execute(sql, *args, **kwargs)
 

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 **What:**
Optimized the vector search query in `src/mnemo_mcp/db.py` to fetch all necessary columns directly in the initial `JOIN` query instead of just returning IDs.

🎯 **Why:**
The previous implementation fetched vector IDs, found the ones missing from the FTS results, and then executed a second SQLite query using `json_each` to fetch the full row details. This was an unnecessary N+1 pattern since the initial vector query was already joining the `memories` table. 

📊 **Impact:**
Eliminates a complete database round-trip for missing vector search hits and avoids the CPU overhead of JSON serialization/parsing required by `json_each` for the ID list.

🔬 **Measurement:**
Verified correctness by running the full test suite (`uv run pytest`), ensuring the mock in `test_db_vec_coverage.py` was appropriately updated. Performance impact verified manually to show consistent reduction in query execution time when retrieving records not found in the initial FTS search.

---
*PR created automatically by Jules for task [1978686000733170827](https://jules.google.com/task/1978686000733170827) started by @n24q02m*