### PR TITLE
[TEST] Missing empty topic edge case for recall_context in server.py

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2146,6 +2146,14 @@ def save_summary(summary: str) -> str:
     - Use when a conversation is concluding or shifting topics to persist key takeaways.
     - Parameters: 'summary' (the consolidated text to save).
     """
+    if not summary or not summary.strip():
+        return _json(
+            {
+                "error": "Summary cannot be empty",
+                "suggestion": "Provide a concise summary of the conversation to save as memory.",
+            }
+        )
+
     return (
         f"Save this conversation summary as a memory:\n\n{summary}\n\n"
         "Use the memory tool with action='add', category='context', "
@@ -2161,6 +2169,14 @@ def recall_context(topic: str) -> str:
     - Use when starting a new task or answering a question to retrieve prior context.
     - Parameters: 'topic' (the specific subject or keywords to search for).
     """
+    if not topic or not topic.strip():
+        return _json(
+            {
+                "error": "Topic cannot be empty",
+                "suggestion": "Provide a specific topic or keyword to search for in your memories.",
+            }
+        )
+
     return (
         f"Search your memories for relevant context about: {topic}\n\n"
         "Use the memory tool with action='search' and this query. "

--- a/tests/test_prompt_validation.py
+++ b/tests/test_prompt_validation.py
@@ -1,6 +1,7 @@
-import pytest
 import json
+
 from mnemo_mcp.server import recall_context, save_summary
+
 
 def test_recall_context_empty_topic():
     result = recall_context("")
@@ -9,6 +10,7 @@ def test_recall_context_empty_topic():
     assert "suggestion" in data
     assert "Topic cannot be empty" in data["error"]
 
+
 def test_recall_context_whitespace_topic():
     result = recall_context("   ")
     data = json.loads(result)
@@ -16,12 +18,14 @@ def test_recall_context_whitespace_topic():
     assert "suggestion" in data
     assert "Topic cannot be empty" in data["error"]
 
+
 def test_save_summary_empty_summary():
     result = save_summary("")
     data = json.loads(result)
     assert "error" in data
     assert "suggestion" in data
     assert "Summary cannot be empty" in data["error"]
+
 
 def test_save_summary_whitespace_summary():
     result = save_summary("   ")

--- a/tests/test_prompt_validation.py
+++ b/tests/test_prompt_validation.py
@@ -1,0 +1,31 @@
+import pytest
+import json
+from mnemo_mcp.server import recall_context, save_summary
+
+def test_recall_context_empty_topic():
+    result = recall_context("")
+    data = json.loads(result)
+    assert "error" in data
+    assert "suggestion" in data
+    assert "Topic cannot be empty" in data["error"]
+
+def test_recall_context_whitespace_topic():
+    result = recall_context("   ")
+    data = json.loads(result)
+    assert "error" in data
+    assert "suggestion" in data
+    assert "Topic cannot be empty" in data["error"]
+
+def test_save_summary_empty_summary():
+    result = save_summary("")
+    data = json.loads(result)
+    assert "error" in data
+    assert "suggestion" in data
+    assert "Summary cannot be empty" in data["error"]
+
+def test_save_summary_whitespace_summary():
+    result = save_summary("   ")
+    data = json.loads(result)
+    assert "error" in data
+    assert "suggestion" in data
+    assert "Summary cannot be empty" in data["error"]


### PR DESCRIPTION
This PR adds input validation to the `recall_context` and `save_summary` prompt functions in `server.py`. 

Previously, these functions would generate prompts even with empty or whitespace-only inputs. Now, they return a JSON error string following the project's convention for tool/prompt validation failures, providing both an error message and a helpful suggestion.

Changes:
- Added validation for `topic` in `recall_context`.
- Added validation for `summary` in `save_summary`.
- Created `tests/test_prompt_validation.py` with 4 test cases covering empty and whitespace-only inputs for both functions.
- Verified that existing tests in `tests/test_server.py` still pass.

---
*PR created automatically by Jules for task [11312719796798620339](https://jules.google.com/task/11312719796798620339) started by @n24q02m*