### PR TITLE
⚡ Bolt: Concurrent batch embeddings for faster processing

### DIFF
--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -359,13 +359,31 @@ class CloudEmbeddingBackend:
             f"(max {self.MAX_BATCH_SIZE}/batch)"
         )
 
+        # Bolt Performance Optimization:
+        # Process embedding batches concurrently instead of sequentially.
+        # This significantly reduces overall latency when processing large text payloads
+        # (e.g. initial knowledge base ingestion or large documents).
+        # We use a semaphore to avoid hitting provider rate limits when processing many batches.
+        semaphore = asyncio.Semaphore(5)
+
+        async def _embed_with_semaphore(batch, dimensions, batch_num):
+            async with semaphore:
+                logger.debug(
+                    f"Processing embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
+                )
+                return await self._embed_batch_inner(batch, dimensions)
+
+        tasks = []
         for i in range(0, len(texts), self.MAX_BATCH_SIZE):
             batch = texts[i : i + self.MAX_BATCH_SIZE]
             batch_num = i // self.MAX_BATCH_SIZE + 1
             logger.debug(
-                f"Embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
+                f"Preparing embedding batch {batch_num}/{total_batches}: {len(batch)} texts"
             )
-            batch_result = await self._embed_batch_inner(batch, dimensions)
+            tasks.append(_embed_with_semaphore(batch, dimensions, batch_num))
+
+        results = await asyncio.gather(*tasks)
+        for batch_result in results:
             all_embeddings.extend(batch_result)
 
         return all_embeddings

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 **What:**
Replaced the sequential loop in `CloudEmbeddingBackend.embed_texts` with an `asyncio.gather` approach, allowing multiple text batches to be sent to the embedding provider concurrently. A semaphore (limit of 5) was added to ensure we don't trigger API rate limits.

🎯 **Why:**
When capturing large amounts of knowledge or ingesting multiple rows, the previous implementation waited for each batch request to finish before starting the next. For cloud providers, this results in significant network round-trip overhead and bottlenecks.

📊 **Impact:**
Substantially faster processing times when generating embeddings for large payloads, cutting latency relative to the number of batches and round-trip time.

🔬 **Measurement:**
Tested by confirming standard embed flows do not regress using the test suite. To test in practice, trigger large imports or long text captures.

---
*PR created automatically by Jules for task [14236906405706419966](https://jules.google.com/task/14236906405706419966) started by @n24q02m*