### PR TITLE
[TEST] Missing empty memory_id edge case for link_memory_entities in graph.py

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -305,7 +305,7 @@ def create_relations(
 
 def link_memory_entities(conn, memory_id: str, entity_ids: list[str]) -> None:
     """Link a memory to entities."""
-    if not entity_ids:
+    if not memory_id or not memory_id.strip() or not entity_ids:
         return
 
     try:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -423,6 +423,16 @@ class TestLinkMemoryEntities:
         ).fetchone()[0]
         assert count == 0
 
+
+    def test_empty_memory_id(self, tmp_db: MemoryDB):
+        """No-op for empty memory_id."""
+        conn = tmp_db._conn
+        entities = [{"name": "Python", "type": "tool"}]
+        eids = upsert_entities(conn, entities)
+        link_memory_entities(conn, "", eids)
+        count = conn.execute("SELECT COUNT(*) FROM memory_entity_links").fetchone()[0]
+        assert count == 0
+
     def test_exception_is_caught_and_logged(self):
         """Exception during linking is caught and logged with details."""
         conn = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Modified `src/mnemo_mcp/graph.py` to handle cases where `memory_id` is an empty string or only contains whitespace in `link_memory_entities`. Added corresponding test coverage in `tests/test_graph.py`.

---
*PR created automatically by Jules for task [2704195034035778261](https://jules.google.com/task/2704195034035778261) started by @n24q02m*