### PR TITLE
🎨 Palette: Add suggestion to entity_graph error message

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1001,6 +1001,7 @@ async def _handle_entity_graph(
             {
                 "error": "entity_id or name required for entity_graph",
                 "example": "action='entity_graph', name='Python', depth=2",
+                "suggestion": "Pass 'entity_id' (from search results) or 'name' (entity name) to specify the anchor for the graph.",
             }
         )
     from mnemo_mcp.temporal.queries import entity_graph


### PR DESCRIPTION
💡 What: Added a `"suggestion"` field to the JSON error dictionary returned by `_handle_entity_graph` when `entity_id` and `name` are missing.
🎯 Why: In a backend MCP server, UX translates to Agent/Developer Experience (DX). Inconsistent error responses (e.g., missing a `suggestion` field in one handler while the rest have it) degrades the UX for consuming agents, who rely on structured hints to auto-correct bad inputs. This change makes the API more intuitive and consistent.
♿ Accessibility / UX: Improves error message clarity with an actionable step.

---
*PR created automatically by Jules for task [4478641256635902698](https://jules.google.com/task/4478641256635902698) started by @n24q02m*