### PR TITLE
[TEST] Missing test for Exception in graph.py

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,6 @@
 """Tests for mnemo_mcp.graph -- entity extraction, relations, graph traversal."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.graph import (
@@ -423,18 +423,22 @@ class TestLinkMemoryEntities:
         ).fetchone()[0]
         assert count == 0
 
-    def test_exception_is_caught_and_logged(self):
-        """Exception during linking is caught and logged with details."""
-        conn = MagicMock()
-        conn.executemany.side_effect = Exception("DB error")
-        with patch("mnemo_mcp.graph.logger") as mock_logger:
-            # Should not raise
-            link_memory_entities(conn, "fake-id", ["eid1", "eid2"])
-            # Verify error was actually logged
-            assert mock_logger.debug.called
-            args, _ = mock_logger.debug.call_args
-            assert "Failed to link memory entities" in args[0]
-            assert "DB error" in args[0]
+    def test_exception_with_realistic_db_failure(self, tmp_db: MemoryDB):
+        """Triggers a real sqlite3.OperationalError by renaming the table."""
+        conn = tmp_db._conn
+        mid = tmp_db.add("test")
+
+        # Rename table to cause error
+        conn.execute("ALTER TABLE memory_entity_links RENAME TO temp_links")
+        try:
+            with patch("mnemo_mcp.graph.logger") as mock_logger:
+                link_memory_entities(conn, mid, ["eid1"])
+                assert mock_logger.debug.called
+                args, _ = mock_logger.debug.call_args
+                assert "Failed to link memory entities" in args[0]
+        finally:
+            # Restore table
+            conn.execute("ALTER TABLE temp_links RENAME TO memory_entity_links")
 
 
 class TestFindRelatedMemoryIds:

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -369,18 +369,22 @@ class TestLinkMemoryEntitiesCoverage:
         ).fetchone()[0]
         assert count == 0
 
-    def test_exception_is_caught_and_logged(self, tmp_db: MemoryDB):
-        """Exception during linking is caught and logged with details."""
-        conn = MagicMock()
-        conn.executemany.side_effect = Exception("DB error")
-        with patch("mnemo_mcp.graph.logger") as mock_logger:
-            # Should not raise
-            link_memory_entities(conn, "fake-id", ["eid1", "eid2"])
-            # Verify error was actually logged
-            assert mock_logger.debug.called
-            args, _ = mock_logger.debug.call_args
-            assert "Failed to link memory entities" in args[0]
-            assert "DB error" in args[0]
+    def test_exception_with_realistic_db_failure(self, tmp_db: MemoryDB):
+        """Triggers a real sqlite3.OperationalError by renaming the table."""
+        conn = tmp_db._conn
+        mid = tmp_db.add("test")
+
+        # Rename table to cause error
+        conn.execute("ALTER TABLE memory_entity_links RENAME TO temp_links")
+        try:
+            with patch("mnemo_mcp.graph.logger") as mock_logger:
+                link_memory_entities(conn, mid, ["eid1"])
+                assert mock_logger.debug.called
+                args, _ = mock_logger.debug.call_args
+                assert "Failed to link memory entities" in args[0]
+        finally:
+            # Restore table
+            conn.execute("ALTER TABLE temp_links RENAME TO memory_entity_links")
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.1.4"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Modified tests/test_graph.py and tests/test_graph_coverage.py to replace the MagicMock-based test_exception_is_caught_and_logged with a more realistic test_exception_with_realistic_db_failure. The new test triggers a real sqlite3.OperationalError by renaming the memory_entity_links table. Verified 100% test coverage for src/mnemo_mcp/graph.py.

---
*PR created automatically by Jules for task [8509884830644125666](https://jules.google.com/task/8509884830644125666) started by @n24q02m*