### PR TITLE
[TEST] Missing empty memory_id edge case for link_memory_entities in graph.py

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -305,6 +305,9 @@ def create_relations(
 
 def link_memory_entities(conn, memory_id: str, entity_ids: list[str]) -> None:
     """Link a memory to entities."""
+    if not memory_id or not memory_id.strip():
+        return
+
     if not entity_ids:
         return
 

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -375,7 +375,6 @@ class TestLinkMemoryEntitiesCoverage:
         # Should return early before any DB calls
         link_memory_entities(conn, "", ["eid1"])
         link_memory_entities(conn, "   ", ["eid1"])
-        link_memory_entities(conn, None, ["eid1"])
         assert not conn.executemany.called
 
     def test_exception_is_caught_and_logged(self, tmp_db: MemoryDB):

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -369,6 +369,15 @@ class TestLinkMemoryEntitiesCoverage:
         ).fetchone()[0]
         assert count == 0
 
+    def test_empty_memory_id(self, tmp_db: MemoryDB):
+        """No-op for empty or whitespace memory_id."""
+        conn = MagicMock()
+        # Should return early before any DB calls
+        link_memory_entities(conn, "", ["eid1"])
+        link_memory_entities(conn, "   ", ["eid1"])
+        link_memory_entities(conn, None, ["eid1"])
+        assert not conn.executemany.called
+
     def test_exception_is_caught_and_logged(self, tmp_db: MemoryDB):
         """Exception during linking is caught and logged with details."""
         conn = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4b1"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Added validation to 'link_memory_entities' in 'src/mnemo_mcp/graph.py' to return early if 'memory_id' is empty or whitespace. Added a corresponding test case 'test_empty_memory_id' in 'tests/test_graph_coverage.py' and verified it passes.

---
*PR created automatically by Jules for task [10603531739783967433](https://jules.google.com/task/10603531739783967433) started by @n24q02m*