### PR TITLE
[TEST] Missing missing/empty dict edge case for upsert_entities in graph.py

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -217,6 +217,8 @@ def upsert_entities(conn, entities: list[dict]) -> list[str]:
     ordered_ents = []
 
     for ent in entities:
+        if not isinstance(ent, dict):
+            continue
         name = ent.get("name", "").strip()
         if not name:
             continue
@@ -267,6 +269,8 @@ def create_relations(
     to_insert = []
 
     for rel in relations:
+        if not isinstance(rel, dict):
+            continue
         src_name = rel.get("source", "").strip()
         tgt_name = rel.get("target", "").strip()
         rtype = rel.get("type", "related_to").strip().lower()

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -14,6 +14,7 @@ from mnemo_mcp.graph import (
     _has_llm_provider,
     _llm_completion,
     _resolve_llm_model,
+    create_relations,
     extract_entities,
     find_related_memory_ids,
     link_memory_entities,
@@ -351,6 +352,29 @@ class TestUpsertEntitiesCoverage:
         # First two should be the same
         assert ids[0] == ids[1]
         assert ids[0] != ids[2]
+
+    def test_non_dict_entities(self, tmp_db: MemoryDB):
+        """Gracefully skips non-dict entries in entities list."""
+        conn = tmp_db._conn
+        entities = [None, "not a dict", {"name": "Valid", "type": "concept"}]
+        ids = upsert_entities(conn, entities)
+        assert len(ids) == 1
+
+    def test_non_dict_relations(self, tmp_db: MemoryDB):
+        """Gracefully skips non-dict entries in relations list."""
+        conn = tmp_db._conn
+        tmp_db.add("test content")
+        eids = upsert_entities(
+            conn, [{"name": "A", "type": "concept"}, {"name": "B", "type": "concept"}]
+        )
+        name_to_id = {"A": eids[0], "B": eids[1]}
+
+        relations = [None, 123, {"source": "A", "target": "B", "type": "related_to"}]
+        # Should not raise
+        create_relations(conn, relations, name_to_id)
+
+        count = conn.execute("SELECT COUNT(*) FROM memory_edges").fetchone()[0]
+        assert count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -357,7 +357,7 @@ class TestUpsertEntitiesCoverage:
         """Gracefully skips non-dict entries in entities list."""
         conn = tmp_db._conn
         entities = [None, "not a dict", {"name": "Valid", "type": "concept"}]
-        ids = upsert_entities(conn, entities)
+        ids = upsert_entities(conn, entities)  # type: ignore
         assert len(ids) == 1
 
     def test_non_dict_relations(self, tmp_db: MemoryDB):
@@ -371,7 +371,7 @@ class TestUpsertEntitiesCoverage:
 
         relations = [None, 123, {"source": "A", "target": "B", "type": "related_to"}]
         # Should not raise
-        create_relations(conn, relations, name_to_id)
+        create_relations(conn, relations, name_to_id)  # type: ignore
 
         count = conn.execute("SELECT COUNT(*) FROM memory_edges").fetchone()[0]
         assert count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR addresses an issue in `src/mnemo_mcp/graph.py` where `upsert_entities` and `create_relations` would crash if passed a list containing non-dictionary elements (e.g., `None`).

Changes:
- Added `isinstance(ent, dict)` checks in the main loops of `upsert_entities` and `create_relations`.
- Added unit tests in `tests/test_graph_coverage.py` to verify the fix.
- Fixed linting and formatting issues in the modified files.

---
*PR created automatically by Jules for task [2807252630081628776](https://jules.google.com/task/2807252630081628776) started by @n24q02m*