### PR TITLE
[TEST] Missing test for Exception in graph.py

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -436,6 +436,21 @@ class TestLinkMemoryEntities:
             assert "Failed to link memory entities" in args[0]
             assert "DB error" in args[0]
 
+    def test_exception_realistic_db_failure(self, tmp_db: MemoryDB):
+        """Trigger a real sqlite3.OperationalError by renaming the table."""
+        conn = tmp_db._conn
+        # Break the database by renaming the required table
+        conn.execute("ALTER TABLE memory_entity_links RENAME TO broken_table")
+
+        with patch("mnemo_mcp.graph.logger") as mock_logger:
+            # Should not raise despite the real DB error
+            link_memory_entities(conn, "some-id", ["eid1"])
+            # Verify error was caught and logged
+            assert mock_logger.debug.called
+            args, _ = mock_logger.debug.call_args
+            assert "Failed to link memory entities" in args[0]
+            assert "no such table: memory_entity_links" in args[0]
+
 
 class TestFindRelatedMemoryIds:
     def test_finds_related_via_shared_entity(self, tmp_db: MemoryDB):

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -358,31 +358,6 @@ class TestUpsertEntitiesCoverage:
 # ---------------------------------------------------------------------------
 
 
-class TestLinkMemoryEntitiesCoverage:
-    def test_empty_entity_ids(self, tmp_db: MemoryDB):
-        """No-op for empty entity_ids list."""
-        conn = tmp_db._conn
-        mid = tmp_db.add("test")
-        link_memory_entities(conn, mid, [])
-        count = conn.execute(
-            "SELECT COUNT(*) FROM memory_entity_links WHERE memory_id = ?", (mid,)
-        ).fetchone()[0]
-        assert count == 0
-
-    def test_exception_is_caught_and_logged(self, tmp_db: MemoryDB):
-        """Exception during linking is caught and logged with details."""
-        conn = MagicMock()
-        conn.executemany.side_effect = Exception("DB error")
-        with patch("mnemo_mcp.graph.logger") as mock_logger:
-            # Should not raise
-            link_memory_entities(conn, "fake-id", ["eid1", "eid2"])
-            # Verify error was actually logged
-            assert mock_logger.debug.called
-            args, _ = mock_logger.debug.call_args
-            assert "Failed to link memory entities" in args[0]
-            assert "DB error" in args[0]
-
-
 # ---------------------------------------------------------------------------
 # find_related_memory_ids -- early break when no new neighbors
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -997,7 +997,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.2.0"
+version = "2.2.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This PR adds a realistic database failure test for `link_memory_entities` in `src/mnemo_mcp/graph.py` by triggering a `sqlite3.OperationalError`. It also consolidates redundant tests by removing the duplicated `TestLinkMemoryEntitiesCoverage` class from `tests/test_graph_coverage.py`. Verified that the project maintains 100% test coverage for the graph module and all tests pass.

---
*PR created automatically by Jules for task [7732997316431918078](https://jules.google.com/task/7732997316431918078) started by @n24q02m*