### PR TITLE
[TEST] Missing empty memory_id edge case for link_memory_entities in graph.py

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -305,7 +305,7 @@ def create_relations(
 
 def link_memory_entities(conn, memory_id: str, entity_ids: list[str]) -> None:
     """Link a memory to entities."""
-    if not entity_ids:
+    if not memory_id or not memory_id.strip() or not entity_ids:
         return
 
     try:

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -369,6 +369,22 @@ class TestLinkMemoryEntitiesCoverage:
         ).fetchone()[0]
         assert count == 0
 
+    def test_empty_memory_id(self, tmp_db: MemoryDB):
+        """No-op for empty or whitespace memory_id."""
+        conn = tmp_db._conn
+        # Create an entity first
+        entity_ids = upsert_entities(conn, [{"name": "TestEntity", "type": "concept"}])
+
+        # Empty memory_id
+        link_memory_entities(conn, "", entity_ids)
+        count = conn.execute("SELECT COUNT(*) FROM memory_entity_links").fetchone()[0]
+        assert count == 0
+
+        # Whitespace memory_id
+        link_memory_entities(conn, "   ", entity_ids)
+        count = conn.execute("SELECT COUNT(*) FROM memory_entity_links").fetchone()[0]
+        assert count == 0
+
     def test_exception_is_caught_and_logged(self, tmp_db: MemoryDB):
         """Exception during linking is caught and logged with details."""
         conn = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -997,7 +997,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.2.0"
+version = "2.2.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds validation to the `link_memory_entities` function in `src/mnemo_mcp/graph.py` to return early if the `memory_id` is an empty string or whitespace-only. This prevents unnecessary database operations and potential foreign key constraint issues. Corresponding tests were added to `tests/test_graph_coverage.py` to achieve and maintain 100% test coverage for the module.

---
*PR created automatically by Jules for task [14704656120498721993](https://jules.google.com/task/14704656120498721993) started by @n24q02m*