### PR TITLE
[TEST] Missing test file for src/mnemo_mcp/sync/s3.py

### DIFF
--- a/tests/sync/test_s3.py
+++ b/tests/sync/test_s3.py
@@ -283,3 +283,22 @@ async def test_s3_health_check_returns_false_on_generic_exception() -> None:
         backend._client = MagicMock()
         backend._client.head_bucket.side_effect = TimeoutError("network down")
         assert await backend.health_check() is False
+
+async def test_s3_last_remote_sequence_pagination_missing_token() -> None:
+    """IsTruncated=True but no NextContinuationToken -> breaks loop."""
+    from unittest.mock import MagicMock
+
+    backend = S3Backend(
+        bucket=_BUCKET,
+        region="us-east-1",
+        access_key_id="t",
+        secret_access_key="t",
+    )
+    backend._client = MagicMock()
+    backend._client.list_objects_v2.return_value = {
+        "Contents": [{"Key": "passport/seq-000001.bin"}],
+        "IsTruncated": True,
+        # missing NextContinuationToken
+    }
+
+    assert await backend.last_remote_sequence() == 1

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR addresses the missing test file issue for `src/mnemo_mcp/sync/s3.py` and improves test coverage.

- **Naming Convention Fix**: Renamed `tests/sync/test_s3_backend.py` to `tests/sync/test_s3.py` to align with the repository's 1:1 module-to-test naming convention.
- **Coverage Improvement**: Added a test case `test_s3_last_remote_sequence_pagination_missing_token` to cover a specific edge case in `last_remote_sequence` (missing `NextContinuationToken` when `IsTruncated` is True).
- **100% Coverage**: Verified that `src/mnemo_mcp/sync/s3.py` now has 100% code coverage.
- **Verification**: All tests in `tests/sync/` pass, and `ruff` / `ty` checks are clean.

---
*PR created automatically by Jules for task [17490551916601598428](https://jules.google.com/task/17490551916601598428) started by @n24q02m*