### PR TITLE
🎨 Palette: Improve DX with programmatic suggestion fields

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1510,14 +1510,14 @@ async def memory(
                 "update",
             ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
-            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                    "hint": "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID.",
-                }
-            )
+            response = {
+                "error": f"Unknown action '{action}'.",
+                "valid_actions": valid_actions,
+                "hint": "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID.",
+            }
+            if closest:
+                response["suggestion"] = f"Did you mean '{closest[0]}'?"
+            return _json(response)
 
 
 @mcp.tool(
@@ -1605,14 +1605,14 @@ async def config(
                 "warmup",
             ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
-            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                    "hint": "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync.",
-                }
-            )
+            response = {
+                "error": f"Unknown action '{action}'.",
+                "valid_actions": valid_actions,
+                "hint": "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync.",
+            }
+            if closest:
+                response["suggestion"] = f"Did you mean '{closest[0]}'?"
+            return _json(response)
 
 
 async def _handle_config_status(ctx: Context | None) -> str:
@@ -2103,13 +2103,13 @@ async def help(topic: str = "memory") -> str:
         import difflib
 
         closest = difflib.get_close_matches(topic, list(valid_topics.keys()), n=1)
-        suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-        return _json(
-            {
-                "error": f"Unknown topic '{topic}'.{suggestion}",
-                "valid_topics": list(valid_topics.keys()),
-            }
-        )
+        response = {
+            "error": f"Unknown topic '{topic}'.",
+            "valid_topics": list(valid_topics.keys()),
+        }
+        if closest:
+            response["suggestion"] = f"Did you mean '{closest[0]}'?"
+        return _json(response)
 
     doc_file = docs_package / filename
     content = await asyncio.to_thread(doc_file.read_text, encoding="utf-8")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -336,11 +336,13 @@ class TestMemoryConsolidate:
 class TestMemoryUnknownAction:
     async def test_unknown_action(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="invalid", ctx=ctx))
+        result = json.loads(await memory(action="ad", ctx=ctx))
         assert "error" in result
         assert "valid_actions" in result
         assert "add" in result["valid_actions"]
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert result["suggestion"] == "Did you mean 'add'?"
+        assert result["error"] == "Unknown action 'ad'."
 
 
 class TestConfigTool:
@@ -398,10 +400,12 @@ class TestConfigTool:
 
     async def test_unknown_action(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await config(action="invalid", ctx=ctx))
+        result = json.loads(await config(action="statu", ctx=ctx))
         assert "error" in result
         assert "valid_actions" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert result["suggestion"] == "Did you mean 'status'?"
+        assert result["error"] == "Unknown action 'statu'."
 
 
 class TestHelpTool:
@@ -415,9 +419,12 @@ class TestHelpTool:
         assert "config" in result.lower()
 
     async def test_invalid_topic(self):
-        result = json.loads(await help(topic="invalid"))
+        result = json.loads(await help(topic="memry"))
         assert "error" in result
         assert "valid_topics" in result
+        assert "suggestion" in result
+        assert result["suggestion"] == "Did you mean 'memory'?"
+        assert result["error"] == "Unknown topic 'memry'."
 
 
 class TestDedupWarning:

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -205,7 +205,7 @@ class TestConfigActions:
         assert "error" in result
         assert "Unknown action" in result["error"]
         assert "valid_actions" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
 
     async def test_config_unknown_action_no_match(self, ctx_with_db):
         """Config with completely invalid action returns error without suggestion."""
@@ -228,7 +228,7 @@ class TestHelpTool:
         assert "error" in result
         assert "Unknown topic" in result["error"]
         assert "valid_topics" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
 
     async def test_help_no_match(self):
         """Completely invalid topic returns error without suggestion."""

--- a/uv.lock
+++ b/uv.lock
@@ -997,7 +997,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR improves the Developer/Agent Experience (DX) of the MCP server's tool outputs. Previously, when a client provided an unknown action or topic to the `memory`, `config`, or `help` tools, the server would append a helpful hint ("Did you mean 'X'?") directly to the end of the `error` string.

This update separates that hint into a distinct top-level `suggestion` key within the JSON response. This simple structural change allows programmatic clients (like AI agents or consuming scripts) to trivially access and act upon the suggestion without needing to parse or regex the primary error string.

Tests have been updated to assert the presence and exact wording of this new key.

---
*PR created automatically by Jules for task [12992148076997363256](https://jules.google.com/task/12992148076997363256) started by @n24q02m*