### PR TITLE
[FIX] N+1 Query in database migration / update

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1707,6 +1707,7 @@ class MemoryDB:
             except Exception:
                 pass
 
+            to_update = []
             for row in rows:
                 row_id = row["id"] if isinstance(row, sqlite3.Row) else row[0]
                 content = row["content"] if isinstance(row, sqlite3.Row) else row[1]
@@ -1714,12 +1715,15 @@ class MemoryDB:
                     row["created_at"] if isinstance(row, sqlite3.Row) else row[2]
                 )
                 digest = hashlib.sha256((content or "").encode("utf-8")).hexdigest()
-                self._conn.execute(
+                to_update.append((digest, created_at, row_id))
+
+            if to_update:
+                self._conn.executemany(
                     "UPDATE memories SET "
                     "  commit_sha = COALESCE(commit_sha, ?), "
                     "  valid_from = COALESCE(valid_from, ?) "
                     "WHERE id = ?",
-                    (digest, created_at, row_id),
+                    to_update,
                 )
             self._conn.commit()
             logger.info(

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -532,3 +532,55 @@ class TestScoringEdgeCases:
 
         # Test with naive datetime string
         assert tmp_db._calc_recency("2023-01-01T00:00:00", now) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 temporal backfill edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillPhase3Temporal:
+    def test_backfill_phase3_temporal(self, tmp_db: MemoryDB):
+        """Backfill commit_sha and valid_from for legacy rows using executemany."""
+        import hashlib
+
+        # Manually create a legacy-like state
+        tmp_db._conn.execute("DELETE FROM memories")
+        tmp_db._conn.commit()
+
+        # Insert rows with NULL commit_sha and valid_from
+        rows = [
+            ("id1", "content1", "2023-01-01 10:00:00"),
+            ("id2", "content2", "2023-01-02 11:00:00"),
+        ]
+        for rid, content, created in rows:
+            tmp_db._conn.execute(
+                "INSERT INTO memories (id, content, created_at, updated_at, last_accessed, commit_sha, valid_from) "
+                "VALUES (?, ?, ?, ?, ?, NULL, NULL)",
+                (rid, content, created, created, created),
+            )
+        tmp_db._conn.commit()
+
+        # Run the backfill
+        tmp_db._backfill_phase3_temporal()
+
+        # Verify they are NOT NULL and have correct values
+        updated_rows = tmp_db._conn.execute(
+            "SELECT id, content, created_at, commit_sha, valid_from FROM memories"
+        ).fetchall()
+        assert len(updated_rows) == 2
+        for row in updated_rows:
+            expected_sha = hashlib.sha256(row["content"].encode("utf-8")).hexdigest()
+            assert row["commit_sha"] == expected_sha
+            assert row["valid_from"] == row["created_at"]
+
+    def test_backfill_phase3_temporal_empty(self, tmp_db: MemoryDB):
+        """Backfill should not crash on empty database."""
+        tmp_db._backfill_phase3_temporal()
+        # Should complete without error
+
+    def test_backfill_phase3_temporal_no_table(self, tmp_db: MemoryDB):
+        """Backfill handles missing memories table gracefully."""
+        tmp_db._conn.execute("DROP TABLE memories")
+        tmp_db._backfill_phase3_temporal()
+        # Should return early via cursor is None check


### PR DESCRIPTION
Optimized the `_backfill_phase3_temporal` method in `src/mnemo_mcp/db.py` by replacing the loop-based `execute` calls with a single `executemany` operation. This significantly improves performance when migrating legacy databases with many rows. Added comprehensive test coverage in `tests/test_db_coverage.py` to verify the backfill logic and handle edge cases like empty databases or missing tables.

---
*PR created automatically by Jules for task [15685972521568059548](https://jules.google.com/task/15685972521568059548) started by @n24q02m*