### PR TITLE
fix: correct stale documentation drift across docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - mnemo-mcp
 
 MCP Server cho AI memory. Python 3.13, uv, hatchling, src layout.
-Hybrid search: FTS5 + sqlite-vec semantic. 3 tools: memory, config, help.
+Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher + config + help + config__open_relay.
 2-mode embedding: Cloud (Jina > Gemini > OpenAI > Cohere) > Local (Qwen3 ONNX). LLM: google-genai + openai.
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - mnemo-mcp
 
 MCP Server cho AI memory. Python 3.13, uv, hatchling, src layout.
-Hybrid search: FTS5 + sqlite-vec semantic. 3 tools: memory, config, help.
+Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher + config + help + config__open_relay.
 2-mode embedding: Cloud (Jina > Gemini > OpenAI > Cohere) > Local (Qwen3 ONNX). LLM: google-genai + openai.
 
 ## Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,23 +76,19 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ### Types
 
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
-- `ci`: CI/CD changes
-- `build`: Build system changes
+This project uses only two commit types:
+
+- `feat`: New feature (triggers a minor version bump)
+- `fix`: Bug fix (triggers a patch version bump)
+
+All other changes (docs, refactors, tests, CI, build, maintenance) are committed under `fix` or `feat` as appropriate. Do not use other types, and do not use the `!` breaking-change indicator.
 
 ### Examples
 
 ```text
 feat: add support for custom embedding models
 fix: handle empty search query gracefully
-docs: update configuration examples
+fix: update configuration examples
 ```
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ mcp-name: io.github.n24q02m/mnemo-mcp
 
 ## Documentation
 
-Full docs at **[mcp.n24q02m.com/servers/mnemo-mcp/](https://mcp.n24q02m.com/servers/mnemo-mcp/)**:
+Full docs at **[mcp.n24q02m.com/servers/mnemo-mcp/setup/](https://mcp.n24q02m.com/servers/mnemo-mcp/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/mnemo-mcp/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
 - [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
@@ -139,13 +139,15 @@ Full docs at **[mcp.n24q02m.com/servers/mnemo-mcp/](https://mcp.n24q02m.com/serv
 
 ## Tools
 
-3 MCP tools, 17 memory actions:
+15 MCP tools, 17 memory actions. The memory surface is exposed both as 11 specialized single-purpose tools and a legacy `memory` dispatcher (same actions), plus `config`, `help`, and `config__open_relay`:
 
 | Tool | Actions | Description |
 |:-----|:--------|:------------|
-| `memory` | `add`, `capture`, `search`, `list`, `update`, `delete`, `export`, `import`, `stats`, `restore`, `archived`, `archive_now`, `consolidate`, `compress`, `entity_search`, `entity_graph`, `history` | Core CRUD + typed capture (6 context_types) + hybrid search (RRF + rerank + temporal decay) + import/export + soft-archive + restore + on-demand archive sweep + LLM consolidation + LLM compression + temporal KG (entity search / graph / history) |
+| `add_memory`, `search_memory`, `list_memories`, `update_memory`, `delete_memory`, `export_memories`, `import_memories`, `memory_stats`, `restore_memory`, `archived_memories`, `consolidate_memories` | (one action each) | Specialized single-purpose memory tools -- the recommended surface |
+| `memory` (legacy dispatcher) | `add`, `capture`, `search`, `list`, `update`, `delete`, `export`, `import`, `stats`, `restore`, `archived`, `archive_now`, `consolidate`, `compress`, `entity_search`, `entity_graph`, `history` | Core CRUD + typed capture (6 context_types) + hybrid search (RRF + rerank + temporal decay) + import/export + soft-archive + restore + on-demand archive sweep + LLM consolidation + LLM compression + temporal KG (entity search / graph / history) |
 | `config` | `status`, `sync`, `set`, `warmup`, `setup_sync`, `setup_status`, `setup_start`, `setup_skip`, `setup_reset`, `setup_complete`, `setup_relay`, `sync_now`, `export_passport`, `import_passport` | Server status, trigger sync, update settings, pre-download embedding model, authenticate sync provider, manage HTTP setup form lifecycle, passport export/import |
 | `help` | `topic="memory"` or `topic="config"` | Full documentation for any tool |
+| `config__open_relay` | (HTTP relay mode) | Open the zero-config relay setup form (registered via mcp-core) |
 
 Plugin trinity (Claude Code marketplace install):
 
@@ -189,7 +191,7 @@ uv run mnemo-mcp
 
 ## Trust Model
 
-This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+This plugin implements **TC-Local** (machine-bound, single trust principal). The mode/storage/encryption breakdown below is the full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.x.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 2.x.x   | :white_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,8 +9,8 @@
 +--------------------+        +---------------------+
 | MCP client         |  MCP   | mnemo-mcp           |
 | (Claude Code,      | <----> | FastMCP server      |
-|  Cursor, Codex,    |        | 3 tools: memory,    |
-|  claude.ai web)    |        | config, help        |
+|  Cursor, Codex,    |        | 15 tools (memory    |
+|  claude.ai web)    |        | + config + help)    |
 +--------------------+        +----------+----------+
                                          |
                                          v
@@ -220,8 +220,7 @@ to upgrade when the backup write fails.
 ## Trust model
 
 This plugin implements **TC-Local** (machine-bound, single trust principal).
-See [mcp-core TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md)
-for the full classification.
+The table below is the full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -256,7 +256,7 @@ Configure via environment variables before starting the server:
 | `EMBEDDING_BACKEND` | (auto-detect) | `cloud` (API), `local` (qwen3-embed ONNX/GGUF), or empty (auto) |
 | `EMBEDDING_MODEL` | (auto-detect) | Provider model name (e.g. jina-embeddings-v5-text-small) or GGUF model ID |
 | `EMBEDDING_DIMS` | `0` | Embedding dimensions (0 = auto, resolves to 768) |
-| `SYNC_ENABLED` | `false` | Enable Google Drive sync |
+| `SYNC_ENABLED` | `true` | Enable Google Drive sync |
 | `GOOGLE_DRIVE_CLIENT_ID` | (none) | OAuth client ID for Google Drive |
 | `SYNC_FOLDER` | `mnemo-mcp` | Google Drive folder name |
 | `SYNC_INTERVAL` | `300` | Auto-sync interval (seconds, 0 = manual) |


### PR DESCRIPTION
## Summary

Multi-repo docs audit pass for `mnemo-mcp`. Every finding was verified against the actual source before editing.

### Findings + fixes

1. **Tool count (stale "3" -> verified 15)**: `CLAUDE.md`, `AGENTS.md`, `docs/ARCHITECTURE.md` and `README.md` claimed "3 tools". The server actually registers 15 tools: 11 specialized memory tools (`add_memory`, `search_memory`, `list_memories`, `update_memory`, `delete_memory`, `export_memories`, `import_memories`, `memory_stats`, `restore_memory`, `archived_memories`, `consolidate_memories`) + legacy `memory` dispatcher + `config` + `help` + `config__open_relay` (registered via `mcp_core.relay.tool_helpers.register_open_relay_tool`). Verified by counting `@mcp.tool(` decorators (14) + the `register_open_relay_tool` call in `src/mnemo_mcp/server.py`. README tool-surface table now lists the specialized tools and `config__open_relay`.

2. **SECURITY.md supported versions (1.x.x -> 2.x.x)**: current latest release is `v2.2.1` (`gh release list`). Supported table updated to `2.x.x` / `< 2.0`.

3. **SYNC_ENABLED default (doc was wrong)**: `src/mnemo_mcp/docs/config.md` said default `false`; code default is `true` (`config.py:102` `sync_enabled: bool = True`, also `config.py:74` docstring). The **doc** was wrong -> corrected to `true`.

4. **Dead links**:
   - `mcp-core/docs/TRUST-MODEL.md` -> 404 (no such file exists anywhere in `n24q02m/mcp-core`; sibling repos like better-notion/imagine/godot link only their in-README `#trust-model` section). Removed the dead external link in `README.md` and `docs/ARCHITECTURE.md`; both already contain the full classification table inline.
   - README bare docs-site server-root `https://mcp.n24q02m.com/servers/mnemo-mcp/` -> 404. Repointed to the working leaf `.../setup/` (curl-verified 200). Other leaf links (setup/modes-overview/multi-user) already return 200.

5. **CONTRIBUTING.md commit types**: listed the full conventional-commit set (docs/style/refactor/perf/test/chore/ci/build), contradicting the fix/feat-only policy. Aligned to `feat`/`fix` only and fixed the `docs:` example.

### Verification
- `uv run ruff format --check .` -> 125 files already formatted
- `uv run ruff check .` -> All checks passed
- Pre-commit hooks passed on commit
- Dead/replacement links curl-verified (setup leaf 200; old TRUST-MODEL + bare root 404)

Docs only; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
