### PR TITLE
fix: report package version in serverInfo and align DB path env var

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 
 
@@ -60,7 +61,9 @@ class Settings(BaseSettings):
     """Mnemo MCP Server configuration.
 
     Environment variables:
-    - DB_PATH: Path to SQLite database (default: ~/.mnemo-mcp/memories.db)
+    - DB_PATH (or MNEMO_DB_PATH): Path to SQLite database
+        (default: ~/.mnemo-mcp/memories.db). Both names are accepted;
+        MNEMO_DB_PATH matches the name used by alembic migrations.
     - API_KEYS: Provider API keys, supports multiple providers
         Format: "ENV_VAR:key,ENV_VAR:key,..."
         Example: "COHERE_API_KEY:co-...,GEMINI_API_KEY:AIza..."
@@ -75,8 +78,10 @@ class Settings(BaseSettings):
     - GOOGLE_DRIVE_CLIENT_SECRET: OAuth client secret for Google Drive sync
     """
 
-    # Database
-    db_path: str = ""
+    # Database. Accepts either DB_PATH (runtime, backward-compat) or
+    # MNEMO_DB_PATH (the name alembic migrations read in alembic/env.py),
+    # so a single env var aligns runtime and migrations.
+    db_path: str = Field("", validation_alias=AliasChoices("DB_PATH", "MNEMO_DB_PATH"))
 
     # Provider API Keys: "ENV_VAR:key,ENV_VAR:key,..."
     api_keys: str | None = None
@@ -159,6 +164,9 @@ class Settings(BaseSettings):
         "env_prefix": "",
         "case_sensitive": False,
         "validate_assignment": True,
+        # Allow init by field name (e.g. Settings(db_path=...)) in addition
+        # to the env aliases declared via validation_alias on db_path.
+        "populate_by_name": True,
     }
 
     def get_db_path(self) -> Path:

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -15,6 +15,7 @@ import sys
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from importlib import resources as pkg_resources
+from importlib.metadata import version as _pkgver
 
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
@@ -22,6 +23,10 @@ from mcp.types import ToolAnnotations
 
 from mnemo_mcp.config import _EMBEDDING_CANDIDATES, settings
 from mnemo_mcp.db import MemoryDB
+
+# Resolved via importlib.metadata (not ``from mnemo_mcp import __version__``)
+# to avoid a circular import: ``mnemo_mcp/__init__`` imports ``server.main``.
+__version__ = _pkgver("mnemo-mcp")
 
 # Constant embedding dimensions for sqlite-vec.
 # All embeddings are truncated to this size so switching models never
@@ -276,6 +281,10 @@ mcp = FastMCP(
     instructions="Persistent AI memory. Proactively save preferences, decisions, facts. Search before recommending.",
     lifespan=lifespan,
 )
+# FastMCP (mcp.server.fastmcp) has no ``version=`` kwarg; set it on the
+# lowlevel server so initialize's serverInfo.version reports the package
+# version instead of the MCP SDK version.
+mcp._mcp_server.version = __version__
 
 
 # --- Helper ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,7 @@ def clean_env(monkeypatch):
         "GOOGLE_DRIVE_CLIENT_ID",
         "GOOGLE_DRIVE_CLIENT_SECRET",
         "DB_PATH",
+        "MNEMO_DB_PATH",
         "LOG_LEVEL",
         "MCP_RELAY_URL",
         "QWEN3_EMBED_CACHE_PATH",
@@ -107,6 +108,18 @@ class TestDbPath:
     def test_data_dir_default(self):
         s = Settings()
         assert s.get_data_dir() == Path.home() / ".mnemo-mcp"
+
+    def test_db_path_env(self, monkeypatch):
+        """DB_PATH env var is honored (backward-compat)."""
+        monkeypatch.setenv("DB_PATH", "/tmp/db_path.db")
+        s = Settings()
+        assert s.get_db_path() == Path("/tmp/db_path.db")
+
+    def test_mnemo_db_path_env(self, monkeypatch):
+        """MNEMO_DB_PATH env var is honored (matches alembic migrations)."""
+        monkeypatch.setenv("MNEMO_DB_PATH", "/tmp/x.db")
+        s = Settings()
+        assert s.get_db_path() == Path("/tmp/x.db")
 
 
 class TestApiKeys:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -708,3 +708,13 @@ class TestPrompts:
         result = recall_context("machine learning")
         assert "machine learning" in result
         assert "search" in result.lower()
+
+
+class TestServerVersion:
+    def test_serverinfo_version_matches_package(self):
+        """initialize's serverInfo.version reports the package version,
+        not the MCP SDK version."""
+        from mnemo_mcp.server import __version__, mcp
+
+        init_opts = mcp._mcp_server.create_initialization_options()
+        assert init_opts.server_version == __version__


### PR DESCRIPTION
Two small fixes.

## Fix A — serverInfo.version
`FastMCP("Mnemo", ...)` (mcp.server.fastmcp) has no `version=` kwarg, so initialize's `serverInfo.version` reported the MCP SDK version (e.g. `1.27.2`). Now `mcp._mcp_server.version` is set to the package version, so `create_initialization_options().server_version == mnemo-mcp version`.

## Fix B — align DB path env var
Runtime `Settings.db_path` read `DB_PATH` while alembic migrations (`alembic/env.py`) read `MNEMO_DB_PATH` — same concept, two names. The `db_path` field now honors both via `AliasChoices("DB_PATH", "MNEMO_DB_PATH")` (DB_PATH kept for backward-compat). `populate_by_name=True` keeps `Settings(db_path=...)` init working. Alembic env.py is unchanged.

## Tests
- `test_server.py::TestServerVersion` asserts `create_initialization_options().server_version == __version__`.
- `test_config.py::TestDbPath` adds `MNEMO_DB_PATH` and `DB_PATH` env resolution tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)