### PR TITLE
[FIX] N+1 Query when syncing memory_entity_links

### DIFF
--- a/src/mnemo_mcp/sync/delta.py
+++ b/src/mnemo_mcp/sync/delta.py
@@ -268,47 +268,43 @@ def _apply_kg_sections(db: MemoryDB, payload: dict[str, bytes]) -> dict:
     counts = {"entities_applied": 0, "edges_applied": 0, "links_applied": 0}
     cursor = db._conn.cursor()
 
+    # 1. Entities
     ents_raw = payload.get("memories_entities.jsonl", b"").decode("utf-8")
+    ents_to_insert = []
     for line in ents_raw.splitlines():
-        line = line.strip()
-        if not line:
+        if not (line := line.strip()):
             continue
         try:
             ent = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        try:
-            cursor.execute(
-                "INSERT OR IGNORE INTO memory_entities "
-                "(id, name, entity_type, created_at, updated_at) "
-                "VALUES (?, ?, ?, ?, ?)",
+            ents_to_insert.append(
                 (
                     ent.get("id"),
                     ent.get("name"),
                     ent.get("entity_type"),
                     ent.get("created_at"),
                     ent.get("updated_at"),
-                ),
+                )
             )
-            counts["entities_applied"] += cursor.rowcount or 0
-        except Exception as e:
-            logger.debug(f"apply_bundle: entity skipped ({e})")
+        except Exception:
+            continue
+    if ents_to_insert:
+        cursor.executemany(
+            "INSERT OR IGNORE INTO memory_entities "
+            "(id, name, entity_type, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ents_to_insert,
+        )
+        counts["entities_applied"] = cursor.rowcount or 0
 
+    # 2. Edges
     edges_raw = payload.get("memories_edges.jsonl", b"").decode("utf-8")
+    edges_to_insert = []
     for line in edges_raw.splitlines():
-        line = line.strip()
-        if not line:
+        if not (line := line.strip()):
             continue
         try:
             edge = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        try:
-            cursor.execute(
-                "INSERT OR IGNORE INTO memory_edges "
-                "(id, source_id, target_id, relation_type, created_at, "
-                " memory_id, valid_from, valid_to) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            edges_to_insert.append(
                 (
                     edge.get("id"),
                     edge.get("source_id"),
@@ -318,30 +314,38 @@ def _apply_kg_sections(db: MemoryDB, payload: dict[str, bytes]) -> dict:
                     edge.get("memory_id"),
                     edge.get("valid_from"),
                     edge.get("valid_to"),
-                ),
+                )
             )
-            counts["edges_applied"] += cursor.rowcount or 0
-        except Exception as e:
-            logger.debug(f"apply_bundle: edge skipped ({e})")
+        except Exception:
+            continue
+    if edges_to_insert:
+        cursor.executemany(
+            "INSERT OR IGNORE INTO memory_edges "
+            "(id, source_id, target_id, relation_type, created_at, "
+            " memory_id, valid_from, valid_to) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            edges_to_insert,
+        )
+        counts["edges_applied"] = cursor.rowcount or 0
 
+    # 3. Links
     links_raw = payload.get("memories_entity_links.jsonl", b"").decode("utf-8")
+    links_to_insert = []
     for line in links_raw.splitlines():
-        line = line.strip()
-        if not line:
+        if not (line := line.strip()):
             continue
         try:
             link = json.loads(line)
-        except json.JSONDecodeError:
+            links_to_insert.append((link.get("memory_id"), link.get("entity_id")))
+        except Exception:
             continue
-        try:
-            cursor.execute(
-                "INSERT OR IGNORE INTO memory_entity_links "
-                "(memory_id, entity_id) VALUES (?, ?)",
-                (link.get("memory_id"), link.get("entity_id")),
-            )
-            counts["links_applied"] += cursor.rowcount or 0
-        except Exception as e:
-            logger.debug(f"apply_bundle: link skipped ({e})")
+    if links_to_insert:
+        cursor.executemany(
+            "INSERT OR IGNORE INTO memory_entity_links "
+            "(memory_id, entity_id) VALUES (?, ?)",
+            links_to_insert,
+        )
+        counts["links_applied"] = cursor.rowcount or 0
 
     db._conn.commit()
     return counts

--- a/src/mnemo_mcp/sync/delta.py
+++ b/src/mnemo_mcp/sync/delta.py
@@ -271,11 +271,11 @@ def _apply_kg_sections(db: MemoryDB, payload: dict[str, bytes]) -> dict:
     # 1. Entities
     ents_raw = payload.get("memories_entities.jsonl", b"").decode("utf-8")
     ents_to_insert = []
-    for line in ents_raw.splitlines():
-        if not (line := line.strip()):
+    for rline in ents_raw.splitlines():
+        if not (rline := rline.strip()):
             continue
         try:
-            ent = json.loads(line)
+            ent = json.loads(rline)
             ents_to_insert.append(
                 (
                     ent.get("id"),
@@ -288,22 +288,34 @@ def _apply_kg_sections(db: MemoryDB, payload: dict[str, bytes]) -> dict:
         except Exception:
             continue
     if ents_to_insert:
-        cursor.executemany(
-            "INSERT OR IGNORE INTO memory_entities "
-            "(id, name, entity_type, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ents_to_insert,
-        )
-        counts["entities_applied"] = cursor.rowcount or 0
-
-    # 2. Edges
+        try:
+            cursor.executemany(
+                "INSERT OR IGNORE INTO memory_entities "
+                "(id, name, entity_type, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ents_to_insert,
+            )
+            counts["entities_applied"] = cursor.rowcount or 0
+        except Exception:
+            # Fallback for integrity errors (e.g. FK violations in bad bundles)
+            for row in ents_to_insert:
+                try:
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO memory_entities "
+                        "(id, name, entity_type, created_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        row,
+                    )
+                    counts["entities_applied"] += cursor.rowcount or 0
+                except Exception:
+                    continue
     edges_raw = payload.get("memories_edges.jsonl", b"").decode("utf-8")
     edges_to_insert = []
-    for line in edges_raw.splitlines():
-        if not (line := line.strip()):
+    for rline in edges_raw.splitlines():
+        if not (rline := rline.strip()):
             continue
         try:
-            edge = json.loads(line)
+            edge = json.loads(rline)
             edges_to_insert.append(
                 (
                     edge.get("id"),
@@ -319,34 +331,57 @@ def _apply_kg_sections(db: MemoryDB, payload: dict[str, bytes]) -> dict:
         except Exception:
             continue
     if edges_to_insert:
-        cursor.executemany(
-            "INSERT OR IGNORE INTO memory_edges "
-            "(id, source_id, target_id, relation_type, created_at, "
-            " memory_id, valid_from, valid_to) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            edges_to_insert,
-        )
-        counts["edges_applied"] = cursor.rowcount or 0
-
-    # 3. Links
+        try:
+            cursor.executemany(
+                "INSERT OR IGNORE INTO memory_edges "
+                "(id, source_id, target_id, relation_type, created_at, "
+                " memory_id, valid_from, valid_to) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                edges_to_insert,
+            )
+            counts["edges_applied"] = cursor.rowcount or 0
+        except Exception:
+            for row in edges_to_insert:
+                try:
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO memory_edges "
+                        "(id, source_id, target_id, relation_type, created_at, "
+                        " memory_id, valid_from, valid_to) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        row,
+                    )
+                    counts["edges_applied"] += cursor.rowcount or 0
+                except Exception:
+                    continue
     links_raw = payload.get("memories_entity_links.jsonl", b"").decode("utf-8")
     links_to_insert = []
-    for line in links_raw.splitlines():
-        if not (line := line.strip()):
+    for rline in links_raw.splitlines():
+        if not (rline := rline.strip()):
             continue
         try:
-            link = json.loads(line)
+            link = json.loads(rline)
             links_to_insert.append((link.get("memory_id"), link.get("entity_id")))
         except Exception:
             continue
     if links_to_insert:
-        cursor.executemany(
-            "INSERT OR IGNORE INTO memory_entity_links "
-            "(memory_id, entity_id) VALUES (?, ?)",
-            links_to_insert,
-        )
-        counts["links_applied"] = cursor.rowcount or 0
-
+        try:
+            cursor.executemany(
+                "INSERT OR IGNORE INTO memory_entity_links "
+                "(memory_id, entity_id) VALUES (?, ?)",
+                links_to_insert,
+            )
+            counts["links_applied"] = cursor.rowcount or 0
+        except Exception:
+            for row in links_to_insert:
+                try:
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO memory_entity_links "
+                        "(memory_id, entity_id) VALUES (?, ?)",
+                        row,
+                    )
+                    counts["links_applied"] += cursor.rowcount or 0
+                except Exception:
+                    continue
     db._conn.commit()
     return counts
 

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Optimized `_apply_kg_sections` in `src/mnemo_mcp/sync/delta.py` to use `executemany` for batch inserting entities, edges, and links. This replaces the N+1 query pattern with efficient batch operations, improving performance during sync.

---
*PR created automatically by Jules for task [717686907300016973](https://jules.google.com/task/717686907300016973) started by @n24q02m*