### PR TITLE
[FIX] Refactor _handle_capture function

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -825,7 +825,6 @@ def _archive_trigger_interval() -> int:
     return max(1, value)
 
 
-
 def _maybe_trigger_background_archive(db: MemoryDB) -> None:
     """Archive policy auto-trigger: every Nth capture (default 100), run a
     background archive_by_score sweep so old low-importance rows soft-archive
@@ -845,9 +844,7 @@ def _maybe_trigger_background_archive(db: MemoryDB) -> None:
         )
 
 
-async def _trigger_capture_side_effects(
-    db: MemoryDB, result: dict, text: str
-) -> None:
+async def _trigger_capture_side_effects(db: MemoryDB, result: dict, text: str) -> None:
     """Trigger background enrichment and archive checks after a capture."""
     # Background enrichment only when we actually inserted a new row.
     if not result.get("deduplicated"):

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -825,6 +825,61 @@ def _archive_trigger_interval() -> int:
     return max(1, value)
 
 
+
+def _maybe_trigger_background_archive(db: MemoryDB) -> None:
+    """Archive policy auto-trigger: every Nth capture (default 100), run a
+    background archive_by_score sweep so old low-importance rows soft-archive
+    without requiring a manual ``archive_now`` call.
+    """
+    if not settings.archive_enabled:
+        return
+
+    _CAPTURE_COUNTER["calls"] += 1
+    interval = _archive_trigger_interval()
+    if _CAPTURE_COUNTER["calls"] % interval == 0:
+        asyncio.create_task(
+            asyncio.to_thread(
+                db.archive_by_score,
+                archive_after_days=int(settings.archive_after_days),
+            )
+        )
+
+
+async def _trigger_capture_side_effects(
+    db: MemoryDB, result: dict, text: str
+) -> None:
+    """Trigger background enrichment and archive checks after a capture."""
+    # Background enrichment only when we actually inserted a new row.
+    if not result.get("deduplicated"):
+        asyncio.create_task(_enrich_memory(db, result["memory_id"], text))
+
+    _maybe_trigger_background_archive(db)
+
+
+def _format_capture_result(
+    result: dict, embedding: list[float] | None, context_type: str
+) -> str:
+    """Format the capture pipeline result into a JSON response string."""
+    return _json(
+        {
+            "status": "deduplicated" if result.get("deduplicated") else "captured",
+            "id": result["memory_id"],
+            "context_type": result.get("context_type", context_type),
+            "deduplicated": bool(result.get("deduplicated")),
+            "auto": bool(result.get("auto")),
+            "semantic": embedding is not None,
+            **(
+                {
+                    "similarity": result["similarity"],
+                    "existing_content": result.get("existing_content"),
+                }
+                if result.get("deduplicated")
+                else {}
+            ),
+        }
+    )
+
+
 async def _handle_capture(
     ctx: Context | None,
     text: str | None,
@@ -891,42 +946,8 @@ async def _handle_capture(
         logger.exception("Unexpected error in _handle_capture")
         return _json({"error": "Internal error while capturing memory"})
 
-    # Background enrichment only when we actually inserted a new row.
-    if not result.get("deduplicated"):
-        asyncio.create_task(_enrich_memory(db, result["memory_id"], text))
-
-    # Archive policy auto-trigger: every Nth capture (default 100), run a
-    # background archive_by_score sweep so old low-importance rows soft-archive
-    # without requiring a manual ``archive_now`` call.
-    if settings.archive_enabled:
-        _CAPTURE_COUNTER["calls"] += 1
-        interval = _archive_trigger_interval()
-        if _CAPTURE_COUNTER["calls"] % interval == 0:
-            asyncio.create_task(
-                asyncio.to_thread(
-                    db.archive_by_score,
-                    archive_after_days=int(settings.archive_after_days),
-                )
-            )
-
-    return _json(
-        {
-            "status": "deduplicated" if result.get("deduplicated") else "captured",
-            "id": result["memory_id"],
-            "context_type": result.get("context_type", context_type),
-            "deduplicated": bool(result.get("deduplicated")),
-            "auto": bool(result.get("auto")),
-            "semantic": embedding is not None,
-            **(
-                {
-                    "similarity": result["similarity"],
-                    "existing_content": result.get("existing_content"),
-                }
-                if result.get("deduplicated")
-                else {}
-            ),
-        }
-    )
+    await _trigger_capture_side_effects(db, result, text)
+    return _format_capture_result(result, embedding, context_type)
 
 
 async def _handle_archive_now(

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Refactored the `_handle_capture` function in `src/mnemo_mcp/server.py` to improve readability and maintainability.
Logic has been decoupled into the following private helper functions:
- `_maybe_trigger_background_archive`: Handles the background archive trigger logic based on `_CAPTURE_COUNTER`.
- `_trigger_capture_side_effects`: Orchestrates post-capture tasks including memory enrichment and archival triggers.
- `_format_capture_result`: Formats the capture result dictionary into a structured JSON response.

Verified with `tests/test_capture.py` and `tests/test_server.py`. All tests passed.

---
*PR created automatically by Jules for task [15391274633986062973](https://jules.google.com/task/15391274633986062973) started by @n24q02m*