### PR TITLE
[TEST] Missing empty topic edge case for recall_context in server.py

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2146,6 +2146,13 @@ def save_summary(summary: str) -> str:
     - Use when a conversation is concluding or shifting topics to persist key takeaways.
     - Parameters: 'summary' (the consolidated text to save).
     """
+    if not summary or not summary.strip():
+        return _json(
+            {
+                "error": "summary is required",
+                "suggestion": "Provide the 'summary' parameter to save a conversation summary.",
+            }
+        )
     return (
         f"Save this conversation summary as a memory:\n\n{summary}\n\n"
         "Use the memory tool with action='add', category='context', "
@@ -2161,6 +2168,13 @@ def recall_context(topic: str) -> str:
     - Use when starting a new task or answering a question to retrieve prior context.
     - Parameters: 'topic' (the specific subject or keywords to search for).
     """
+    if not topic or not topic.strip():
+        return _json(
+            {
+                "error": "topic is required",
+                "suggestion": "Provide the 'topic' parameter to search for relevant context.",
+            }
+        )
     return (
         f"Search your memories for relevant context about: {topic}\n\n"
         "Use the memory tool with action='search' and this query. "

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -709,6 +709,28 @@ class TestPrompts:
         assert "machine learning" in result
         assert "search" in result.lower()
 
+    def test_save_summary_empty(self):
+        result = save_summary("")
+        data = json.loads(result)
+        assert "error" in data
+        assert "summary is required" in data["error"]
+
+    def test_save_summary_whitespace(self):
+        result = save_summary("   ")
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_recall_context_empty(self):
+        result = recall_context("")
+        data = json.loads(result)
+        assert "error" in data
+        assert "topic is required" in data["error"]
+
+    def test_recall_context_whitespace(self):
+        result = recall_context("   ")
+        data = json.loads(result)
+        assert "error" in data
+
 
 class TestServerVersion:
     def test_serverinfo_version_matches_package(self):

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Added input validation to `recall_context` and `save_summary` prompts in `server.py` to handle empty or whitespace-only strings. The functions now return JSON error strings with descriptive 'error' and 'suggestion' fields, aligning with the project's developer experience (DX) patterns. New tests were added to `tests/test_server.py` to verify these edge cases.

---
*PR created automatically by Jules for task [3682601138359630507](https://jules.google.com/task/3682601138359630507) started by @n24q02m*