### PR TITLE
fix(graph): add memory_id validation to link_memory_entities

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -305,6 +305,9 @@ def create_relations(
 
 def link_memory_entities(conn, memory_id: str, entity_ids: list[str]) -> None:
     """Link a memory to entities."""
+    if not memory_id or not memory_id.strip():
+        return
+
     if not entity_ids:
         return
 

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -369,6 +369,22 @@ class TestLinkMemoryEntitiesCoverage:
         ).fetchone()[0]
         assert count == 0
 
+    def test_empty_memory_id(self, tmp_db: MemoryDB):
+        """No-op for empty or whitespace memory_id."""
+        conn = tmp_db._conn
+        entities = upsert_entities(conn, [{"name": "Python", "type": "tool"}])
+
+        # Empty string
+        link_memory_entities(conn, "", entities)
+        # Whitespace
+        link_memory_entities(conn, "  ", entities)
+        with patch("mnemo_mcp.graph.logger") as mock_logger:
+            link_memory_entities(conn, "", entities)
+            assert not mock_logger.debug.called
+
+        count = conn.execute("SELECT COUNT(*) FROM memory_entity_links").fetchone()[0]
+        assert count == 0
+
     def test_exception_is_caught_and_logged(self, tmp_db: MemoryDB):
         """Exception during linking is caught and logged with details."""
         conn = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Added validation to return early if memory_id is empty or whitespace-only. This prevents unnecessary database operations and potential foreign key constraint violations when the caller provides an invalid ID. Added corresponding unit test in tests/test_graph_coverage.py.

---
*PR created automatically by Jules for task [13640561808278921473](https://jules.google.com/task/13640561808278921473) started by @n24q02m*