### PR TITLE
[TEST] Missing empty topic edge case for recall_context in server.py

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2152,6 +2152,9 @@ def recall_context(topic: str) -> str:
     - Use when starting a new task or answering a question to retrieve prior context.
     - Parameters: 'topic' (the specific subject or keywords to search for).
     """
+    if not topic.strip():
+        raise ValueError("Topic cannot be empty")
+
     return (
         f"Search your memories for relevant context about: {topic}\n\n"
         "Use the memory tool with action='search' and this query. "

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -708,3 +708,9 @@ class TestPrompts:
         result = recall_context("machine learning")
         assert "machine learning" in result
         assert "search" in result.lower()
+
+    def test_recall_context_empty(self):
+        with pytest.raises(ValueError, match="Topic cannot be empty"):
+            recall_context("")
+        with pytest.raises(ValueError, match="Topic cannot be empty"):
+            recall_context("   ")

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The `recall_context` prompt was accepting empty or whitespace-only strings for the `topic` argument, resulting in nonsensical search prompts. This PR adds input validation to `recall_context` in `src/mnemo_mcp/server.py` to raise a `ValueError` with an appropriate message when the topic is empty. It also adds a corresponding unit test in `tests/test_server.py` to cover these edge cases.

---
*PR created automatically by Jules for task [18195889933493586088](https://jules.google.com/task/18195889933493586088) started by @n24q02m*