### PR TITLE
[FIX] N+1 Query when saving relations

### DIFF
--- a/src/mnemo_mcp/temporal/store.py
+++ b/src/mnemo_mcp/temporal/store.py
@@ -82,20 +82,33 @@ def store_kg_with_memory_id(
     edge_count = 0
     if relations:
         now_iso = time.strftime("%Y-%m-%dT%H:%M:%S")
+        valid_rels = []
         for rel in relations:
             src_name = rel.get("source", "").strip()
             tgt_name = rel.get("target", "").strip()
             rtype = rel.get("type", "").strip().lower()
             src_id = name_to_id.get(src_name)
             tgt_id = name_to_id.get(tgt_name)
-            if not (src_id and tgt_id and rtype):
-                continue
+            if src_id and tgt_id and rtype:
+                valid_rels.append((src_id, tgt_id, rtype))
+
+        # Bolt Performance Optimization:
+        # Replaced N+1 single-row UPDATEs with batched UPDATE + IN (VALUES ...)
+        # to eliminate SQLite VM overhead while preserving reliable row counting.
+        BATCH_SIZE = 100
+        for i in range(0, len(valid_rels), BATCH_SIZE):
+            batch = valid_rels[i : i + BATCH_SIZE]
+            placeholders = ", ".join(["(?, ?, ?)"] * len(batch))
+            params = [memory_id, now_iso]
+            for r_src, r_tgt, r_type in batch:
+                params.extend([r_src, r_tgt, r_type])
+
             cursor = conn.execute(
                 "UPDATE memory_edges SET "
                 "  memory_id = COALESCE(memory_id, ?), "
                 "  valid_from = COALESCE(valid_from, ?) "
-                "WHERE source_id = ? AND target_id = ? AND relation_type = ?",
-                (memory_id, now_iso, src_id, tgt_id, rtype),
+                f"WHERE (source_id, target_id, relation_type) IN (VALUES {placeholders})",
+                params,
             )
             edge_count += cursor.rowcount or 0
         conn.commit()

--- a/tests/temporal/test_store.py
+++ b/tests/temporal/test_store.py
@@ -102,3 +102,25 @@ class TestStoreKgWithMemoryId:
         ).fetchone()[0]
         assert ent_count == 2
         assert edge_count == 1
+
+    def test_batch_update_multiple_relations(self, tmp_db: MemoryDB):
+        mid = tmp_db.add("Alice works on Project X and Project Y")
+        extracted = {
+            "entities": [
+                {"name": "Alice", "type": "person"},
+                {"name": "Project X", "type": "project"},
+                {"name": "Project Y", "type": "project"},
+            ],
+            "relations": [
+                {"source": "Alice", "target": "Project X", "type": "works_on"},
+                {"source": "Alice", "target": "Project Y", "type": "works_on"},
+            ],
+        }
+        result = store_kg_with_memory_id(tmp_db._conn, mid, extracted)
+        assert result["edges"] == 2
+
+        # Verify both edges have correct memory_id
+        edges = tmp_db._conn.execute(
+            "SELECT COUNT(*) FROM memory_edges WHERE memory_id = ?", (mid,)
+        ).fetchone()[0]
+        assert edges == 2

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Optimized `store_kg_with_memory_id` in `src/mnemo_mcp/temporal/store.py` by replacing individual `UPDATE` statements for each relation with a batched `UPDATE` using `WHERE (source_id, target_id, relation_type) IN (VALUES ...)`. This reduces SQLite VM overhead while preserving reliable `rowcount` tracking, which is essential for accurate KG growth reporting.

Key changes:
- Collected valid relations into batches of 100.
- Used a single `UPDATE` per batch with positional parameters.
- Updated `edge_count` using `cursor.rowcount` from each batch execution.
- Added a regression test in `tests/temporal/test_store.py`.

---
*PR created automatically by Jules for task [6843791664473952954](https://jules.google.com/task/6843791664473952954) started by @n24q02m*