### PR TITLE
[FIX] N+1 Query in database migration / update

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -8,6 +8,7 @@ Provides:
 - Alembic schema migrations with backup-before-migrate
 """
 
+import hashlib
 import io
 import json
 import math
@@ -1672,8 +1673,6 @@ class MemoryDB:
         valid_from = migration time, breaking ``as_of`` queries against
         historical data).
         """
-        import hashlib
-
         try:
             cursor = self._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='memories'"
@@ -1709,6 +1708,7 @@ class MemoryDB:
             except Exception:
                 pass
 
+            updates = []
             for row in rows:
                 row_id = row["id"] if isinstance(row, sqlite3.Row) else row[0]
                 content = row["content"] if isinstance(row, sqlite3.Row) else row[1]
@@ -1716,12 +1716,15 @@ class MemoryDB:
                     row["created_at"] if isinstance(row, sqlite3.Row) else row[2]
                 )
                 digest = hashlib.sha256((content or "").encode("utf-8")).hexdigest()
-                self._conn.execute(
+                updates.append((digest, created_at, row_id))
+
+            if updates:
+                self._conn.executemany(
                     "UPDATE memories SET "
                     "  commit_sha = COALESCE(commit_sha, ?), "
                     "  valid_from = COALESCE(valid_from, ?) "
                     "WHERE id = ?",
-                    (digest, created_at, row_id),
+                    updates,
                 )
             self._conn.commit()
             logger.info(

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Refactored _backfill_phase3_temporal in src/mnemo_mcp/db.py to use executemany instead of individual execute calls for legacy row backfills. This improves performance by reducing database round-trips. Verified with a reproduction script and existing test suite.

---
*PR created automatically by Jules for task [453699280035572190](https://jules.google.com/task/453699280035572190) started by @n24q02m*