### PR TITLE
[SECURITY] Google Drive Query Injection

### DIFF
--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -63,6 +63,12 @@ _TOKEN_PROVIDER = "google_drive"
 # In-memory folder ID cache to avoid duplicate folder creation
 _folder_id_cache: dict[str, str] = {}
 
+
+def _escape_q(value: str) -> str:
+    """Escape single quotes for GDrive q queries."""
+    return value.replace("'", "\\'")
+
+
 # Lock to prevent race conditions during disk cache operations
 _folder_id_disk_lock = asyncio.Lock()
 
@@ -263,7 +269,7 @@ async def _find_or_create_folder(token: dict, folder_name: str) -> str | None:
     import asyncio
 
     query = (
-        f"name='{folder_name}' and mimeType='application/vnd.google-apps.folder' "
+        f"name='{_escape_q(folder_name)}' and mimeType='application/vnd.google-apps.folder' "
         f"and trashed=false"
     )
     for attempt in range(3):
@@ -316,7 +322,7 @@ async def _find_file_in_folder(
 
     Returns file metadata dict (id, name, modifiedTime), or None.
     """
-    query = f"name='{file_name}' and '{folder_id}' in parents and trashed=false"
+    query = f"name='{_escape_q(file_name)}' and '{_escape_q(folder_id)}' in parents and trashed=false"
     response = await _drive_request(
         "GET",
         f"{_DRIVE_API_BASE}/files",
@@ -861,7 +867,7 @@ async def _ensure_bundle_folder(token: dict, base_folder: str) -> str | None:
     # GDrive does not support nested folder names in queries directly; we
     # find-or-create a folder named "passport" whose parent is base_id.
     query = (
-        f"name='{_BUNDLE_FOLDER}' and '{base_id}' in parents "
+        f"name='{_escape_q(_BUNDLE_FOLDER)}' and '{_escape_q(base_id)}' in parents "
         f"and mimeType='application/vnd.google-apps.folder' and trashed=false"
     )
     response = await _drive_request(
@@ -1001,7 +1007,7 @@ class GDriveBackend(SyncBackend):
 
     @staticmethod
     async def _max_sequence(token: dict, folder_id: str) -> int:
-        query = f"'{folder_id}' in parents and trashed=false"
+        query = f"'{_escape_q(folder_id)}' in parents and trashed=false"
         response = await _drive_request(
             "GET",
             f"{_DRIVE_API_BASE}/files",

--- a/tests/test_sync_injection.py
+++ b/tests/test_sync_injection.py
@@ -1,0 +1,62 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mnemo_mcp.sync.gdrive import _find_file_in_folder, _find_or_create_folder
+
+
+@pytest.mark.asyncio
+async def test_find_file_in_folder_injection():
+    token = {"access_token": "test"}
+    folder_id = "folder123"
+    file_name = "o'malley.db"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"files": []}
+
+    with patch(
+        "mnemo_mcp.sync.gdrive._drive_request",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_request:
+        await _find_file_in_folder(token, folder_id, file_name)
+
+        call_args = mock_request.call_args
+        params = call_args.kwargs.get("params", {})
+        query = params.get("q", "")
+
+        # We expect it to be escaped: name='o\'malley.db'
+        assert "name='o\\'malley.db'" in query
+
+
+@pytest.mark.asyncio
+async def test_find_or_create_folder_injection():
+    token = {"access_token": "test"}
+    folder_name = "folder'name"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"files": []}
+
+    with patch(
+        "mnemo_mcp.sync.gdrive._drive_request",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_request:
+        # Avoid the cache and persistence
+        with (
+            patch("mnemo_mcp.sync.gdrive._folder_id_cache", {}),
+            patch("mnemo_mcp.sync.gdrive._load_folder_id", return_value=None),
+        ):
+            await _find_or_create_folder(token, folder_name)
+
+            # Find the GET call to /files
+            found_query = None
+            for call in mock_request.call_args_list:
+                if call.args[0] == "GET" and "/files" in call.args[1]:
+                    found_query = call.kwargs.get("params", {}).get("q", "")
+                    break
+
+            assert found_query is not None
+            assert "name='folder\\'name'" in found_query

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Fixed a vulnerability where single quotes in filenames or folder names could modify the intent of Google Drive search queries.

- Added `_escape_q` helper to escape single quotes in GDrive 'q' parameters.
- Applied escaping to `_find_or_create_folder`, `_find_file_in_folder`, `_ensure_bundle_folder`, and `_max_sequence`.
- Added `tests/test_sync_injection.py` to verify the fix.
- Documented the vulnerability and fix in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7037793886601643507](https://jules.google.com/task/7037793886601643507) started by @n24q02m*