### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SQL variable limit DoS vector in tag queries

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -696,9 +696,8 @@ class MemoryDB:
                     vec_params.append(category)
 
                 if tags:
-                    q = ",".join(["?"] * len(tags))
-                    vec_sql += f" AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({q}))"
-                    vec_params.extend(tags)
+                    vec_sql += " AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN (SELECT value FROM json_each(?)))"
+                    vec_params.append(json.dumps(tags))
 
                 extra_sql, extra_params = self._build_filter_sql(**filter_kwargs)
                 if extra_sql:
@@ -825,9 +824,8 @@ class MemoryDB:
             filter_sql += " AND m.category = ?"
             filter_params.append(category)
         if tags:
-            q = ",".join(["?"] * len(tags))
-            filter_sql += f" AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({q}))"
-            filter_params.extend(tags)
+            filter_sql += " AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN (SELECT value FROM json_each(?)))"
+            filter_params.append(json.dumps(tags))
 
         extra_sql, extra_params = self._build_filter_sql(
             context_type=context_type,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The SQLite query generated for tag filtering dynamically expanded placeholders `IN (?, ?, ?)` for each tag provided in the input array.
🎯 Impact: This could crash the application due to SQLite exceeding its max bound variable limit (which can be as low as 999), creating a DoS vector if an attacker queries with a massive number of tags.
🔧 Fix: Used `json_each(?)` with a single bound `json.dumps(tags)` parameter, bypassing variable limits completely and ensuring safe parameter binding.
✅ Verification: Ran `uv run pytest tests/` which passed completely. Tested the specific DB and DB coverage tests which also succeeded.

---
*PR created automatically by Jules for task [9648192760657994146](https://jules.google.com/task/9648192760657994146) started by @n24q02m*