### PR TITLE
fix: gitignore bot/merge junk artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,11 @@ docs/superpowers/
 *.db.bak.*-wal
 *.db.bak.*-shm
 .mnemo-mcp-alembic-placeholder.db
+
+# Bot/merge junk artifacts (prevent accidental commits) — 2026-06-07
+*.orig
+*.rej
+*.cover
+*.bak
+/*.patch
+/*.diff


### PR DESCRIPTION
Prevents accidental commits of merge/patch junk (*.orig, *.rej, *.patch, *.diff, *.cover, *.bak) that bot PRs occasionally introduced. gitignore-only, inert.