### PR TITLE
[TEST] Missing test for Exception in resolve.py

### DIFF
--- a/tests/temporal/test_resolve_exception.py
+++ b/tests/temporal/test_resolve_exception.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+from mnemo_mcp.temporal.resolve import find_similar_entity, insert_entity_with_embedding
+
+
+def test_find_similar_entity_exception_handling():
+    conn = MagicMock()
+    # Force _vec_table_exists to True so it proceeds to KNN
+    with (
+        patch("mnemo_mcp.temporal.resolve._vec_table_exists", return_value=True),
+        patch("mnemo_mcp.temporal.resolve.logger") as mock_logger,
+    ):
+
+        def side_effect(query, *args):
+            if "memory_entities_vec" in query:
+                raise Exception("KNN error")
+            mock_res = MagicMock()
+            mock_res.fetchone.return_value = None
+            return mock_res
+
+        conn.execute.side_effect = side_effect
+
+        res = find_similar_entity(conn, "name", "type", [0.1] * 768)
+
+        assert res is None
+        mock_logger.debug.assert_called_with(
+            "temporal.resolve: vec KNN failed (non-blocking): KNN error"
+        )
+
+
+def test_insert_entity_with_embedding_exception_handling():
+    conn = MagicMock()
+    # Force _vec_table_exists to True
+    with (
+        patch("mnemo_mcp.temporal.resolve._vec_table_exists", return_value=True),
+        patch("mnemo_mcp.temporal.resolve.logger") as mock_logger,
+    ):
+
+        def side_effect(query, *args):
+            if "INSERT INTO memory_entities_vec" in query:
+                raise Exception("Insert error")
+            mock_res = MagicMock()
+            if "SELECT id FROM memory_entities" in query:
+                mock_res.fetchone.return_value = ["some-id"]
+            elif "SELECT rowid FROM memory_entities" in query:
+                mock_res.fetchone.return_value = [123]
+            return mock_res
+
+        conn.execute.side_effect = side_effect
+
+        res = insert_entity_with_embedding(conn, "name", "type", [0.1] * 768)
+
+        assert res == "some-id"
+        mock_logger.debug.assert_called_with(
+            "temporal.resolve: embedding insert failed (non-blocking): Insert error"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds missing test coverage for exception handling in `src/mnemo_mcp/temporal/resolve.py`. 

The surrounding code in `resolve.py` contains `try...except` blocks that catch exceptions during vector database operations (like KNN search and embedding insertion) to ensure they are non-blocking. 

The new tests in `tests/temporal/test_resolve_exception.py`:
1. Use `unittest.mock.patch` to force `_vec_table_exists` to return `True`.
2. Mock the database connection's `execute` method to raise a generic `Exception` when specific SQL queries target the `memory_entities_vec` table.
3. Assert that `find_similar_entity` returns `None` and `insert_entity_with_embedding` returns the entity ID, proving the exceptions are caught and handled gracefully.
4. Verify via a mocked logger that the expected debug messages are emitted.

All tests in `tests/temporal/` have been run and passed.

---
*PR created automatically by Jules for task [2063181734617716156](https://jules.google.com/task/2063181734617716156) started by @n24q02m*