### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQLite Maximum Variable Limit DoS

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -696,9 +696,8 @@ class MemoryDB:
                     vec_params.append(category)
 
                 if tags:
-                    q = ",".join(["?"] * len(tags))
-                    vec_sql += f" AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({q}))"
-                    vec_params.extend(tags)
+                    vec_sql += " AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN (SELECT value FROM json_each(?)))"
+                    vec_params.append(json.dumps(tags))
 
                 extra_sql, extra_params = self._build_filter_sql(**filter_kwargs)
                 if extra_sql:
@@ -825,9 +824,8 @@ class MemoryDB:
             filter_sql += " AND m.category = ?"
             filter_params.append(category)
         if tags:
-            q = ",".join(["?"] * len(tags))
-            filter_sql += f" AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN ({q}))"
-            filter_params.extend(tags)
+            filter_sql += " AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS (SELECT 1 FROM json_each(m.tags) WHERE value IN (SELECT value FROM json_each(?)))"
+            filter_params.append(json.dumps(tags))
 
         extra_sql, extra_params = self._build_filter_sql(
             context_type=context_type,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Generating dynamic placeholders for tags `IN (?, ?, ?)` in `src/mnemo_mcp/db.py` could hit SQLite's default variable limit (999), causing an application crash / DoS when searching with large arrays.
🎯 Impact: Denial of Service via application crash for queries supplying more than 999 tags.
🔧 Fix: Used `json_each(?)` with a JSON string parameter instead of dynamically generating `?` placeholders. This resolves the variable limit.
✅ Verification: Ran `uv run pytest tests/test_db.py` and full suite. Tests passed.

---
*PR created automatically by Jules for task [2107394293146822237](https://jules.google.com/task/2107394293146822237) started by @n24q02m*