### PR TITLE
🎨 Palette: Enhance API error responses with actionable suggestions

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -405,10 +405,17 @@ async def _handle_add(
             embedding=embedding,
         )
     except ValueError as e:
-        return _json({"error": str(e)})
+        return _json(
+            {"error": str(e), "suggestion": "Ensure the input values are valid."}
+        )
     except Exception:
         logger.exception("Unexpected error in _handle_add")
-        return _json({"error": "Internal error while adding memory"})
+        return _json(
+            {
+                "error": "Internal error while adding memory",
+                "suggestion": "Try again or check server logs for details.",
+            }
+        )
 
     result: dict = {
         "id": memory_id,
@@ -669,10 +676,17 @@ async def _handle_update(
             embedding=embedding,
         )
     except ValueError as e:
-        return _json({"error": str(e)})
+        return _json(
+            {"error": str(e), "suggestion": "Ensure the input values are valid."}
+        )
     except Exception:
         logger.exception("Unexpected error in _handle_update")
-        return _json({"error": "Internal error while updating memory"})
+        return _json(
+            {
+                "error": "Internal error while updating memory",
+                "suggestion": "Try again or check server logs for details.",
+            }
+        )
     if ok:
         # Background: re-extract entities if content changed
         if content:
@@ -886,10 +900,15 @@ async def _handle_capture(
                     ),
                 }
             )
-        return _json({"error": msg})
+        return _json({"error": msg, "suggestion": "Ensure the input values are valid."})
     except Exception:
         logger.exception("Unexpected error in _handle_capture")
-        return _json({"error": "Internal error while capturing memory"})
+        return _json(
+            {
+                "error": "Internal error while capturing memory",
+                "suggestion": "Try again or check server logs for details.",
+            }
+        )
 
     # Background enrichment only when we actually inserted a new row.
     if not result.get("deduplicated"):
@@ -1049,7 +1068,12 @@ async def _handle_consolidate(
 
     mode = settings.resolve_provider_mode()
     if mode == "local" and not _has_llm_provider():
-        return _json({"error": "Consolidation requires LLM (SDK mode with API keys)"})
+        return _json(
+            {
+                "error": "Consolidation requires LLM (SDK mode with API keys)",
+                "suggestion": "Configure an LLM provider and API key.",
+            }
+        )
 
     if not category:
         return _json(
@@ -1103,7 +1127,12 @@ async def _handle_consolidate(
             }
         )
     except Exception as e:
-        return _json({"error": f"Consolidation failed: {e}"})
+        return _json(
+            {
+                "error": f"Consolidation failed: {e}",
+                "suggestion": "Check server logs for details.",
+            }
+        )
 
 
 # --- Tools ---
@@ -1914,10 +1943,20 @@ async def _handle_config_sync_now(ctx: Context | None, backend: str | None) -> s
         result = await sync_now(db, target, passphrase)
         return _json({"backend": target, **result})
     except KeyError as e:
-        return _json({"error": str(e)})
+        return _json(
+            {
+                "error": str(e),
+                "suggestion": "Check your configuration for the requested backend.",
+            }
+        )
     except Exception as e:
         logger.exception("sync_now failed")
-        return _json({"error": f"sync_now failed: {e}"})
+        return _json(
+            {
+                "error": f"sync_now failed: {e}",
+                "suggestion": "Check server logs for details.",
+            }
+        )
 
 
 async def _handle_config_export_passport(ctx: Context | None) -> str:
@@ -1970,10 +2009,20 @@ async def _handle_config_import_passport(
         backend = get_backend(target)
         bundle = await backend.pull(sequence=None)
     except KeyError as e:
-        return _json({"error": str(e)})
+        return _json(
+            {
+                "error": str(e),
+                "suggestion": "Check your configuration for the requested backend.",
+            }
+        )
     except Exception as e:
         logger.exception("import_passport: backend pull failed")
-        return _json({"error": f"backend pull failed: {e}"})
+        return _json(
+            {
+                "error": f"backend pull failed: {e}",
+                "suggestion": "Check server logs for details.",
+            }
+        )
 
     if not bundle:
         return _json(
@@ -2019,7 +2068,12 @@ async def _handle_memory_compress(ctx: Context | None, memory_id: str | None) ->
 
     row = await asyncio.to_thread(db.get, memory_id)
     if not row:
-        return _json({"error": f"Memory {memory_id} not found"})
+        return _json(
+            {
+                "error": f"Memory {memory_id} not found",
+                "suggestion": "Verify the memory_id using action='search' or action='list'.",
+            }
+        )
     if row.get("compressed"):
         return _json(
             {

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Enhance API error responses with actionable suggestions

**Learning:** 
Adding actionable `suggestion` fields to all JSON error responses makes the MCP server's tools much easier to use, improving Developer/Agent Experience (DX). In the context of a backend service, this is a core UX improvement as it guides the user (often an AI agent or a developer using the system) towards a successful resolution without having to dig through logs or documentation.

**Action:** 
Ensured all API error responses generated by `_json({"error": ...})` include a `suggestion` field providing concrete steps to resolve the error. For example, pointing to the correct action to find an ID or checking configuration when a backend request fails. Included these updates in `src/mnemo_mcp/server.py` and documented the learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [3536599536905406649](https://jules.google.com/task/3536599536905406649) started by @n24q02m*