### PR TITLE
[TEST] Missing test for Exception in resolve.py

### DIFF
--- a/src/mnemo_mcp/temporal/resolve.py
+++ b/src/mnemo_mcp/temporal/resolve.py
@@ -99,37 +99,31 @@ def find_similar_entity(
     if embedding is None or not _vec_table_exists(conn):
         return None
 
-    try:  # pragma: no cover - requires sqlite-vec; macOS sqlite3 lacks loadable ext
+    try:
         rows = conn.execute(
             "SELECT v.rowid, v.distance FROM memory_entities_vec v "
             "WHERE v.embedding MATCH ? AND k = 1 "
             "ORDER BY v.distance",
             (_serialize(embedding),),
         ).fetchall()
-    except Exception as e:  # pragma: no cover
+    except Exception as e:
         logger.debug(f"temporal.resolve: vec KNN failed (non-blocking): {e}")
         return None
 
-    if not rows:  # pragma: no cover
+    if not rows:
         return None
-    rowid = (
-        rows[0][0] if not hasattr(rows[0], "keys") else rows[0]["rowid"]
-    )  # pragma: no cover
-    distance = (
-        rows[0][1] if not hasattr(rows[0], "keys") else rows[0]["distance"]
-    )  # pragma: no cover
-    similarity = max(0.0, 1.0 - float(distance) / 2.0)  # pragma: no cover
-    if similarity < threshold:  # pragma: no cover
+    rowid = rows[0][0] if not hasattr(rows[0], "keys") else rows[0]["rowid"]
+    distance = rows[0][1] if not hasattr(rows[0], "keys") else rows[0]["distance"]
+    similarity = max(0.0, 1.0 - float(distance) / 2.0)
+    if similarity < threshold:
         return None
 
-    ent_row = conn.execute(  # pragma: no cover
+    ent_row = conn.execute(
         "SELECT id FROM memory_entities WHERE rowid = ?", (rowid,)
     ).fetchone()
-    if ent_row is None:  # pragma: no cover
+    if ent_row is None:
         return None
-    return (
-        ent_row[0] if not hasattr(ent_row, "keys") else ent_row["id"]
-    )  # pragma: no cover
+    return ent_row[0] if not hasattr(ent_row, "keys") else ent_row["id"]
 
 
 def insert_entity_with_embedding(
@@ -158,7 +152,7 @@ def insert_entity_with_embedding(
     actual_id = actual[0] if actual and not hasattr(actual, "keys") else actual["id"]
 
     # Parallel embedding row when vec table is present.
-    if embedding is not None and _vec_table_exists(conn):  # pragma: no cover - vec ext
+    if embedding is not None and _vec_table_exists(conn):
         try:
             ent_rowid = conn.execute(
                 "SELECT rowid FROM memory_entities WHERE id = ?",

--- a/tests/temporal/test_resolve_exception.py
+++ b/tests/temporal/test_resolve_exception.py
@@ -1,6 +1,14 @@
+import struct
 from unittest.mock import MagicMock, patch
 
-from mnemo_mcp.temporal.resolve import find_similar_entity, insert_entity_with_embedding
+import pytest
+
+from mnemo_mcp.temporal.resolve import (
+    _resolve_threshold,
+    _serialize,
+    find_similar_entity,
+    insert_entity_with_embedding,
+)
 
 
 def test_find_similar_entity_exception_handling():
@@ -54,3 +62,61 @@ def test_insert_entity_with_embedding_exception_handling():
         mock_logger.debug.assert_called_with(
             "temporal.resolve: embedding insert failed (non-blocking): Insert error"
         )
+
+
+def test_serialize_short_vector():
+    vec = [0.1, 0.2]
+    res = _serialize(vec)
+    assert len(res) == 768 * 4
+    unpacked = struct.unpack("768f", res)
+    assert unpacked[0] == pytest.approx(0.1)
+    assert unpacked[1] == pytest.approx(0.2)
+    assert all(v == 0.0 for v in unpacked[2:])
+
+
+def test_serialize_long_vector():
+    vec = [0.1] * 1000
+    res = _serialize(vec)
+    assert len(res) == 768 * 4
+    unpacked = struct.unpack("768f", res)
+    assert len(unpacked) == 768
+
+
+def test_insert_entity_with_embedding_no_rowid():
+    conn = MagicMock()
+    # Mocking refetch of id to succeed
+    actual_mock = MagicMock()
+    actual_mock.__getitem__.side_effect = lambda x: (
+        "some-id" if x == 0 or x == "id" else None
+    )
+    actual_mock.keys.return_value = ["id"]
+
+    # Mocking refetch of rowid to return None
+    def side_effect(query, *args):
+        mock_res = MagicMock()
+        if "SELECT id FROM memory_entities" in query:
+            mock_res.fetchone.return_value = actual_mock
+            return mock_res
+        if "SELECT rowid FROM memory_entities" in query:
+            mock_res.fetchone.return_value = None
+            return mock_res
+        return mock_res
+
+    conn.execute.side_effect = side_effect
+
+    with patch("mnemo_mcp.temporal.resolve._vec_table_exists", return_value=True):
+        res = insert_entity_with_embedding(conn, "name", "type", [0.1] * 768)
+        assert res == "some-id"
+        # Ensure it didn't try to DELETE or INSERT into vec table
+        for call in conn.execute.call_args_list:
+            query = call[0][0]
+            assert "DELETE FROM memory_entities_vec" not in query
+            assert "INSERT INTO memory_entities_vec" not in query
+
+
+def test_resolve_threshold_invalid_env(monkeypatch):
+    monkeypatch.setenv("TEMPORAL_ENTITY_RESOLUTION_THRESHOLD", "not-a-float")
+    with patch("mnemo_mcp.temporal.resolve.logger") as mock_logger:
+        val = _resolve_threshold()
+        assert val == 0.85
+        mock_logger.warning.assert_called()

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Achieved 100% test coverage for `src/mnemo_mcp/temporal/resolve.py` by removing `pragma: no cover` markers and adding explicit tests for exception handling, edge cases in `_serialize` (short/long vectors), and database re-fetch failures in `insert_entity_with_embedding`.

Specifically:
- Removed `pragma: no cover` markers from `src/mnemo_mcp/temporal/resolve.py`.
- Added tests for `_serialize` with short and long vectors.
- Added a test for `insert_entity_with_embedding` where the re-fetch of `rowid` fails.
- Added a test for `_resolve_threshold` with an invalid environment variable value.
- Updated `tests/temporal/test_resolve_exception.py` to include these new cases and ensured it passes linting and type checking.

---
*PR created automatically by Jules for task [7079183766867985068](https://jules.google.com/task/7079183766867985068) started by @n24q02m*