### PR TITLE
feat: migrate LLM/embedding/rerank to litellm passthrough via mcp-core[llm]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 MCP Server cho AI memory. Python 3.13, uv, hatchling, src layout.
 Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher + config + help + config__open_relay.
-2-mode embedding: Cloud (Jina > Gemini > OpenAI > Cohere) > Local (Qwen3 ONNX). LLM: google-genai + openai.
+2-mode embedding: Cloud (Jina > Gemini > OpenAI > Cohere) > Local (Qwen3 ONNX). LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]).
 
 ## Commands
 
@@ -71,7 +71,9 @@ Khong co prefix (khac voi cac project khac):
 - `GEMINI_API_KEY` -- Google Gemini API key (embedding + LLM)
 - `OPENAI_API_KEY` -- OpenAI API key (embedding)
 - `COHERE_API_KEY` -- Cohere API key (embedding + reranking)
+- `ANTHROPIC_API_KEY` -- Anthropic API key (LLM; chay qua litellm, KHONG can `anthropic` package)
 - `XAI_API_KEY` -- xAI/Grok API key (LLM)
+- LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm`. Custom endpoint: `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
 - `EMBEDDING_BACKEND` -- `cloud` hoac `local` (auto-detect)
 - `EMBEDDING_MODEL` -- Cloud embedding model name
 - `EMBEDDING_DIMS` -- default 768 (0 = auto)
@@ -109,7 +111,7 @@ PSR v10 (workflow_dispatch) -> PyPI + Docker (amd64+arm64) + GHCR + MCP Registry
 - `asyncio.to_thread()` cho blocking I/O (SQLite, embedding).
 - Sync: Google Drive API (httpx), JSONL-based merge. OAuth Device Code flow, token luu tai `~/.mnemo-mcp/tokens/google_drive.json` (600).
 - Local embedding: first run download ~570MB model, cached.
-- Dependencies: `qwen3-embed>=1.5.1`, `cohere`, `sqlite-vec`.
+- Dependencies: `qwen3-embed`, `sqlite-vec`, `n24q02m-mcp-core[llm]` (litellm). Native SDK (google-genai/openai/cohere/anthropic) da go -- moi LLM/embed/rerank qua litellm passthrough.
 - Pre-commit: ruff lint + format, ty check, pytest.
 - Secrets: skret SSM namespace `/mnemo-mcp/prod` (region `ap-southeast-1`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 MCP Server cho AI memory. Python 3.13, uv, hatchling, src layout.
 Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher + config + help + config__open_relay.
-2-mode embedding: Cloud (Jina > Gemini > OpenAI > Cohere) > Local (Qwen3 ONNX). LLM: google-genai + openai.
+2-mode embedding: Cloud (Jina > Gemini > OpenAI > Cohere) > Local (Qwen3 ONNX). LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]).
 
 ## Commands
 
@@ -71,7 +71,9 @@ Khong co prefix (khac voi cac project khac):
 - `GEMINI_API_KEY` -- Google Gemini API key (embedding + LLM)
 - `OPENAI_API_KEY` -- OpenAI API key (embedding)
 - `COHERE_API_KEY` -- Cohere API key (embedding + reranking)
+- `ANTHROPIC_API_KEY` -- Anthropic API key (LLM; chay qua litellm, KHONG can `anthropic` package)
 - `XAI_API_KEY` -- xAI/Grok API key (LLM)
+- LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm`. Custom endpoint: `LLM_API_BASE`, `EMBEDDING_API_BASE`, `RERANK_API_BASE`
 - `EMBEDDING_BACKEND` -- `cloud` hoac `local` (auto-detect)
 - `EMBEDDING_MODEL` -- Cloud embedding model name
 - `EMBEDDING_DIMS` -- default 768 (0 = auto)
@@ -109,7 +111,7 @@ PSR v10 (workflow_dispatch) -> PyPI + Docker (amd64+arm64) + GHCR + MCP Registry
 - `asyncio.to_thread()` cho blocking I/O (SQLite, embedding).
 - Sync: Google Drive API (httpx), JSONL-based merge. OAuth Device Code flow, token luu tai `~/.mnemo-mcp/tokens/google_drive.json` (600).
 - Local embedding: first run download ~570MB model, cached.
-- Dependencies: `qwen3-embed>=1.5.1`, `cohere`, `sqlite-vec`.
+- Dependencies: `qwen3-embed`, `sqlite-vec`, `n24q02m-mcp-core[llm]` (litellm). Native SDK (google-genai/openai/cohere/anthropic) da go -- moi LLM/embed/rerank qua litellm passthrough.
 - Pre-commit: ruff lint + format, ty check, pytest.
 - Secrets: skret SSM namespace `/mnemo-mcp/prod` (region `ap-southeast-1`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,17 +27,12 @@ dependencies = [
     "pydantic-settings",
     # Logging
     "loguru",
-    # Cloud embedding + reranking (Cohere SDK)
-    "cohere>=7.0.3",
-    # LLM completion (native SDKs)
-    "google-genai>=2.8.0",
-    "openai>=2.41.0",
     # SQLite vector search
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.11.0",
-    # Zero-env-config credential relay
-    "n24q02m-mcp-core>=1.17.3,<2",
+    # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
+    "n24q02m-mcp-core[llm]>=1.18.0b1,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -192,7 +192,6 @@ class CloudEmbeddingBackend:
         self.api_key = api_key
         self.api_base = api_base
         self._provider = _detect_embedding_provider(self.model)
-        self._bare_model = _strip_provider(self.model)
 
     def _litellm_model(self) -> str:
         """Map mnemo's model naming to a litellm ``provider/model`` string."""
@@ -235,7 +234,12 @@ class CloudEmbeddingBackend:
     def _call_provider_sync(
         self, texts: list[str], dimensions: int | None = None
     ) -> list[list[float]]:
-        """Sync cloud path for ``check_available`` (sync mirror)."""
+        """Sync cloud path for ``check_available`` (sync mirror).
+
+        Keep in sync with :meth:`_call_provider`: same model/api_base/api_key
+        resolution + ``_build_kwargs`` + ``_parse_embeddings``; only the
+        sync ``embedding`` vs async ``aembedding`` call differs.
+        """
         from mcp_core.llm import embedding
 
         response = embedding(

--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -1,8 +1,9 @@
-"""Dual-backend embedding: Cloud (multi-provider) + qwen3-embed (local).
+"""Dual-backend embedding: Cloud (litellm passthrough) + qwen3-embed (local).
 
 Supports two backends:
-- **cloud**: Cloud embedding via native SDKs (Jina > Gemini > OpenAI > Cohere).
-  Auto-detects provider from model name or API keys in environment.
+- **cloud**: Cloud embedding via mcp_core.llm (litellm passthrough — Jina,
+  Gemini, OpenAI, Cohere, or any litellm 'provider/model'). Requires API
+  keys. Auto-detects provider from model name or API keys in environment.
 - **local**: Local inference via qwen3-embed. GGUF if GPU + llama-cpp-python,
   ONNX otherwise. No API keys needed, ~0.5GB model download on first use.
 
@@ -18,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -144,12 +145,39 @@ def _strip_provider(model: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Cloud Embedding Backend (multi-provider: Jina, Gemini, OpenAI, Cohere)
+# Embedding response parsing (litellm-native shapes)
+# ---------------------------------------------------------------------------
+
+
+def _parse_embeddings(response: Any) -> list[list[float]]:
+    """Extract sorted embedding vectors from a litellm embedding response.
+
+    litellm embedding items (``response.data``) may be pydantic ``Embedding``
+    objects or plain dicts depending on provider/version, and ``data`` may be
+    ``None`` — handle all shapes.
+    """
+
+    def _idx(item: Any) -> int:
+        return (
+            item.get("index", 0)
+            if isinstance(item, dict)
+            else getattr(item, "index", 0)
+        )
+
+    def _vec(item: Any) -> list[float]:
+        return item["embedding"] if isinstance(item, dict) else item.embedding
+
+    data = sorted(response.data or [], key=_idx)
+    return [_vec(item) for item in data]
+
+
+# ---------------------------------------------------------------------------
+# Cloud Embedding Backend (litellm passthrough via mcp_core.llm)
 # ---------------------------------------------------------------------------
 
 
 class CloudEmbeddingBackend:
-    """Cloud embedding via native SDKs (Jina, Gemini, OpenAI, Cohere)."""
+    """Cloud embedding via mcp_core.llm (litellm passthrough)."""
 
     # Max texts per batch request (safe for all providers).
     MAX_BATCH_SIZE = 96
@@ -166,123 +194,58 @@ class CloudEmbeddingBackend:
         self._provider = _detect_embedding_provider(self.model)
         self._bare_model = _strip_provider(self.model)
 
-    def _call_provider(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Route to the correct provider SDK."""
+    def _litellm_model(self) -> str:
+        """Map mnemo's model naming to a litellm ``provider/model`` string."""
+        if "/" in self.model:
+            return self.model
         if self._provider == "jina":
-            return self._embed_jina(texts, dimensions)
-        elif self._provider == "gemini":
-            return self._embed_gemini(texts, dimensions)
-        elif self._provider == "openai":
-            return self._embed_openai(texts, dimensions)
-        else:
-            return self._embed_cohere(texts, dimensions)
+            return f"jina_ai/{self.model}"
+        if self._provider == "gemini":
+            return f"gemini/{self.model}"
+        if self._provider == "cohere":
+            return f"cohere/{self.model}"
+        # OpenAI-style bare names (text-embedding-3-*) pass through as-is.
+        return self.model
 
-    def _embed_jina(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Embed via Jina AI (httpx, REST API)."""
-        import httpx
-
-        key = self.api_key or os.getenv("JINA_AI_API_KEY") or ""
-        payload: dict = {
-            "model": self._bare_model,
-            "input": texts,
-        }
-        if dimensions:
-            payload["dimensions"] = dimensions
-
-        response = httpx.post(
-            "https://api.jina.ai/v1/embeddings",
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {key}",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
-        response.raise_for_status()
-        data = response.json()["data"]
-        data_sorted = sorted(data, key=lambda x: x["index"])
-        return [d["embedding"] for d in data_sorted]
-
-    def _embed_gemini(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Embed via Google Gemini (google-genai SDK)."""
-        from google import genai
-        from google.genai import types
-
-        key = (
-            self.api_key
-            or os.getenv("GEMINI_API_KEY")
-            or os.getenv("GOOGLE_API_KEY")
-            or ""
-        )
-        client = genai.Client(api_key=key)
-
-        config_kwargs: dict = {}
-        if dimensions:
-            config_kwargs["output_dimensionality"] = dimensions
-
-        result = client.models.embed_content(
-            model=self._bare_model,
-            contents=texts,
-            config=types.EmbedContentConfig(**config_kwargs) if config_kwargs else None,
-        )
-
-        embeddings = result.embeddings or []
-        return [list(e.values or []) for e in embeddings]
-
-    def _embed_openai(
-        self, texts: list[str], dimensions: int | None = None
-    ) -> list[list[float]]:
-        """Embed via OpenAI SDK."""
-        from openai import OpenAI
-
-        key = self.api_key or os.getenv("OPENAI_API_KEY") or ""
-        base = self.api_base or "https://api.openai.com/v1"
-        client = OpenAI(api_key=key, base_url=base)
-
-        kwargs: dict = {
-            "model": self._bare_model,
-            "input": texts,
-        }
+    def _build_kwargs(self, dimensions: int | None) -> dict:
+        """Build provider-specific aembedding/embedding kwargs."""
+        kwargs: dict = {}
         if dimensions:
             kwargs["dimensions"] = dimensions
+        if self._provider == "cohere":
+            kwargs["input_type"] = "search_document"
+        return kwargs
 
-        response = client.embeddings.create(**kwargs)
-        data = sorted(response.data, key=lambda x: x.index)
-        return [d.embedding for d in data]
-
-    def _embed_cohere(
+    async def _call_provider(
         self, texts: list[str], dimensions: int | None = None
     ) -> list[list[float]]:
-        """Embed via Cohere SDK (v5.20+, ClientV2)."""
-        import cohere
+        """Single cloud path via mcp_core.llm (litellm passthrough)."""
+        # Lazy import: litellm costs ~1-2s on first import.
+        from mcp_core.llm import aembedding
 
-        key = (
-            self.api_key or os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or ""
+        response = await aembedding(
+            model=self._litellm_model(),
+            input=texts,
+            api_base=self.api_base or os.getenv("EMBEDDING_API_BASE") or None,
+            api_key=self.api_key or None,
+            **self._build_kwargs(dimensions),
         )
-        client = cohere.ClientV2(api_key=key)
-        kwargs: dict = {
-            "model": self._bare_model,
-            "texts": texts,
-            "input_type": "search_document",
-            "embedding_types": ["float"],
-            "truncate": "END",
-        }
-        if dimensions:
-            kwargs["output_dimension"] = dimensions
+        return _parse_embeddings(response)
 
-        response = client.embed(**kwargs)
-        embeddings = response.embeddings.float_
+    def _call_provider_sync(
+        self, texts: list[str], dimensions: int | None = None
+    ) -> list[list[float]]:
+        """Sync cloud path for ``check_available`` (sync mirror)."""
+        from mcp_core.llm import embedding
 
-        # Truncate locally if server returned more dims than requested
-        if dimensions and embeddings and len(embeddings[0]) > dimensions:
-            embeddings = [e[:dimensions] for e in embeddings]
-        return embeddings or []
+        response = embedding(
+            model=self._litellm_model(),
+            input=texts,
+            api_base=self.api_base or os.getenv("EMBEDDING_API_BASE") or None,
+            api_key=self.api_key or None,
+            **self._build_kwargs(dimensions),
+        )
+        return _parse_embeddings(response)
 
     async def _embed_batch_inner(
         self,
@@ -300,9 +263,7 @@ class CloudEmbeddingBackend:
         last_exc: Exception | None = None
         for attempt in range(MAX_RETRIES):
             try:
-                embeddings = await asyncio.to_thread(
-                    self._call_provider, texts, use_dimensions
-                )
+                embeddings = await self._call_provider(texts, use_dimensions)
 
                 # Truncate locally if server returned more dims than requested
                 if dimensions and embeddings and len(embeddings[0]) > dimensions:
@@ -386,7 +347,7 @@ class CloudEmbeddingBackend:
         failures (debug) so users know when their keys are wrong.
         """
         try:
-            embeddings = self._call_provider(["test"])
+            embeddings = self._call_provider_sync(["test"])
             if embeddings:
                 dim = len(embeddings[0])
                 logger.info(f"Embedding model {self.model} available (dims={dim})")

--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -14,14 +14,21 @@ def _has_llm_provider() -> bool:
         os.getenv("GEMINI_API_KEY")
         or os.getenv("GOOGLE_API_KEY")
         or os.getenv("OPENAI_API_KEY")
+        or os.getenv("ANTHROPIC_API_KEY")
         or os.getenv("XAI_API_KEY")
     )
 
 
 def _resolve_llm_model(settings_obj) -> str:
-    """Resolve the LLM model to use from settings."""
+    """Resolve the LLM model to use from settings, in litellm ``provider/model`` form.
+
+    ``LLM_MODELS`` accepts ``provider=model`` (=-form) or ``provider/model``
+    (slash form). A bare =-form first entry (no slash) is normalised to slash
+    form so ``_litellm_model`` does not double-prefix it.
+    """
     models = [m.strip() for m in settings_obj.llm_models.split(",") if m.strip()]
-    return models[0] if models else "gemini/gemini-3-flash-preview"
+    raw = models[0] if models else "gemini/gemini-3-flash-preview"
+    return raw.replace("=", "/", 1) if ("=" in raw and "/" not in raw) else raw
 
 
 def _litellm_model(model: str) -> str:

--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -24,6 +24,21 @@ def _resolve_llm_model(settings_obj) -> str:
     return models[0] if models else "gemini/gemini-3-flash-preview"
 
 
+def _litellm_model(model: str) -> str:
+    """Normalise a model string to litellm ``provider/model`` form.
+
+    ``_resolve_llm_model`` may yield ``provider/model`` (slash form) or a bare
+    name. litellm infers the provider from the prefix, so a bare gemini model
+    (e.g. ``gemini-3-flash-preview``) is prefixed with ``gemini/``; any other
+    bare name is left as-is for litellm to route via env keys.
+    """
+    if "/" in model:
+        return model
+    if "gemini" in model.lower():
+        return f"gemini/{model}"
+    return model
+
+
 async def _llm_completion(
     model: str,
     messages: list[dict],
@@ -31,69 +46,26 @@ async def _llm_completion(
     max_tokens: int = 500,
     response_format: dict | None = None,
 ) -> str:
-    """Call LLM completion using native SDK (google-genai or openai).
+    """Call LLM completion via mcp_core.llm (litellm passthrough).
 
-    Supports gemini/ models via google-genai, and other models via openai SDK.
+    litellm infers the provider from the ``provider/model`` prefix and returns
+    OpenAI-shaped responses (``resp.choices[0].message.content``).
     Returns the response text content.
     """
-    # Strip provider prefix for SDK routing
-    raw_model = model
-    if "/" in model:
-        provider_prefix, model_name = model.split("/", 1)
-    else:
-        provider_prefix, model_name = "", model
+    # Lazy import: litellm costs ~1-2s on first import.
+    from mcp_core.llm import acompletion
 
-    is_gemini = provider_prefix in ("gemini", "") and (
-        "gemini" in model_name or provider_prefix == "gemini"
+    kwargs: dict = {"temperature": temperature, "max_tokens": max_tokens}
+    if response_format:
+        kwargs["response_format"] = response_format
+
+    resp = await acompletion(
+        model=_litellm_model(model),
+        messages=messages,
+        api_base=os.environ.get("LLM_API_BASE") or None,
+        **kwargs,
     )
-
-    if is_gemini:
-        from google import genai
-
-        api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
-        client = genai.Client(api_key=api_key)
-
-        # Build config
-        config_kwargs: dict = {
-            "temperature": temperature,
-            "max_output_tokens": max_tokens,
-        }
-        if response_format and response_format.get("type") == "json_object":
-            config_kwargs["response_mime_type"] = "application/json"
-
-        # Flatten messages to a single prompt for Gemini
-        prompt = messages[-1]["content"] if messages else ""
-        from google.genai import types
-
-        response = client.models.generate_content(
-            model=model_name,
-            contents=prompt,
-            config=types.GenerateContentConfig(**config_kwargs),
-        )
-        return response.text or ""
-    else:
-        # Use openai SDK for OpenAI, xAI, and other providers
-        import openai
-
-        # Determine API key and base URL
-        api_key = os.getenv("OPENAI_API_KEY") or os.getenv("XAI_API_KEY")
-        base_url = None
-        if os.getenv("XAI_API_KEY") and not os.getenv("OPENAI_API_KEY"):
-            base_url = "https://api.x.ai/v1"
-
-        client = openai.OpenAI(api_key=api_key, base_url=base_url)
-
-        kwargs: dict = {
-            "model": model_name if not provider_prefix else raw_model,
-            "messages": messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-        }
-        if response_format:
-            kwargs["response_format"] = response_format
-
-        response = client.chat.completions.create(**kwargs)
-        return response.choices[0].message.content or ""
+    return resp.choices[0].message.content or ""
 
 
 async def extract_entities(content: str) -> dict | None:

--- a/src/mnemo_mcp/llm.py
+++ b/src/mnemo_mcp/llm.py
@@ -1,14 +1,17 @@
 """Multi-provider LLM dispatch layer (Phase 1 foundation).
 
 Provides a single ``call_llm`` entry point that auto-detects the active
-provider from environment variables and dispatches to the appropriate native
-SDK. The priority order matches the spec
+provider from environment variables and dispatches via ``mcp_core.llm``
+(litellm passthrough). The priority order matches the spec
 (`2026-04-19-mnemo-v2-design.md` §4.2):
 
     1. Gemini (``GEMINI_API_KEY`` or ``GOOGLE_API_KEY``)
     2. OpenAI (``OPENAI_API_KEY``)
     3. Anthropic (``ANTHROPIC_API_KEY``)
     4. xAI / Grok (``XAI_API_KEY``)
+
+litellm calls each provider's API directly, so ``ANTHROPIC_API_KEY`` now
+works WITHOUT the ``anthropic`` package installed (no native SDK import).
 
 If no provider key is available, ``call_llm`` logs a warning and returns
 ``None`` so callers (e.g. the upcoming ``capture`` action's optional fact
@@ -109,7 +112,7 @@ async def call_llm(
             When ``None`` (the default), auto-detection runs.
         model: Optional explicit model override. When ``None``, the result of
             :func:`get_default_model` for the resolved provider is used.
-        temperature: Sampling temperature passed through to the SDK.
+        temperature: Sampling temperature passed through to litellm.
         max_tokens: Maximum response tokens to request from the provider.
 
     Returns:
@@ -129,98 +132,19 @@ async def call_llm(
     resolved_model = model or get_default_model(resolved_provider)
 
     try:
-        if resolved_provider == "gemini":
-            return await _call_gemini(resolved_model, prompt, temperature, max_tokens)
-        if resolved_provider == "openai":
-            return await _call_openai(resolved_model, prompt, temperature, max_tokens)
-        if resolved_provider == "anthropic":
-            return await _call_anthropic(
-                resolved_model, prompt, temperature, max_tokens
-            )
-        if resolved_provider == "xai":
-            return await _call_xai(resolved_model, prompt, temperature, max_tokens)
+        # Lazy import: litellm costs ~1-2s on first import.
+        from mcp_core.llm import acompletion
+
+        response = await acompletion(
+            model=f"{resolved_provider}/{resolved_model}",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            api_base=os.environ.get("LLM_API_BASE") or None,
+        )
+        return response.choices[0].message.content or ""
     except Exception as e:  # pragma: no cover - per-provider runtime guard
         logger.warning(
             f"call_llm: provider={resolved_provider} model={resolved_model} failed: {e}"
         )
         return None
-
-    logger.warning(f"call_llm: unknown provider {resolved_provider!r}")
-    return None
-
-
-async def _call_gemini(
-    model: str, prompt: str, temperature: float, max_tokens: int
-) -> str:
-    """Dispatch to ``google-genai``. Mirrors graph.py LLM completion path."""
-    from google import genai
-    from google.genai import types
-
-    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    client = genai.Client(api_key=api_key)
-    response = client.models.generate_content(
-        model=model,
-        contents=prompt,
-        config=types.GenerateContentConfig(
-            temperature=temperature,
-            max_output_tokens=max_tokens,
-        ),
-    )
-    return response.text or ""
-
-
-async def _call_openai(
-    model: str, prompt: str, temperature: float, max_tokens: int
-) -> str:
-    """Dispatch to OpenAI Chat Completions via the ``openai`` SDK."""
-    import openai
-
-    api_key = os.environ.get("OPENAI_API_KEY")
-    client = openai.OpenAI(api_key=api_key)
-    response = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
-    return response.choices[0].message.content or ""
-
-
-async def _call_anthropic(
-    model: str, prompt: str, temperature: float, max_tokens: int
-) -> str:
-    """Dispatch to Anthropic Messages API via the ``anthropic`` SDK.
-
-    The ``anthropic`` package is not declared as a hard dependency yet — when
-    a user sets ``ANTHROPIC_API_KEY`` without installing it, ``call_llm``
-    catches the ``ImportError`` and returns ``None``.
-    """
-    import anthropic  # noqa: I001 - lazy optional import
-
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    client = anthropic.Anthropic(api_key=api_key)
-    message = client.messages.create(
-        model=model,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    parts = getattr(message, "content", []) or []
-    return "".join(getattr(p, "text", "") for p in parts)
-
-
-async def _call_xai(
-    model: str, prompt: str, temperature: float, max_tokens: int
-) -> str:
-    """Dispatch to xAI Grok via the OpenAI-compatible endpoint."""
-    import openai
-
-    api_key = os.environ.get("XAI_API_KEY")
-    client = openai.OpenAI(api_key=api_key, base_url="https://api.x.ai/v1")
-    response = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
-    return response.choices[0].message.content or ""

--- a/src/mnemo_mcp/reranker.py
+++ b/src/mnemo_mcp/reranker.py
@@ -1,13 +1,15 @@
-"""Dual-backend reranking: Cloud (Jina/Cohere) + qwen3-embed (local ONNX).
+"""Dual-backend reranking: Cloud (litellm passthrough) + qwen3-embed (local ONNX).
 
-Reranker takes search results and re-scores them with a cross-encoder
-for better precision. Pipeline: retrieve top-N*3 -> rerank -> return top-N.
+Cloud reranking goes through mcp_core.llm (litellm passthrough — Jina, Cohere,
+or any litellm rerank 'provider/model'). Reranker takes search results and
+re-scores them with a cross-encoder for better precision.
+Pipeline: retrieve top-N*3 -> rerank -> return top-N.
 """
 
 from __future__ import annotations
 
 import os
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -52,7 +54,7 @@ class RerankerBackend(Protocol):
 
 
 class CloudReranker:
-    """Cloud reranking via Jina AI or Cohere SDK."""
+    """Cloud reranking via mcp_core.llm (litellm passthrough)."""
 
     def __init__(
         self,
@@ -66,83 +68,63 @@ class CloudReranker:
         self._provider = _detect_rerank_provider(self.model)
         self._bare_model = _strip_provider(self.model)
 
+    def _litellm_model(self) -> str:
+        """Map mnemo's model naming to a litellm ``provider/model`` string."""
+        if "/" in self.model:
+            return self.model
+        if self._provider == "jina":
+            return f"jina_ai/{self.model}"
+        return f"cohere/{self.model}"
+
+    def _call_rerank(
+        self, query: str, documents: list[str], top_n: int
+    ) -> list[tuple[int, float]]:
+        """Single cloud path via mcp_core.llm (sync mirror — runs in to_thread)."""
+        # Lazy import: litellm costs ~1-2s on first import.
+        from mcp_core.llm import rerank as core_rerank
+
+        response = core_rerank(
+            model=self._litellm_model(),
+            query=query,
+            documents=documents,
+            top_n=top_n,
+            api_base=self.api_base or os.getenv("RERANK_API_BASE") or None,
+            api_key=self.api_key or None,
+        )
+
+        # litellm RerankResponse.results defaults to None and rerank items
+        # may be pydantic objects or plain dicts — guard + handle both shapes.
+        def _idx(r: Any) -> int:
+            return r["index"] if isinstance(r, dict) else getattr(r, "index", 0)
+
+        def _score(r: Any) -> float:
+            return (
+                r["relevance_score"]
+                if isinstance(r, dict)
+                else getattr(r, "relevance_score", 0.0)
+            )
+
+        return [(_idx(r), _score(r)) for r in (response.results or [])]
+
     def rerank(
         self, query: str, documents: list[str], top_n: int = 10
     ) -> list[tuple[int, float]]:
-        """Rerank documents via cloud API (Jina or Cohere)."""
+        """Rerank documents via the cloud rerank API."""
         if not documents:
             return []
         try:
-            if self._provider == "jina":
-                return self._rerank_jina(query, documents, top_n)
-            return self._rerank_cohere(query, documents, top_n)
+            results = self._call_rerank(query, documents, top_n)
+            results.sort(key=lambda x: x[1], reverse=True)
+            return results[:top_n]
         except Exception as e:
             logger.warning(f"Cloud reranking failed ({self._provider}): {e}")
             return []
 
-    def _rerank_jina(
-        self, query: str, documents: list[str], top_n: int
-    ) -> list[tuple[int, float]]:
-        """Rerank via Jina AI REST API."""
-        import httpx
-
-        key = self.api_key or os.getenv("JINA_AI_API_KEY") or ""
-        payload: dict = {
-            "model": self._bare_model,
-            "query": query,
-            "documents": documents,
-            "top_n": top_n,
-        }
-
-        response = httpx.post(
-            "https://api.jina.ai/v1/rerank",
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {key}",
-                "Content-Type": "application/json",
-            },
-            timeout=60,
-        )
-        response.raise_for_status()
-        data = response.json()["results"]
-
-        results: list[tuple[int, float]] = []
-        for item in data:
-            results.append((item["index"], item["relevance_score"]))
-        results.sort(key=lambda x: x[1], reverse=True)
-        return results[:top_n]
-
-    def _rerank_cohere(
-        self, query: str, documents: list[str], top_n: int
-    ) -> list[tuple[int, float]]:
-        """Rerank via Cohere SDK."""
-        import cohere
-
-        key = (
-            self.api_key or os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or ""
-        )
-        client = cohere.ClientV2(api_key=key)
-        response = client.rerank(
-            model=self._bare_model,
-            query=query,
-            documents=documents,
-            top_n=top_n,
-        )
-        results: list[tuple[int, float]] = []
-        for item in response.results:
-            if isinstance(item, dict):
-                results.append((item["index"], item["relevance_score"]))
-            else:
-                results.append((item.index, item.relevance_score))
-        results.sort(key=lambda x: x[1], reverse=True)
-        return results[:top_n]
-
     def check_available(self) -> bool:
         """Check if the cloud reranker model is reachable."""
         try:
-            if self._provider == "jina":
-                return self._check_jina()
-            return self._check_cohere()
+            results = self._call_rerank("test", ["test document"], 1)
+            return bool(results)
         except Exception as e:
             msg = str(e).lower()
             if any(
@@ -152,44 +134,6 @@ class CloudReranker:
             else:
                 logger.debug(f"Reranker {self.model} not available: {e}")
             return False
-
-    def _check_jina(self) -> bool:
-        """Check Jina reranker availability."""
-        import httpx
-
-        key = self.api_key or os.getenv("JINA_AI_API_KEY") or ""
-        response = httpx.post(
-            "https://api.jina.ai/v1/rerank",
-            json={
-                "model": self._bare_model,
-                "query": "test",
-                "documents": ["test"],
-                "top_n": 1,
-            },
-            headers={
-                "Authorization": f"Bearer {key}",
-                "Content-Type": "application/json",
-            },
-            timeout=30,
-        )
-        response.raise_for_status()
-        return bool(response.json().get("results"))
-
-    def _check_cohere(self) -> bool:
-        """Check Cohere reranker availability."""
-        import cohere
-
-        key = (
-            self.api_key or os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or ""
-        )
-        client = cohere.ClientV2(api_key=key)
-        response = client.rerank(
-            model=self._bare_model,
-            query="test",
-            documents=["test"],
-            top_n=1,
-        )
-        return bool(response.results)
 
 
 # Backward compatibility aliases

--- a/src/mnemo_mcp/reranker.py
+++ b/src/mnemo_mcp/reranker.py
@@ -66,7 +66,6 @@ class CloudReranker:
         self.api_base = api_base
         self.api_key = api_key
         self._provider = _detect_rerank_provider(self.model)
-        self._bare_model = _strip_provider(self.model)
 
     def _litellm_model(self) -> str:
         """Map mnemo's model naming to a litellm ``provider/model`` string."""

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1522,7 +1522,7 @@ async def memory(
 
 @mcp.tool(
     description=(
-        "Server config, sync, and setup. Actions: status|sync|set|warmup|setup_sync.\n"
+        "Server config, sync, and setup. Actions: status|sync|set|models|warmup|setup_sync.\n"
         "\n"
         "ACTION GUIDE — when to use each:\n"
         "- status: Show current configuration, setup status, and database stats.\n"
@@ -1530,6 +1530,8 @@ async def memory(
         "- set: Update a setting. Requires 'key' and 'value'.\n"
         "  Valid keys: 'sync_enabled' (true/false), 'sync_interval' (int), 'log_level' (str).\n"
         "  Example: action='set', key='sync_enabled', value='true'\n"
+        "- models: List cloud models (chat/embedding/rerank) for configured\n"
+        "  providers; key='all' lists the full catalog.\n"
         "- warmup: Pre-download embedding model (~570 MB) to avoid delays later.\n"
         "- setup_sync: Authenticate Google Drive via Device Code OAuth flow."
     ),
@@ -1553,6 +1555,8 @@ async def config(
     - status: Show current config
     - sync: Trigger manual Google Drive sync (requires sync_enabled + google_drive_client_id)
     - set: Update setting (key + value required)
+    - models: List cloud models (chat/embedding/rerank) for configured
+      providers; key='all' lists the full catalog
     - warmup: Pre-download embedding model (~570 MB) to avoid first-run delays
     - setup_sync: Authenticate Google Drive via Device Code OAuth flow
     """
@@ -1563,6 +1567,8 @@ async def config(
             return await _handle_config_sync(ctx)
         case "set":
             return await _handle_config_set(key, value)
+        case "models":
+            return await _handle_config_models(key)
         case "warmup":
             return await _handle_config_warmup()
         case "setup_sync":
@@ -1591,6 +1597,7 @@ async def config(
             valid_actions = [
                 "export_passport",
                 "import_passport",
+                "models",
                 "set",
                 "setup_complete",
                 "setup_relay",
@@ -1613,6 +1620,26 @@ async def config(
                     "hint": "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync.",
                 }
             )
+
+
+async def _handle_config_models(key: str | None) -> str:
+    from mcp_core.llm import list_models
+
+    show_all = key == "all"
+    # to_thread: first list_models call imports litellm (~1-2s, blocking).
+    models = await asyncio.to_thread(
+        list_models,
+        modes=("chat", "embedding", "rerank"),
+        configured_only=not show_all,
+        limit=200,
+    )
+    return _json(
+        {
+            "models": models,
+            "note": "Any litellm 'provider/model' works via passthrough, "
+            "even if not listed here.",
+        }
+    )
 
 
 async def _handle_config_status(ctx: Context | None) -> str:

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,5 +1,11 @@
-"""Tests for mnemo_mcp.embedder -- dual-backend embedding (all mocked)."""
+"""Tests for mnemo_mcp.embedder -- dual-backend embedding (all mocked).
 
+Cloud embedding goes through mcp_core.llm (litellm passthrough). Async paths
+patch ``mcp_core.llm.aembedding``; ``check_available`` (sync) patches the sync
+mirror ``mcp_core.llm.embedding``.
+"""
+
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -14,119 +20,96 @@ from mnemo_mcp.embedder import (
 )
 
 
-class TestCloudEmbeddingBackend:
-    @patch("cohere.ClientV2")
-    async def test_returns_embeddings(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
+def _resp(*vectors):
+    """Build a litellm-shaped embedding response (resp.data list of pydantic)."""
+    return SimpleNamespace(
+        data=[
+            SimpleNamespace(index=i, embedding=list(v)) for i, v in enumerate(vectors)
+        ]
+    )
 
-        backend = CloudEmbeddingBackend(api_key="test-key")
-        result = await backend.embed_texts(["hello", "world"])
+
+def _async_resp(*vectors):
+    """AsyncMock returning a litellm embedding response."""
+    return AsyncMock(return_value=_resp(*vectors))
+
+
+class TestCloudEmbeddingBackend:
+    async def test_returns_embeddings(self):
+        mock = _async_resp([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="test-key")
+            result = await backend.embed_texts(["hello", "world"])
         assert len(result) == 2
         assert result[0] == [0.1, 0.2, 0.3]
 
-    @patch("cohere.ClientV2")
-    async def test_empty_input(self, mock_client_cls):
-        backend = CloudEmbeddingBackend(api_key="test-key")
-        result = await backend.embed_texts([])
+    async def test_empty_input(self):
+        mock = _async_resp([0.1])
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="test-key")
+            result = await backend.embed_texts([])
         assert result == []
-        mock_client_cls.assert_not_called()
+        mock.assert_not_called()
 
-    @patch("cohere.ClientV2")
-    async def test_passes_dimensions(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
+    async def test_passes_dimensions(self):
+        mock = _async_resp([0.1])
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="embed-multilingual-v3.0", api_key="key"
+            )
+            await backend.embed_texts(["test"], dimensions=512)
+        assert mock.call_args.kwargs.get("dimensions") == 512
 
-        backend = CloudEmbeddingBackend(model="embed-multilingual-v3.0", api_key="key")
-        await backend.embed_texts(["test"], dimensions=512)
-        call_kwargs = mock_client.embed.call_args
-        assert call_kwargs.kwargs.get("output_dimension") == 512
-
-    @patch("cohere.ClientV2")
-    async def test_dimensions_fallback_on_unsupported(self, mock_client_cls):
+    async def test_dimensions_fallback_on_unsupported(self):
         """Falls back to local truncation when provider rejects dimensions."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1] * 1024]
         unsupported_err = Exception("output_dimension is not supported for this model")
-        mock_client.embed.side_effect = [unsupported_err, mock_response]
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(model="embed-multilingual-v3.0", api_key="key")
-        result = await backend.embed_texts(["test"], dimensions=768)
+        mock = AsyncMock(side_effect=[unsupported_err, _resp([0.1] * 1024)])
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="embed-multilingual-v3.0", api_key="key"
+            )
+            result = await backend.embed_texts(["test"], dimensions=768)
         assert len(result[0]) == 768
 
-    @patch("cohere.ClientV2")
-    async def test_local_truncation_when_server_returns_more(self, mock_client_cls):
+    async def test_local_truncation_when_server_returns_more(self):
         """Truncates locally when server returns more dims than requested."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1] * 3072]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        result = await backend.embed_texts(["test"], dimensions=768)
+        mock = _async_resp([0.1] * 3072)
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            result = await backend.embed_texts(["test"], dimensions=768)
         assert len(result[0]) == 768
 
-    @patch("cohere.ClientV2")
-    async def test_embed_single(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1, 0.2, 0.3]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        result = await backend.embed_single("hello")
+    async def test_embed_single(self):
+        mock = _async_resp([0.1, 0.2, 0.3])
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            result = await backend.embed_single("hello")
         assert result == [0.1, 0.2, 0.3]
 
-    @patch("cohere.ClientV2")
-    def test_check_available_returns_dims(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1, 0.2]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
+    def test_check_available_returns_dims(self):
+        mock = MagicMock(return_value=_resp([0.1, 0.2]))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            assert backend.check_available() == 2
 
-        backend = CloudEmbeddingBackend(api_key="key")
-        assert backend.check_available() == 2
+    def test_check_available_error(self):
+        mock = MagicMock(side_effect=Exception("Model not found"))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            assert backend.check_available() == 0
 
-    @patch("cohere.ClientV2")
-    def test_check_available_error(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("Model not found")
-        mock_client_cls.return_value = mock_client
+    async def test_raises_on_non_retryable_error(self):
+        mock = AsyncMock(side_effect=Exception("Invalid API key"))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            with pytest.raises(Exception, match="Invalid API key"):
+                await backend.embed_texts(["test"])
 
-        backend = CloudEmbeddingBackend(api_key="key")
-        assert backend.check_available() == 0
-
-    @patch("cohere.ClientV2")
-    async def test_raises_on_non_retryable_error(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("Invalid API key")
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        with pytest.raises(Exception, match="Invalid API key"):
-            await backend.embed_texts(["test"])
-
-    @patch("cohere.ClientV2")
-    def test_check_available_empty_data(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = []
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        assert backend.check_available() == 0
+    def test_check_available_empty_data(self):
+        mock = MagicMock(return_value=SimpleNamespace(data=[]))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            assert backend.check_available() == 0
 
     def test_litellm_backward_compat_alias(self):
         """LiteLLMBackend is an alias for CloudEmbeddingBackend."""
@@ -134,139 +117,109 @@ class TestCloudEmbeddingBackend:
 
 
 class TestBatchSplitting:
-    @patch("cohere.ClientV2")
-    async def test_splits_large_batch(self, mock_client_cls):
+    async def test_splits_large_batch(self):
         """Texts exceeding MAX_BATCH_SIZE are split into sub-batches."""
         n = CloudEmbeddingBackend.MAX_BATCH_SIZE + 50
 
-        mock_client = MagicMock()
+        async def fake(*, input, **kwargs):
+            return SimpleNamespace(
+                data=[
+                    SimpleNamespace(index=j, embedding=[float(j)])
+                    for j in range(len(input))
+                ]
+            )
 
-        def mock_embed(**kwargs):
-            count = len(kwargs["texts"])
-            resp = MagicMock()
-            resp.embeddings.float_ = [[float(j)] for j in range(count)]
-            return resp
-
-        mock_client.embed.side_effect = mock_embed
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        vecs = await backend.embed_texts([f"t{i}" for i in range(n)])
+        with patch("mcp_core.llm.aembedding", side_effect=fake):
+            backend = CloudEmbeddingBackend(api_key="key")
+            vecs = await backend.embed_texts([f"t{i}" for i in range(n)])
         assert len(vecs) == n
 
-    @patch("cohere.ClientV2")
-    async def test_batch_call_count(self, mock_client_cls):
+    async def test_batch_call_count(self):
         """Correct number of API calls for split batches."""
         n = CloudEmbeddingBackend.MAX_BATCH_SIZE * 2 + 10
 
-        mock_client = MagicMock()
+        async def fake(*, input, **kwargs):
+            return SimpleNamespace(
+                data=[
+                    SimpleNamespace(index=j, embedding=[0.0]) for j in range(len(input))
+                ]
+            )
 
-        def mock_embed(**kwargs):
-            count = len(kwargs["texts"])
-            resp = MagicMock()
-            resp.embeddings.float_ = [[0.0] for _ in range(count)]
-            return resp
+        mock = AsyncMock(side_effect=fake)
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            await backend.embed_texts([f"t{i}" for i in range(n)])
+        assert mock.call_count == 3
 
-        mock_client.embed.side_effect = mock_embed
-        mock_client_cls.return_value = mock_client
+    async def test_no_split_under_limit(self):
+        async def fake(*, input, **kwargs):
+            return SimpleNamespace(
+                data=[
+                    SimpleNamespace(index=j, embedding=[0.0]) for j in range(len(input))
+                ]
+            )
 
-        backend = CloudEmbeddingBackend(api_key="key")
-        await backend.embed_texts([f"t{i}" for i in range(n)])
-        assert mock_client.embed.call_count == 3
-
-    @patch("cohere.ClientV2")
-    async def test_no_split_under_limit(self, mock_client_cls):
-        mock_client = MagicMock()
-
-        def mock_embed(**kwargs):
-            count = len(kwargs["texts"])
-            resp = MagicMock()
-            resp.embeddings.float_ = [[0.0] for _ in range(count)]
-            return resp
-
-        mock_client.embed.side_effect = mock_embed
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        await backend.embed_texts(
-            [f"t{i}" for i in range(CloudEmbeddingBackend.MAX_BATCH_SIZE)]
-        )
-        assert mock_client.embed.call_count == 1
+        mock = AsyncMock(side_effect=fake)
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            await backend.embed_texts(
+                [f"t{i}" for i in range(CloudEmbeddingBackend.MAX_BATCH_SIZE)]
+            )
+        assert mock.call_count == 1
 
 
 class TestRetryLogic:
     @patch("mnemo_mcp.embedder.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cohere.ClientV2")
-    async def test_retries_on_rate_limit(self, mock_client_cls, mock_sleep):
-        mock_client = MagicMock()
-        success_response = MagicMock()
-        success_response.embeddings.float_ = [[0.1]]
-        mock_client.embed.side_effect = [
-            Exception("429 rate limit exceeded"),
-            success_response,
-        ]
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        result = await backend.embed_texts(["test"])
+    async def test_retries_on_rate_limit(self, mock_sleep):
+        mock = AsyncMock(
+            side_effect=[Exception("429 rate limit exceeded"), _resp([0.1])]
+        )
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            result = await backend.embed_texts(["test"])
         assert result == [[0.1]]
         mock_sleep.assert_called_once_with(1.0)
 
     @patch("mnemo_mcp.embedder.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cohere.ClientV2")
-    async def test_retries_on_server_error(self, mock_client_cls, mock_sleep):
-        mock_client = MagicMock()
-        success_response = MagicMock()
-        success_response.embeddings.float_ = [[0.2]]
-        mock_client.embed.side_effect = [
-            Exception("503 temporarily unavailable"),
-            success_response,
-        ]
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        result = await backend.embed_texts(["test"])
+    async def test_retries_on_server_error(self, mock_sleep):
+        mock = AsyncMock(
+            side_effect=[Exception("503 temporarily unavailable"), _resp([0.2])]
+        )
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            result = await backend.embed_texts(["test"])
         assert result == [[0.2]]
 
     @patch("mnemo_mcp.embedder.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cohere.ClientV2")
-    async def test_no_retry_on_non_retryable(self, mock_client_cls, mock_sleep):
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("Invalid API key")
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        with pytest.raises(Exception, match="Invalid API key"):
-            await backend.embed_texts(["test"])
+    async def test_no_retry_on_non_retryable(self, mock_sleep):
+        mock = AsyncMock(side_effect=Exception("Invalid API key"))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            with pytest.raises(Exception, match="Invalid API key"):
+                await backend.embed_texts(["test"])
         mock_sleep.assert_not_called()
 
     @patch("mnemo_mcp.embedder.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cohere.ClientV2")
-    async def test_exponential_backoff(self, mock_client_cls, mock_sleep):
-        mock_client = MagicMock()
-        success_response = MagicMock()
-        success_response.embeddings.float_ = [[0.1]]
-        mock_client.embed.side_effect = [
-            Exception("429 rate limit"),
-            Exception("429 rate limit"),
-            success_response,
-        ]
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        await backend.embed_texts(["test"])
+    async def test_exponential_backoff(self, mock_sleep):
+        mock = AsyncMock(
+            side_effect=[
+                Exception("429 rate limit"),
+                Exception("429 rate limit"),
+                _resp([0.1]),
+            ]
+        )
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            await backend.embed_texts(["test"])
         assert mock_sleep.call_args_list == [call(1.0), call(2.0)]
 
     @patch("mnemo_mcp.embedder.asyncio.sleep", new_callable=AsyncMock)
-    @patch("cohere.ClientV2")
-    async def test_max_retries_exhausted(self, mock_client_cls, mock_sleep):
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("429 rate limit")
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        with pytest.raises(Exception, match="429 rate limit"):
-            await backend.embed_texts(["test"])
+    async def test_max_retries_exhausted(self, mock_sleep):
+        mock = AsyncMock(side_effect=Exception("429 rate limit"))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            with pytest.raises(Exception, match="429 rate limit"):
+                await backend.embed_texts(["test"])
         assert mock_sleep.call_count == 2
 
 
@@ -335,56 +288,40 @@ class TestBackendFactory:
 class TestCheckAvailableApiKeyValidation:
     """check_available() distinguishes API key errors from other failures."""
 
-    @patch("cohere.ClientV2")
-    def test_api_key_401_logs_warning(self, mock_client_cls):
+    def test_api_key_401_logs_warning(self):
         """401 errors are logged at warning level (not debug)."""
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("401 Unauthorized: Invalid API key")
-        mock_client_cls.return_value = mock_client
+        mock = MagicMock(side_effect=Exception("401 Unauthorized: Invalid API key"))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="bad-key")
+            assert backend.check_available() == 0
 
-        backend = CloudEmbeddingBackend(api_key="bad-key")
-        result = backend.check_available()
-        assert result == 0
-
-    @patch("cohere.ClientV2")
-    def test_api_key_403_logs_warning(self, mock_client_cls):
+    def test_api_key_403_logs_warning(self):
         """403 forbidden errors are logged at warning level."""
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("403 Forbidden")
-        mock_client_cls.return_value = mock_client
+        mock = MagicMock(side_effect=Exception("403 Forbidden"))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="bad-key")
+            assert backend.check_available() == 0
 
-        backend = CloudEmbeddingBackend(api_key="bad-key")
-        assert backend.check_available() == 0
-
-    @patch("cohere.ClientV2")
-    def test_invalid_key_detected(self, mock_client_cls):
+    def test_invalid_key_detected(self):
         """'invalid' keyword in error triggers warning path."""
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("Invalid API key provided")
-        mock_client_cls.return_value = mock_client
+        mock = MagicMock(side_effect=Exception("Invalid API key provided"))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="bad-key")
+            assert backend.check_available() == 0
 
-        backend = CloudEmbeddingBackend(api_key="bad-key")
-        assert backend.check_available() == 0
-
-    @patch("cohere.ClientV2")
-    def test_unauthorized_detected(self, mock_client_cls):
+    def test_unauthorized_detected(self):
         """'unauthorized' keyword in error triggers warning path."""
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("Unauthorized access")
-        mock_client_cls.return_value = mock_client
+        mock = MagicMock(side_effect=Exception("Unauthorized access"))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="bad-key")
+            assert backend.check_available() == 0
 
-        backend = CloudEmbeddingBackend(api_key="bad-key")
-        assert backend.check_available() == 0
-
-    @patch("cohere.ClientV2")
-    def test_non_auth_error_logged_at_debug(self, mock_client_cls):
+    def test_non_auth_error_logged_at_debug(self):
         """Non-auth errors (e.g. model not found) go to debug level."""
-        mock_client = MagicMock()
-        mock_client.embed.side_effect = Exception("Model not found: xyz")
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="key")
-        assert backend.check_available() == 0
+        mock = MagicMock(side_effect=Exception("Model not found: xyz"))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            assert backend.check_available() == 0
 
 
 class TestQwen3GetModelWarning:
@@ -414,13 +351,10 @@ class TestQwen3GetModelWarning:
 class TestLegacyCompat:
     """Legacy module-level functions still work."""
 
-    @patch("cohere.ClientV2")
-    async def test_embed_single_legacy(self, mock_client_cls):
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1, 0.2]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        result = await embed_single("test", "embed-multilingual-v3.0", api_key="key")
+    async def test_embed_single_legacy(self):
+        mock = _async_resp([0.1, 0.2])
+        with patch("mcp_core.llm.aembedding", mock):
+            result = await embed_single(
+                "test", "embed-multilingual-v3.0", api_key="key"
+            )
         assert result == [0.1, 0.2]

--- a/tests/test_embedder_coverage.py
+++ b/tests/test_embedder_coverage.py
@@ -4,42 +4,43 @@ Targets: CloudEmbeddingBackend with api_base/api_key, Qwen3EmbedBackend._get_mod
 embed_texts inner function, embed_single_query, check_available result empty.
 """
 
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from mnemo_mcp.embedder import CloudEmbeddingBackend, Qwen3EmbedBackend, _is_retryable
 
+
+def _resp(*vectors):
+    """Build a litellm-shaped embedding response."""
+    return SimpleNamespace(
+        data=[
+            SimpleNamespace(index=i, embedding=list(v)) for i, v in enumerate(vectors)
+        ]
+    )
+
+
 # ---------------------------------------------------------------------------
-# CloudEmbeddingBackend with custom endpoint
+# CloudEmbeddingBackend with custom endpoint / api_key
 # ---------------------------------------------------------------------------
 
 
 class TestCloudEmbeddingBackendCustomEndpoint:
-    @patch("cohere.ClientV2")
-    async def test_passes_api_key(self, mock_client_cls):
-        """api_key is passed through to Cohere client."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
+    async def test_passes_api_key(self):
+        """api_key is passed through to aembedding."""
+        mock = AsyncMock(return_value=_resp([0.1]))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(api_key="sk-custom")
+            await backend.embed_texts(["test"])
+        assert mock.call_args.kwargs["api_key"] == "sk-custom"
 
-        backend = CloudEmbeddingBackend(api_key="sk-custom")
-        await backend.embed_texts(["test"])
-        mock_client_cls.assert_called_with(api_key="sk-custom")
-
-    @patch("cohere.ClientV2")
-    def test_check_available_with_api_key(self, mock_client_cls):
-        """check_available passes api_key for validation."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.embeddings.float_ = [[0.1]]
-        mock_client.embed.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(api_key="sk-key")
-        dims = backend.check_available()
+    def test_check_available_with_api_key(self):
+        """check_available passes api_key for validation (sync mirror)."""
+        mock = MagicMock(return_value=_resp([0.1]))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="sk-key")
+            dims = backend.check_available()
         assert dims == 1
-        mock_client_cls.assert_called_with(api_key="sk-key")
+        assert mock.call_args.kwargs["api_key"] == "sk-key"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_embedder_dimension_recovery.py
+++ b/tests/test_embedder_dimension_recovery.py
@@ -7,7 +7,10 @@ from mnemo_mcp.embedder import MAX_RETRIES, CloudEmbeddingBackend
 
 @pytest.mark.asyncio
 class TestDimensionRecovery:
-    @patch("mnemo_mcp.embedder.CloudEmbeddingBackend._call_provider")
+    @patch(
+        "mnemo_mcp.embedder.CloudEmbeddingBackend._call_provider",
+        new_callable=AsyncMock,
+    )
     async def test_dimension_unsupported_recovery(self, mock_call_provider):
         """
         Test that if the provider rejects the 'dimensions' parameter,
@@ -38,7 +41,10 @@ class TestDimensionRecovery:
             [call(["hello"], 512), call(["hello"], None)]
         )
 
-    @patch("mnemo_mcp.embedder.CloudEmbeddingBackend._call_provider")
+    @patch(
+        "mnemo_mcp.embedder.CloudEmbeddingBackend._call_provider",
+        new_callable=AsyncMock,
+    )
     async def test_no_recovery_on_other_error(self, mock_call_provider):
         """
         Test that other non-retryable errors do not trigger recovery.
@@ -53,7 +59,10 @@ class TestDimensionRecovery:
         # Should only be called once if it's not retryable and not unsupported param
         assert mock_call_provider.call_count == 1
 
-    @patch("mnemo_mcp.embedder.CloudEmbeddingBackend._call_provider")
+    @patch(
+        "mnemo_mcp.embedder.CloudEmbeddingBackend._call_provider",
+        new_callable=AsyncMock,
+    )
     @patch("mnemo_mcp.embedder.asyncio.sleep", new_callable=AsyncMock)
     async def test_retryable_error_takes_precedence(
         self, mock_sleep, mock_call_provider

--- a/tests/test_embedder_providers.py
+++ b/tests/test_embedder_providers.py
@@ -5,7 +5,8 @@ Jina embed backend, Gemini embed backend, OpenAI embed backend,
 _embed_batch_inner no-retry RuntimeError path, CloudEmbeddingBackend routing.
 """
 
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -13,8 +14,16 @@ from mnemo_mcp.embedder import (
     CloudEmbeddingBackend,
     _detect_embedding_provider,
     _is_unsupported_param,
+    _parse_embeddings,
     _strip_provider,
 )
+
+
+def _embedding_response(*vectors, indexed=True):
+    """Build a litellm-shaped embedding response (resp.data list)."""
+    data = [SimpleNamespace(index=i, embedding=list(v)) for i, v in enumerate(vectors)]
+    return SimpleNamespace(data=data if indexed else list(vectors))
+
 
 # ---------------------------------------------------------------------------
 # _detect_embedding_provider
@@ -121,225 +130,153 @@ class TestIsUnsupportedParam:
 
 
 # ---------------------------------------------------------------------------
-# CloudEmbeddingBackend -- Jina provider
+# _litellm_model mapping (provider -> litellm 'provider/model')
 # ---------------------------------------------------------------------------
 
 
-class TestJinaEmbedding:
-    @patch("httpx.post")
-    async def test_jina_embed(self, mock_post):
-        """Jina embedding via REST API."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {
-            "data": [
-                {"index": 0, "embedding": [0.1, 0.2, 0.3]},
-                {"index": 1, "embedding": [0.4, 0.5, 0.6]},
-            ]
-        }
-        mock_post.return_value = mock_response
+class TestLitellmModelMapping:
+    def test_jina_bare_name_prefixed(self):
+        backend = CloudEmbeddingBackend(model="jina-embeddings-v5", api_key="key")
+        assert backend._litellm_model() == "jina_ai/jina-embeddings-v5"
 
+    def test_gemini_bare_name_prefixed(self):
+        backend = CloudEmbeddingBackend(model="gemini-embedding-001", api_key="key")
+        assert backend._litellm_model() == "gemini/gemini-embedding-001"
+
+    def test_cohere_bare_name_prefixed(self):
+        backend = CloudEmbeddingBackend(model="embed-multilingual-v3.0", api_key="key")
+        assert backend._litellm_model() == "cohere/embed-multilingual-v3.0"
+
+    def test_openai_bare_name_passthrough(self):
+        backend = CloudEmbeddingBackend(model="text-embedding-3-large", api_key="key")
+        assert backend._litellm_model() == "text-embedding-3-large"
+
+    def test_slash_form_passthrough(self):
         backend = CloudEmbeddingBackend(
-            model="jina_ai/jina-embeddings-v5-text-small",
-            api_key="jina_test",
+            model="jina_ai/jina-embeddings-v5", api_key="key"
         )
-        result = await backend.embed_texts(["hello", "world"])
+        assert backend._litellm_model() == "jina_ai/jina-embeddings-v5"
+
+
+# ---------------------------------------------------------------------------
+# CloudEmbeddingBackend -- litellm passthrough (aembedding)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudEmbeddingPassthrough:
+    async def test_jina_embed(self):
+        """Embeds via aembedding and returns sorted vectors."""
+        mock = AsyncMock(
+            return_value=_embedding_response([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+        )
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="jina_ai/jina-embeddings-v5-text-small", api_key="jina_test"
+            )
+            result = await backend.embed_texts(["hello", "world"])
 
         assert len(result) == 2
         assert result[0] == [0.1, 0.2, 0.3]
         assert result[1] == [0.4, 0.5, 0.6]
+        assert mock.call_args.kwargs["model"] == "jina_ai/jina-embeddings-v5-text-small"
 
-    @patch("httpx.post")
-    async def test_jina_embed_with_dimensions(self, mock_post):
-        """Jina embedding passes dimensions param."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {"data": [{"index": 0, "embedding": [0.1]}]}
-        mock_post.return_value = mock_response
+    async def test_dimensions_forwarded(self):
+        """dimensions is forwarded to aembedding."""
+        mock = AsyncMock(return_value=_embedding_response([0.1]))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="jina_ai/jina-embeddings-v5-text-small", api_key="jina_test"
+            )
+            await backend.embed_texts(["test"], dimensions=512)
 
-        backend = CloudEmbeddingBackend(
-            model="jina_ai/jina-embeddings-v5-text-small",
-            api_key="jina_test",
-        )
-        await backend.embed_texts(["test"], dimensions=512)
+        assert mock.call_args.kwargs["dimensions"] == 512
 
-        call_kwargs = mock_post.call_args
-        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-        assert payload["dimensions"] == 512
-
-    @patch("httpx.post")
-    async def test_jina_embed_unsorted_data(self, mock_post):
-        """Jina results are sorted by index."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {
-            "data": [
-                {"index": 1, "embedding": [0.4]},
-                {"index": 0, "embedding": [0.1]},
+    async def test_results_sorted_by_index(self):
+        """Out-of-order embedding data is sorted by index."""
+        resp = SimpleNamespace(
+            data=[
+                SimpleNamespace(index=1, embedding=[0.4]),
+                SimpleNamespace(index=0, embedding=[0.1]),
             ]
-        }
-        mock_post.return_value = mock_response
-
-        backend = CloudEmbeddingBackend(
-            model="jina_ai/test",
-            api_key="key",
         )
-        result = await backend.embed_texts(["a", "b"])
+        mock = AsyncMock(return_value=resp)
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(model="jina_ai/test", api_key="key")
+            result = await backend.embed_texts(["a", "b"])
         assert result[0] == [0.1]
         assert result[1] == [0.4]
 
+    async def test_cohere_input_type_forwarded(self):
+        """Cohere provider passes input_type='search_document'."""
+        mock = AsyncMock(return_value=_embedding_response([0.1]))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="embed-multilingual-v3.0", api_key="key"
+            )
+            await backend.embed_texts(["test"])
+        assert mock.call_args.kwargs["input_type"] == "search_document"
+        assert mock.call_args.kwargs["model"] == "cohere/embed-multilingual-v3.0"
 
-# ---------------------------------------------------------------------------
-# CloudEmbeddingBackend -- Gemini provider
-# ---------------------------------------------------------------------------
-
-
-class TestGeminiEmbedding:
-    @patch("google.genai.Client")
-    async def test_gemini_embed(self, mock_client_cls):
-        """Gemini embedding via google-genai SDK."""
-        mock_embedding = MagicMock()
-        mock_embedding.values = [0.1, 0.2, 0.3]
-
-        mock_result = MagicMock()
-        mock_result.embeddings = [mock_embedding]
-
-        mock_client = MagicMock()
-        mock_client.models.embed_content.return_value = mock_result
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(
-            model="gemini/gemini-embedding-001",
-            api_key="AIza_test",
-        )
-        result = await backend.embed_texts(["hello"])
-
-        assert len(result) == 1
-        assert result[0] == [0.1, 0.2, 0.3]
-
-    @patch("google.genai.Client")
-    async def test_gemini_embed_with_dimensions(self, mock_client_cls):
-        """Gemini passes output_dimensionality in config."""
-        mock_embedding = MagicMock()
-        mock_embedding.values = [0.1]
-
-        mock_result = MagicMock()
-        mock_result.embeddings = [mock_embedding]
-
-        mock_client = MagicMock()
-        mock_client.models.embed_content.return_value = mock_result
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(
-            model="gemini/gemini-embedding-001",
-            api_key="AIza_test",
-        )
-        await backend.embed_texts(["test"], dimensions=768)
-
-        call_kwargs = mock_client.models.embed_content.call_args
-        config = call_kwargs.kwargs.get("config")
-        assert config is not None
-
-    @patch("google.genai.Client")
-    async def test_gemini_embed_empty_embeddings(self, mock_client_cls):
-        """Gemini handles empty embeddings list."""
-        mock_result = MagicMock()
-        mock_result.embeddings = None
-
-        mock_client = MagicMock()
-        mock_client.models.embed_content.return_value = mock_result
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(
-            model="gemini/gemini-embedding-001",
-            api_key="AIza_test",
-        )
-        result = await backend.embed_texts(["test"])
+    async def test_none_data_returns_empty(self):
+        """resp.data=None is guarded and yields []."""
+        mock = AsyncMock(return_value=SimpleNamespace(data=None))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="gemini/gemini-embedding-001", api_key="AIza_test"
+            )
+            result = await backend.embed_texts(["test"])
         assert result == []
 
+    async def test_dict_items_parsed(self):
+        """Embedding items may be plain dicts."""
+        resp = SimpleNamespace(
+            data=[{"index": 0, "embedding": [0.7, 0.8]}],
+        )
+        mock = AsyncMock(return_value=resp)
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="text-embedding-3-large", api_key="sk_test"
+            )
+            result = await backend.embed_texts(["x"])
+        assert result == [[0.7, 0.8]]
+
+    async def test_api_base_forwarded(self):
+        """Custom api_base flows through to aembedding."""
+        mock = AsyncMock(return_value=_embedding_response([0.1]))
+        with patch("mcp_core.llm.aembedding", mock):
+            backend = CloudEmbeddingBackend(
+                model="openai/text-embedding-3-large",
+                api_key="sk_test",
+                api_base="https://proxy.example.com/v1",
+            )
+            await backend.embed_texts(["test"])
+        assert mock.call_args.kwargs["api_base"] == "https://proxy.example.com/v1"
+        assert mock.call_args.kwargs["api_key"] == "sk_test"
+
 
 # ---------------------------------------------------------------------------
-# CloudEmbeddingBackend -- OpenAI provider
+# _parse_embeddings shape handling
 # ---------------------------------------------------------------------------
 
 
-class TestOpenAIEmbedding:
-    @patch("openai.OpenAI")
-    async def test_openai_embed(self, mock_client_cls):
-        """OpenAI embedding via SDK."""
-        mock_data_0 = MagicMock()
-        mock_data_0.index = 0
-        mock_data_0.embedding = [0.1, 0.2]
-
-        mock_data_1 = MagicMock()
-        mock_data_1.index = 1
-        mock_data_1.embedding = [0.3, 0.4]
-
-        mock_response = MagicMock()
-        mock_response.data = [mock_data_1, mock_data_0]  # Out of order
-
-        mock_client = MagicMock()
-        mock_client.embeddings.create.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(
-            model="text-embedding-3-large",
-            api_key="sk_test",
+class TestParseEmbeddings:
+    def test_pydantic_items(self):
+        resp = SimpleNamespace(
+            data=[
+                SimpleNamespace(index=1, embedding=[0.4]),
+                SimpleNamespace(index=0, embedding=[0.1]),
+            ]
         )
-        result = await backend.embed_texts(["hello", "world"])
+        assert _parse_embeddings(resp) == [[0.1], [0.4]]
 
-        assert result[0] == [0.1, 0.2]
-        assert result[1] == [0.3, 0.4]
-
-    @patch("openai.OpenAI")
-    async def test_openai_embed_with_dimensions(self, mock_client_cls):
-        """OpenAI passes dimensions param."""
-        mock_data = MagicMock()
-        mock_data.index = 0
-        mock_data.embedding = [0.1]
-
-        mock_response = MagicMock()
-        mock_response.data = [mock_data]
-
-        mock_client = MagicMock()
-        mock_client.embeddings.create.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(
-            model="text-embedding-3-large",
-            api_key="sk_test",
+    def test_dict_items(self):
+        resp = SimpleNamespace(
+            data=[{"index": 0, "embedding": [0.1]}, {"index": 1, "embedding": [0.2]}]
         )
-        await backend.embed_texts(["test"], dimensions=512)
+        assert _parse_embeddings(resp) == [[0.1], [0.2]]
 
-        call_kwargs = mock_client.embeddings.create.call_args
-        assert call_kwargs.kwargs.get("dimensions") == 512
-
-    @patch("openai.OpenAI")
-    async def test_openai_embed_with_api_base(self, mock_client_cls):
-        """OpenAI respects custom api_base."""
-        mock_data = MagicMock()
-        mock_data.index = 0
-        mock_data.embedding = [0.1]
-
-        mock_response = MagicMock()
-        mock_response.data = [mock_data]
-
-        mock_client = MagicMock()
-        mock_client.embeddings.create.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        backend = CloudEmbeddingBackend(
-            model="openai/text-embedding-3-large",
-            api_key="sk_test",
-            api_base="https://proxy.example.com/v1",
-        )
-        await backend.embed_texts(["test"])
-
-        mock_client_cls.assert_called_with(
-            api_key="sk_test",
-            base_url="https://proxy.example.com/v1",
-        )
+    def test_none_data(self):
+        assert _parse_embeddings(SimpleNamespace(data=None)) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -16,10 +16,14 @@ from mnemo_mcp.graph import (
 
 class TestHasLlmProvider:
     def test_no_keys(self, monkeypatch):
-        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        for key in (
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "XAI_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
         assert _has_llm_provider() is False
 
     def test_gemini_key(self, monkeypatch):
@@ -30,6 +34,18 @@ class TestHasLlmProvider:
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "test")
+        assert _has_llm_provider() is True
+
+    def test_anthropic_key_only(self, monkeypatch):
+        """ANTHROPIC_API_KEY alone enables LLM enrichment (litellm path)."""
+        for key in (
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
         assert _has_llm_provider() is True
 
 
@@ -195,6 +211,49 @@ class TestExtractEntities:
             llm_models = ""
 
         assert _resolve_llm_model(MockSettings()) == "gemini/gemini-3-flash-preview"
+
+    async def test_resolve_llm_model_equals_form_normalised(self):
+        """=-form first entry is normalised to slash form for litellm."""
+        from mnemo_mcp.graph import _resolve_llm_model
+
+        class MockSettings:
+            llm_models = "gemini=gemini-2.0-flash,openai=gpt-5-mini"
+
+        assert _resolve_llm_model(MockSettings()) == "gemini/gemini-2.0-flash"
+
+    async def test_resolve_llm_model_slash_form_unchanged(self):
+        """Slash-form first entry is passed through unchanged."""
+        from mnemo_mcp.graph import _resolve_llm_model
+
+        class MockSettings:
+            llm_models = "openai/gpt-5.4-mini,gemini/gemini-3-flash-preview"
+
+        assert _resolve_llm_model(MockSettings()) == "openai/gpt-5.4-mini"
+
+    async def test_equals_form_reaches_litellm_as_slash(self):
+        """End-to-end: =-form resolved model reaches acompletion as provider/model."""
+        from types import SimpleNamespace
+
+        from mnemo_mcp.graph import _litellm_model, _resolve_llm_model
+
+        class MockSettings:
+            llm_models = "openai=gpt-5-mini"
+
+        resolved = _resolve_llm_model(MockSettings())
+        assert resolved == "openai/gpt-5-mini"
+        # _litellm_model must NOT double-prefix an already-slash model.
+        assert _litellm_model(resolved) == "openai/gpt-5-mini"
+
+        mock = AsyncMock(
+            return_value=SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            )
+        )
+        with patch("mcp_core.llm.acompletion", mock):
+            from mnemo_mcp.graph import _llm_completion
+
+            await _llm_completion(resolved, [{"role": "user", "content": "hi"}])
+        assert mock.call_args.kwargs["model"] == "openai/gpt-5-mini"
 
 
 class TestScoreImportance:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -121,60 +121,64 @@ class TestExtractEntities:
             assert result is not None
             mock_llm.assert_called_once()
 
-    async def test_llm_completion_gemini_no_prefix(self):
-        with (
-            patch(
-                "mnemo_mcp.graph.os.getenv",
-                side_effect=lambda k, d=None: "test-key" if "KEY" in k else d,
-            ),
-            patch("google.genai.Client") as mock_genai,
-        ):
-            mock_genai.return_value.models.generate_content.return_value.text = (
-                "gemini response"
+    async def test_llm_completion_gemini_bare_name_gets_prefixed(self):
+        """Bare gemini model is prefixed to litellm 'gemini/...' form."""
+        from types import SimpleNamespace
+
+        mock = AsyncMock(
+            return_value=SimpleNamespace(
+                choices=[
+                    SimpleNamespace(message=SimpleNamespace(content="gemini response"))
+                ]
             )
+        )
+        with patch("mcp_core.llm.acompletion", mock):
             from mnemo_mcp.graph import _llm_completion
 
             res = await _llm_completion(
                 "gemini-pro", [{"role": "user", "content": "hi"}]
             )
             assert res == "gemini response"
+            assert mock.call_args.kwargs["model"] == "gemini/gemini-pro"
 
-    async def test_llm_completion_openai_with_prefix(self):
-        with (
-            patch(
-                "mnemo_mcp.graph.os.getenv",
-                side_effect=lambda k, d=None: "test-key" if "KEY" in k else d,
-            ),
-            patch("openai.OpenAI") as mock_openai,
-        ):
-            mock_openai.return_value.chat.completions.create.return_value.choices[
-                0
-            ].message.content = "openai response"
+    async def test_llm_completion_slash_form_passes_through(self):
+        """A 'provider/model' string is passed to litellm unchanged."""
+        from types import SimpleNamespace
+
+        mock = AsyncMock(
+            return_value=SimpleNamespace(
+                choices=[
+                    SimpleNamespace(message=SimpleNamespace(content="openai response"))
+                ]
+            )
+        )
+        with patch("mcp_core.llm.acompletion", mock):
             from mnemo_mcp.graph import _llm_completion
 
             res = await _llm_completion(
                 "openai/gpt-4", [{"role": "user", "content": "hi"}]
             )
             assert res == "openai response"
+            assert mock.call_args.kwargs["model"] == "openai/gpt-4"
 
-    async def test_llm_completion_xai_routing(self):
-        def mock_getenv(k, d=None):
-            if k == "XAI_API_KEY":
-                return "xai-key"
-            if k == "OPENAI_API_KEY":
-                return None
-            return d
+    async def test_llm_completion_response_format_forwarded(self):
+        """response_format is forwarded to litellm only when provided."""
+        from types import SimpleNamespace
 
-        with (
-            patch("mnemo_mcp.graph.os.getenv", side_effect=mock_getenv),
-            patch("openai.OpenAI") as mock_openai,
-        ):
+        mock = AsyncMock(
+            return_value=SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="{}"))]
+            )
+        )
+        with patch("mcp_core.llm.acompletion", mock):
             from mnemo_mcp.graph import _llm_completion
 
-            await _llm_completion("gpt-4", [{"role": "user", "content": "hi"}])
-            # Verify base_url was set for xAI
-            _, kwargs = mock_openai.call_args
-            assert kwargs["base_url"] == "https://api.x.ai/v1"
+            await _llm_completion(
+                "gemini/gemini-3-flash-preview",
+                [{"role": "user", "content": "hi"}],
+                response_format={"type": "json_object"},
+            )
+            assert mock.call_args.kwargs["response_format"] == {"type": "json_object"}
 
     async def test_resolve_llm_model_custom(self):
         from mnemo_mcp.graph import _resolve_llm_model

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -47,151 +47,83 @@ class TestResolveLlmModel:
 # ---------------------------------------------------------------------------
 
 
+def _completion(content):
+    """Build a litellm-shaped completion response."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
 class TestLlmCompletion:
-    async def test_gemini_path(self, monkeypatch):
-        """Routes to Gemini SDK when model is gemini/..."""
-        monkeypatch.setenv("GEMINI_API_KEY", "AIza_test")
-
-        with patch("google.genai.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_response = MagicMock()
-            mock_response.text = '{"result": "test"}'
-            mock_client.models.generate_content.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+    async def test_slash_form_passthrough(self):
+        """A 'provider/model' string is passed to litellm unchanged."""
+        mock = AsyncMock(return_value=_completion('{"result": "test"}'))
+        with patch("mcp_core.llm.acompletion", mock):
             result = await _llm_completion(
                 "gemini/gemini-3-flash-preview",
                 [{"role": "user", "content": "test prompt"}],
                 response_format={"type": "json_object"},
             )
+        assert result == '{"result": "test"}'
+        kwargs = mock.call_args.kwargs
+        assert kwargs["model"] == "gemini/gemini-3-flash-preview"
+        assert kwargs["response_format"] == {"type": "json_object"}
 
-            assert result == '{"result": "test"}'
-            # Verify json_object maps to response_mime_type
-            call_kwargs = mock_client.models.generate_content.call_args
-            config = call_kwargs.kwargs.get("config")
-            assert config is not None
-
-    async def test_gemini_no_prefix(self, monkeypatch):
-        """Routes to Gemini for model without prefix containing 'gemini'."""
-        monkeypatch.setenv("GEMINI_API_KEY", "AIza_test")
-
-        with patch("google.genai.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_response = MagicMock()
-            mock_response.text = "0.7"
-            mock_client.models.generate_content.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+    async def test_gemini_bare_name_prefixed(self):
+        """A bare gemini model gets the 'gemini/' prefix for litellm."""
+        mock = AsyncMock(return_value=_completion("0.7"))
+        with patch("mcp_core.llm.acompletion", mock):
             result = await _llm_completion(
                 "gemini-3-flash-preview",
                 [{"role": "user", "content": "score"}],
             )
-            assert result == "0.7"
+        assert result == "0.7"
+        assert mock.call_args.kwargs["model"] == "gemini/gemini-3-flash-preview"
 
-    async def test_gemini_empty_text(self, monkeypatch):
-        """Gemini returns empty string when response.text is None."""
-        monkeypatch.setenv("GEMINI_API_KEY", "AIza_test")
-
-        with patch("google.genai.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_response = MagicMock()
-            mock_response.text = None
-            mock_client.models.generate_content.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+    async def test_empty_content(self):
+        """Returns empty string when message.content is None."""
+        mock = AsyncMock(return_value=_completion(None))
+        with patch("mcp_core.llm.acompletion", mock):
             result = await _llm_completion(
                 "gemini/gemini-3-flash-preview",
                 [{"role": "user", "content": "test"}],
             )
-            assert result == ""
+        assert result == ""
 
-    async def test_openai_path(self, monkeypatch):
-        """Routes to OpenAI SDK when model is openai/..."""
-        monkeypatch.setenv("OPENAI_API_KEY", "sk_test")
-        monkeypatch.delenv("XAI_API_KEY", raising=False)
-
-        with patch("openai.OpenAI") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_choice = MagicMock()
-            mock_choice.message.content = '{"entities": []}'
-            mock_response = MagicMock()
-            mock_response.choices = [mock_choice]
-            mock_client.chat.completions.create.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
-            result = await _llm_completion(
-                "openai/gpt-5.4-mini",
-                [{"role": "user", "content": "test"}],
-                response_format={"type": "json_object"},
-            )
-            assert result == '{"entities": []}'
-
-    async def test_xai_path(self, monkeypatch):
-        """Routes to OpenAI SDK with xAI base_url when XAI_API_KEY is set."""
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.setenv("XAI_API_KEY", "xai_test")
-
-        with patch("openai.OpenAI") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_choice = MagicMock()
-            mock_choice.message.content = "0.5"
-            mock_response = MagicMock()
-            mock_response.choices = [mock_choice]
-            mock_client.chat.completions.create.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
-            result = await _llm_completion(
-                "xai/grok-4-mini",
-                [{"role": "user", "content": "test"}],
-            )
-            assert result == "0.5"
-            mock_client_cls.assert_called_once_with(
-                api_key="xai_test",
-                base_url="https://api.x.ai/v1",
-            )
-
-    async def test_openai_empty_content(self, monkeypatch):
-        """OpenAI returns empty string when message.content is None."""
-        monkeypatch.setenv("OPENAI_API_KEY", "sk_test")
-        monkeypatch.delenv("XAI_API_KEY", raising=False)
-
-        with patch("openai.OpenAI") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_choice = MagicMock()
-            mock_choice.message.content = None
-            mock_response = MagicMock()
-            mock_response.choices = [mock_choice]
-            mock_client.chat.completions.create.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+    async def test_response_format_omitted_when_none(self):
+        """response_format is not forwarded when not provided."""
+        mock = AsyncMock(return_value=_completion('{"entities": []}'))
+        with patch("mcp_core.llm.acompletion", mock):
             result = await _llm_completion(
                 "openai/gpt-5.4-mini",
                 [{"role": "user", "content": "test"}],
             )
-            assert result == ""
+        assert result == '{"entities": []}'
+        assert "response_format" not in mock.call_args.kwargs
 
-    async def test_openai_no_prefix(self, monkeypatch):
-        """Non-gemini model without prefix uses openai SDK."""
-        monkeypatch.setenv("OPENAI_API_KEY", "sk_test")
-        monkeypatch.delenv("XAI_API_KEY", raising=False)
-
-        with patch("openai.OpenAI") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_choice = MagicMock()
-            mock_choice.message.content = "0.8"
-            mock_response = MagicMock()
-            mock_response.choices = [mock_choice]
-            mock_client.chat.completions.create.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+    async def test_non_gemini_bare_name_passthrough(self):
+        """A non-gemini bare model name is passed to litellm as-is."""
+        mock = AsyncMock(return_value=_completion("0.8"))
+        with patch("mcp_core.llm.acompletion", mock):
             result = await _llm_completion(
                 "gpt-5.4-mini",
                 [{"role": "user", "content": "test"}],
             )
-            assert result == "0.8"
-            # Model should be used as-is (no prefix)
-            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-            assert call_kwargs["model"] == "gpt-5.4-mini"
+        assert result == "0.8"
+        assert mock.call_args.kwargs["model"] == "gpt-5.4-mini"
+
+    async def test_api_base_from_env(self, monkeypatch):
+        """LLM_API_BASE flows through to acompletion as api_base."""
+        monkeypatch.setenv("LLM_API_BASE", "https://proxy.example/v1")
+        mock = AsyncMock(return_value=_completion("ok"))
+        with patch("mcp_core.llm.acompletion", mock):
+            await _llm_completion(
+                "gemini/gemini-3-flash-preview",
+                [{"role": "user", "content": "test"}],
+            )
+        assert mock.call_args.kwargs["api_base"] == "https://proxy.example/v1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -12,11 +12,19 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from mnemo_mcp import llm
+
+
+def _fake_completion(content: str) -> SimpleNamespace:
+    """Build a litellm-shaped completion response (resp.choices[0].message.content)."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
 
 _ALL_KEYS = (
     "GEMINI_API_KEY",
@@ -123,133 +131,90 @@ def test_call_llm_graceful_skip_no_provider() -> None:
 
 
 def test_call_llm_unknown_explicit_provider_returns_none() -> None:
-    """Explicit but unsupported provider must not silently dispatch."""
-    with patch.object(llm.logger, "warning") as warn:
+    """Explicit but unsupported provider returns None when litellm raises."""
+    mock = AsyncMock(side_effect=Exception("bogus provider"))
+    with (
+        patch("mcp_core.llm.acompletion", mock),
+        patch.object(llm.logger, "warning") as warn,
+    ):
         result = asyncio.run(llm.call_llm("hello", provider="bogus"))
     assert result is None
     assert warn.called
 
 
 # ---------------------------------------------------------------------------
-# call_llm — per-provider dispatch
+# call_llm — litellm passthrough dispatch
 # ---------------------------------------------------------------------------
-
-
-def _install_fake_gemini() -> tuple[MagicMock, SimpleNamespace]:
-    """Install fake ``google.genai`` modules into sys.modules and return handles.
-
-    ``from X import Y`` resolves Y as an attribute of X *after* the import
-    machinery loads X, so the SimpleNamespace standing in for ``google.genai``
-    must expose ``types`` as an attribute too.
-    """
-    fake_response = SimpleNamespace(text="from gemini")
-    fake_models = SimpleNamespace(
-        generate_content=MagicMock(return_value=fake_response)
-    )
-    fake_client_cls = MagicMock(return_value=SimpleNamespace(models=fake_models))
-    fake_types = SimpleNamespace(
-        GenerateContentConfig=lambda **kw: SimpleNamespace(**kw)
-    )
-    fake_genai = SimpleNamespace(Client=fake_client_cls, types=fake_types)
-    fake_google = SimpleNamespace(genai=fake_genai)
-
-    return fake_client_cls, SimpleNamespace(
-        google=fake_google,
-        genai=fake_genai,
-        types=fake_types,
-        models=fake_models,
-    )
 
 
 def test_call_llm_dispatches_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GEMINI_API_KEY", "g-key")
 
-    fake_client_cls, fakes = _install_fake_gemini()
-
-    with patch.dict(
-        "sys.modules",
-        {
-            "google": fakes.google,
-            "google.genai": fakes.genai,
-            "google.genai.types": fakes.types,
-        },
-    ):
+    mock = AsyncMock(return_value=_fake_completion("from gemini"))
+    with patch("mcp_core.llm.acompletion", mock):
         result = asyncio.run(llm.call_llm("hi"))
 
     assert result == "from gemini"
-    fake_client_cls.assert_called_once_with(api_key="g-key")
-    call_kwargs = fakes.models.generate_content.call_args.kwargs
-    assert call_kwargs["contents"] == "hi"
-    assert call_kwargs["model"] == llm._DEFAULT_MODELS["gemini"]
+    call_kwargs = mock.call_args.kwargs
+    assert call_kwargs["model"] == f"gemini/{llm._DEFAULT_MODELS['gemini']}"
+    assert call_kwargs["messages"] == [{"role": "user", "content": "hi"}]
 
 
 def test_call_llm_dispatches_openai(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "o-key")
 
-    fake_message = SimpleNamespace(content="from openai")
-    fake_choice = SimpleNamespace(message=fake_message)
-    fake_response = SimpleNamespace(choices=[fake_choice])
-    fake_completions = SimpleNamespace(create=MagicMock(return_value=fake_response))
-    fake_chat = SimpleNamespace(completions=fake_completions)
-    fake_client = SimpleNamespace(chat=fake_chat)
-    fake_openai_cls = MagicMock(return_value=fake_client)
-    fake_openai = SimpleNamespace(OpenAI=fake_openai_cls)
-
-    with patch.dict("sys.modules", {"openai": fake_openai}):
+    mock = AsyncMock(return_value=_fake_completion("from openai"))
+    with patch("mcp_core.llm.acompletion", mock):
         result = asyncio.run(
             llm.call_llm("hi", model="gpt-test", temperature=0.2, max_tokens=42)
         )
 
     assert result == "from openai"
-    fake_openai_cls.assert_called_once_with(api_key="o-key")
-    call_kwargs = fake_completions.create.call_args.kwargs
-    assert call_kwargs["model"] == "gpt-test"
+    call_kwargs = mock.call_args.kwargs
+    assert call_kwargs["model"] == "openai/gpt-test"
     assert call_kwargs["messages"] == [{"role": "user", "content": "hi"}]
     assert call_kwargs["temperature"] == 0.2
     assert call_kwargs["max_tokens"] == 42
 
 
 def test_call_llm_dispatches_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ANTHROPIC_API_KEY now works WITHOUT the anthropic package (litellm)."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
 
-    fake_part = SimpleNamespace(text="from anthropic")
-    fake_message = SimpleNamespace(content=[fake_part])
-    fake_messages = SimpleNamespace(create=MagicMock(return_value=fake_message))
-    fake_client = SimpleNamespace(messages=fake_messages)
-    fake_anthropic_cls = MagicMock(return_value=fake_client)
-    fake_anthropic = SimpleNamespace(Anthropic=fake_anthropic_cls)
-
-    with patch.dict("sys.modules", {"anthropic": fake_anthropic}):
-        result = asyncio.run(llm.call_llm("hi"))
+    mock = AsyncMock(return_value=_fake_completion("from anthropic"))
+    # No `anthropic` package: ensure import is never attempted.
+    with patch.dict("sys.modules", {"anthropic": None}):
+        with patch("mcp_core.llm.acompletion", mock):
+            result = asyncio.run(llm.call_llm("hi"))
 
     assert result == "from anthropic"
-    fake_anthropic_cls.assert_called_once_with(api_key="a-key")
-    call_kwargs = fake_messages.create.call_args.kwargs
-    assert call_kwargs["model"] == llm._DEFAULT_MODELS["anthropic"]
+    call_kwargs = mock.call_args.kwargs
+    assert call_kwargs["model"] == f"anthropic/{llm._DEFAULT_MODELS['anthropic']}"
     assert call_kwargs["messages"] == [{"role": "user", "content": "hi"}]
 
 
 def test_call_llm_dispatches_xai(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("XAI_API_KEY", "x-key")
 
-    fake_message = SimpleNamespace(content="from xai")
-    fake_choice = SimpleNamespace(message=fake_message)
-    fake_response = SimpleNamespace(choices=[fake_choice])
-    fake_completions = SimpleNamespace(create=MagicMock(return_value=fake_response))
-    fake_chat = SimpleNamespace(completions=fake_completions)
-    fake_client = SimpleNamespace(chat=fake_chat)
-    fake_openai_cls = MagicMock(return_value=fake_client)
-    fake_openai = SimpleNamespace(OpenAI=fake_openai_cls)
-
-    with patch.dict("sys.modules", {"openai": fake_openai}):
+    mock = AsyncMock(return_value=_fake_completion("from xai"))
+    with patch("mcp_core.llm.acompletion", mock):
         result = asyncio.run(llm.call_llm("hi"))
 
     assert result == "from xai"
-    fake_openai_cls.assert_called_once_with(
-        api_key="x-key", base_url="https://api.x.ai/v1"
-    )
-    call_kwargs = fake_completions.create.call_args.kwargs
-    assert call_kwargs["model"] == llm._DEFAULT_MODELS["xai"]
+    call_kwargs = mock.call_args.kwargs
+    assert call_kwargs["model"] == f"xai/{llm._DEFAULT_MODELS['xai']}"
+
+
+def test_call_llm_passes_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM_API_BASE flows through to acompletion as api_base."""
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    monkeypatch.setenv("LLM_API_BASE", "https://proxy.example/v1")
+
+    mock = AsyncMock(return_value=_fake_completion("ok"))
+    with patch("mcp_core.llm.acompletion", mock):
+        asyncio.run(llm.call_llm("hi"))
+
+    assert mock.call_args.kwargs["api_base"] == "https://proxy.example/v1"
 
 
 # ---------------------------------------------------------------------------
@@ -264,37 +229,22 @@ def test_call_llm_explicit_provider_override_skips_detection(
     monkeypatch.setenv("GEMINI_API_KEY", "g-key")
     monkeypatch.setenv("OPENAI_API_KEY", "o-key")
 
-    fake_message = SimpleNamespace(content="from openai")
-    fake_choice = SimpleNamespace(message=fake_message)
-    fake_response = SimpleNamespace(choices=[fake_choice])
-    fake_completions = SimpleNamespace(create=MagicMock(return_value=fake_response))
-    fake_chat = SimpleNamespace(completions=fake_completions)
-    fake_client = SimpleNamespace(chat=fake_chat)
-    fake_openai_cls = MagicMock(return_value=fake_client)
-    fake_openai = SimpleNamespace(OpenAI=fake_openai_cls)
-
-    with patch.dict("sys.modules", {"openai": fake_openai}):
+    mock = AsyncMock(return_value=_fake_completion("from openai"))
+    with patch("mcp_core.llm.acompletion", mock):
         result = asyncio.run(llm.call_llm("hi", provider="openai"))
 
     assert result == "from openai"
-    fake_openai_cls.assert_called_once_with(api_key="o-key")
+    call_kwargs = mock.call_args.kwargs
+    assert call_kwargs["model"].startswith("openai/")
 
 
 def test_call_llm_uses_env_model(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GEMINI_API_KEY", "g-key")
     monkeypatch.setenv("LLM_MODELS", "gemini=gemini-3-flash-from-env")
 
-    _, fakes = _install_fake_gemini()
-
-    with patch.dict(
-        "sys.modules",
-        {
-            "google": fakes.google,
-            "google.genai": fakes.genai,
-            "google.genai.types": fakes.types,
-        },
-    ):
+    mock = AsyncMock(return_value=_fake_completion("ok"))
+    with patch("mcp_core.llm.acompletion", mock):
         asyncio.run(llm.call_llm("hi"))
 
-    call_kwargs = fakes.models.generate_content.call_args.kwargs
-    assert call_kwargs["model"] == "gemini-3-flash-from-env"
+    call_kwargs = mock.call_args.kwargs
+    assert call_kwargs["model"] == "gemini/gemini-3-flash-from-env"

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,5 +1,10 @@
-"""Tests for mnemo_mcp.reranker -- dual-backend reranking."""
+"""Tests for mnemo_mcp.reranker -- dual-backend reranking.
 
+Cloud reranking goes through mcp_core.llm (litellm passthrough); tests patch
+the sync mirror ``mcp_core.llm.rerank``.
+"""
+
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,6 +20,11 @@ from mnemo_mcp.reranker import (
 )
 
 
+def _rerank_resp(*results):
+    """Build a litellm-shaped RerankResponse (resp.results)."""
+    return SimpleNamespace(results=list(results))
+
+
 @pytest.fixture(autouse=True)
 def _reset_reranker_backend():
     """Reset module-level _backend before each test."""
@@ -26,29 +36,15 @@ def _reset_reranker_backend():
 
 class TestCohereReranker:
     def test_rerank_success(self):
-        """Cohere reranker returns sorted (index, score) tuples."""
+        """Cloud reranker returns sorted (index, score) tuples."""
         reranker = CohereReranker(api_key="test-key")
+        resp = _rerank_resp(
+            SimpleNamespace(index=0, relevance_score=0.3),
+            SimpleNamespace(index=1, relevance_score=0.9),
+            SimpleNamespace(index=2, relevance_score=0.6),
+        )
 
-        mock_result_0 = MagicMock()
-        mock_result_0.index = 0
-        mock_result_0.relevance_score = 0.3
-
-        mock_result_1 = MagicMock()
-        mock_result_1.index = 1
-        mock_result_1.relevance_score = 0.9
-
-        mock_result_2 = MagicMock()
-        mock_result_2.index = 2
-        mock_result_2.relevance_score = 0.6
-
-        mock_response = MagicMock()
-        mock_response.results = [mock_result_0, mock_result_1, mock_result_2]
-
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.rerank.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+        with patch("mcp_core.llm.rerank", return_value=resp):
             results = reranker.rerank("test query", ["doc0", "doc1", "doc2"], top_n=2)
 
         assert len(results) == 2
@@ -56,24 +52,28 @@ class TestCohereReranker:
         assert results[1] == (2, 0.6)
 
     def test_rerank_with_dict_results(self):
-        """Cohere reranker handles dict-style results."""
+        """Cloud reranker handles dict-style results."""
         reranker = CohereReranker(api_key="test-key")
-
-        mock_response = MagicMock()
-        mock_response.results = [
+        resp = _rerank_resp(
             {"index": 0, "relevance_score": 0.8},
             {"index": 1, "relevance_score": 0.5},
-        ]
+        )
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.rerank.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+        with patch("mcp_core.llm.rerank", return_value=resp):
             results = reranker.rerank("query", ["doc0", "doc1"])
 
         assert results[0] == (0, 0.8)
         assert results[1] == (1, 0.5)
+
+    def test_rerank_none_results_guarded(self):
+        """litellm RerankResponse.results defaults to None -> empty list."""
+        reranker = CohereReranker(api_key="test-key")
+        resp = SimpleNamespace(results=None)
+
+        with patch("mcp_core.llm.rerank", return_value=resp):
+            results = reranker.rerank("query", ["doc"])
+
+        assert results == []
 
     def test_rerank_empty_docs(self):
         """Empty documents list returns empty results."""
@@ -85,11 +85,7 @@ class TestCohereReranker:
         """Reranker returns empty list on failure (never raises)."""
         reranker = CohereReranker(api_key="test-key")
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.rerank.side_effect = Exception("API error")
-            mock_client_cls.return_value = mock_client
-
+        with patch("mcp_core.llm.rerank", side_effect=Exception("API error")):
             results = reranker.rerank("query", ["doc"])
 
         assert results == []
@@ -97,38 +93,36 @@ class TestCohereReranker:
     def test_check_available_success(self):
         """check_available returns True when API responds."""
         reranker = CohereReranker(api_key="test-key")
+        resp = _rerank_resp(SimpleNamespace(index=0, relevance_score=0.5))
 
-        mock_response = MagicMock()
-        mock_response.results = [MagicMock()]
-
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.rerank.return_value = mock_response
-            mock_client_cls.return_value = mock_client
-
+        with patch("mcp_core.llm.rerank", return_value=resp):
             assert reranker.check_available() is True
 
     def test_check_available_failure(self):
         """check_available returns False on API failure."""
         reranker = CohereReranker(api_key="test-key")
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.rerank.side_effect = Exception("connection error")
-            mock_client_cls.return_value = mock_client
-
+        with patch("mcp_core.llm.rerank", side_effect=Exception("connection error")):
             assert reranker.check_available() is False
 
     def test_check_available_auth_error(self):
         """check_available logs warning for auth errors."""
         reranker = CohereReranker(api_key="bad-key")
 
-        with patch("cohere.ClientV2") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.rerank.side_effect = Exception("401 unauthorized")
-            mock_client_cls.return_value = mock_client
-
+        with patch("mcp_core.llm.rerank", side_effect=Exception("401 unauthorized")):
             assert reranker.check_available() is False
+
+    def test_litellm_model_mapping(self):
+        """Bare jina/cohere names map to litellm provider/model form."""
+        assert CloudReranker(model="rerank-v4.0-pro")._litellm_model() == (
+            "cohere/rerank-v4.0-pro"
+        )
+        assert CloudReranker(model="jina-reranker-v3")._litellm_model() == (
+            "jina_ai/jina-reranker-v3"
+        )
+        assert CloudReranker(model="cohere/rerank-v4.0-pro")._litellm_model() == (
+            "cohere/rerank-v4.0-pro"
+        )
 
     def test_litellm_backward_compat_alias(self):
         """LiteLLMReranker is an alias for CloudReranker."""

--- a/tests/test_reranker_coverage.py
+++ b/tests/test_reranker_coverage.py
@@ -1,10 +1,11 @@
-"""Tests for reranker.py -- Jina provider and detection logic coverage.
+"""Tests for reranker.py -- provider detection logic and cloud path coverage.
 
 Targets: _detect_rerank_provider (Jina env fallback, non-rerank/cohere model),
-_strip_provider, CloudReranker Jina backend, CloudReranker._check_jina,
-CloudReranker._check_cohere, Qwen3Reranker lazy load.
+_strip_provider, CloudReranker litellm passthrough (Jina + Cohere routing),
+check_available auth/non-auth branches, Qwen3Reranker lazy load.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from mnemo_mcp.reranker import (
@@ -13,6 +14,12 @@ from mnemo_mcp.reranker import (
     _detect_rerank_provider,
     _strip_provider,
 )
+
+
+def _rerank_resp(*results):
+    """Build a litellm-shaped RerankResponse (resp.results)."""
+    return SimpleNamespace(results=list(results))
+
 
 # ---------------------------------------------------------------------------
 # _detect_rerank_provider
@@ -52,133 +59,84 @@ class TestStripProviderReranker:
 
 
 # ---------------------------------------------------------------------------
-# CloudReranker -- Jina backend
+# CloudReranker -- cloud path (litellm passthrough)
 # ---------------------------------------------------------------------------
 
 
 class TestCloudRerankerJina:
-    @patch("httpx.post")
-    def test_rerank_jina_success(self, mock_post):
-        """Jina reranker returns sorted results."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {
-            "results": [
-                {"index": 0, "relevance_score": 0.3},
-                {"index": 1, "relevance_score": 0.9},
-                {"index": 2, "relevance_score": 0.6},
-            ]
-        }
-        mock_post.return_value = mock_response
-
-        reranker = CloudReranker(
-            model="jina_ai/jina-reranker-v3",
-            api_key="jina_test",
+    def test_rerank_jina_success(self):
+        """Jina-model reranker returns sorted results via litellm."""
+        resp = _rerank_resp(
+            {"index": 0, "relevance_score": 0.3},
+            {"index": 1, "relevance_score": 0.9},
+            {"index": 2, "relevance_score": 0.6},
         )
-        results = reranker.rerank("query", ["doc0", "doc1", "doc2"], top_n=2)
+        reranker = CloudReranker(model="jina_ai/jina-reranker-v3", api_key="jina_test")
+        with patch("mcp_core.llm.rerank", return_value=resp) as mock:
+            results = reranker.rerank("query", ["doc0", "doc1", "doc2"], top_n=2)
 
         assert len(results) == 2
         assert results[0] == (1, 0.9)
         assert results[1] == (2, 0.6)
+        assert mock.call_args.kwargs["model"] == "jina_ai/jina-reranker-v3"
 
-    @patch("httpx.post")
-    def test_rerank_jina_failure(self, mock_post):
-        """Jina reranker returns empty on failure."""
-        mock_post.side_effect = Exception("API error")
-
-        reranker = CloudReranker(
-            model="jina_ai/jina-reranker-v3",
-            api_key="jina_test",
-        )
-        results = reranker.rerank("query", ["doc0"])
+    def test_rerank_jina_failure(self):
+        """Reranker returns empty on failure."""
+        reranker = CloudReranker(model="jina_ai/jina-reranker-v3", api_key="jina_test")
+        with patch("mcp_core.llm.rerank", side_effect=Exception("API error")):
+            results = reranker.rerank("query", ["doc0"])
         assert results == []
 
 
 # ---------------------------------------------------------------------------
-# CloudReranker -- check_available (Jina and Cohere paths)
+# CloudReranker -- check_available (auth vs non-auth branches)
 # ---------------------------------------------------------------------------
 
 
 class TestCheckAvailableReranker:
-    @patch("httpx.post")
-    def test_check_jina_available(self, mock_post):
-        """Jina check_available returns True on success."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {
-            "results": [{"index": 0, "relevance_score": 0.5}]
-        }
-        mock_post.return_value = mock_response
+    def test_check_jina_available(self):
+        """check_available returns True on success."""
+        resp = _rerank_resp({"index": 0, "relevance_score": 0.5})
+        reranker = CloudReranker(model="jina_ai/jina-reranker-v3", api_key="jina_test")
+        with patch("mcp_core.llm.rerank", return_value=resp):
+            assert reranker.check_available() is True
 
-        reranker = CloudReranker(
-            model="jina_ai/jina-reranker-v3",
-            api_key="jina_test",
-        )
-        assert reranker.check_available() is True
-
-    @patch("httpx.post")
-    def test_check_jina_api_key_invalid(self, mock_post):
-        """Jina check_available returns False and logs warning on 401."""
-        mock_post.side_effect = Exception("401 Unauthorized")
-
-        reranker = CloudReranker(
-            model="jina_ai/jina-reranker-v3",
-            api_key="bad_key",
-        )
-        with patch("mnemo_mcp.reranker.logger") as mock_logger:
+    def test_check_jina_api_key_invalid(self):
+        """check_available returns False and logs warning on 401."""
+        reranker = CloudReranker(model="jina_ai/jina-reranker-v3", api_key="bad_key")
+        with (
+            patch("mcp_core.llm.rerank", side_effect=Exception("401 Unauthorized")),
+            patch("mnemo_mcp.reranker.logger") as mock_logger,
+        ):
             assert reranker.check_available() is False
             mock_logger.warning.assert_called()
             assert "API key invalid" in mock_logger.warning.call_args[0][0]
 
-    @patch("cohere.ClientV2")
-    def test_check_cohere_available(self, mock_client_cls):
-        """Cohere check_available returns True on success."""
-        mock_result = MagicMock()
-        mock_result.index = 0
-        mock_result.relevance_score = 0.5
+    def test_check_cohere_available(self):
+        """check_available returns True on success for cohere model."""
+        resp = _rerank_resp(SimpleNamespace(index=0, relevance_score=0.5))
+        reranker = CloudReranker(model="rerank-v4.0-pro", api_key="co_test")
+        with patch("mcp_core.llm.rerank", return_value=resp):
+            assert reranker.check_available() is True
 
-        mock_response = MagicMock()
-        mock_response.results = [mock_result]
-
-        mock_client = MagicMock()
-        mock_client.rerank.return_value = mock_response
-        mock_client_cls.return_value = mock_client
-
-        reranker = CloudReranker(
-            model="rerank-v4.0-pro",
-            api_key="co_test",
-        )
-        assert reranker.check_available() is True
-
-    @patch("cohere.ClientV2")
-    def test_check_cohere_api_key_invalid_logging(self, mock_client_cls):
-        """Cohere check_available logs warning for auth errors."""
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("invalid api key")
-        mock_client_cls.return_value = mock_client
-
-        reranker = CloudReranker(
-            model="rerank-v4.0-pro",
-            api_key="bad_key",
-        )
-        with patch("mnemo_mcp.reranker.logger") as mock_logger:
+    def test_check_cohere_api_key_invalid_logging(self):
+        """check_available logs warning for auth errors."""
+        reranker = CloudReranker(model="rerank-v4.0-pro", api_key="bad_key")
+        with (
+            patch("mcp_core.llm.rerank", side_effect=Exception("invalid api key")),
+            patch("mnemo_mcp.reranker.logger") as mock_logger,
+        ):
             assert reranker.check_available() is False
             mock_logger.warning.assert_called()
             assert "API key invalid" in mock_logger.warning.call_args[0][0]
 
-    @patch("cohere.ClientV2")
-    def test_check_cohere_non_auth_error(self, mock_client_cls):
-        """Cohere check_available returns False on non-auth error."""
-        mock_client = MagicMock()
-        mock_client.rerank.side_effect = Exception("Model not found")
-        mock_client_cls.return_value = mock_client
-
-        reranker = CloudReranker(
-            model="rerank-v4.0-pro",
-            api_key="co_test",
-        )
-        with patch("mnemo_mcp.reranker.logger") as mock_logger:
+    def test_check_cohere_non_auth_error(self):
+        """check_available returns False on non-auth error."""
+        reranker = CloudReranker(model="rerank-v4.0-pro", api_key="co_test")
+        with (
+            patch("mcp_core.llm.rerank", side_effect=Exception("Model not found")),
+            patch("mnemo_mcp.reranker.logger") as mock_logger,
+        ):
             assert reranker.check_available() is False
             mock_logger.debug.assert_called()
             assert "not available" in mock_logger.debug.call_args[0][0]

--- a/tests/test_reranker_error_fallback.py
+++ b/tests/test_reranker_error_fallback.py
@@ -5,9 +5,11 @@ from mnemo_mcp.reranker import CloudReranker
 
 class TestCloudRerankerErrorFallback:
     def test_rerank_jina_exception_logs_and_returns_empty(self):
-        """Verify that an exception in _rerank_jina is caught, logged, and returns []."""
-        with patch("mnemo_mcp.reranker.CloudReranker._rerank_jina") as mock_jina:
-            mock_jina.side_effect = Exception("Mock Jina Failure")
+        """An exception in the cloud rerank path is caught, logged, returns []."""
+        with patch(
+            "mnemo_mcp.reranker.CloudReranker._call_rerank",
+            side_effect=Exception("Mock Jina Failure"),
+        ):
             reranker = CloudReranker(model="jina-reranker-v3")
 
             with patch("mnemo_mcp.reranker.logger") as mock_logger:
@@ -19,9 +21,11 @@ class TestCloudRerankerErrorFallback:
                 assert "Cloud reranking failed (jina): Mock Jina Failure" in args[0]
 
     def test_rerank_cohere_exception_logs_and_returns_empty(self):
-        """Verify that an exception in _rerank_cohere is caught, logged, and returns []."""
-        with patch("mnemo_mcp.reranker.CloudReranker._rerank_cohere") as mock_cohere:
-            mock_cohere.side_effect = Exception("Mock Cohere Failure")
+        """An exception in the cloud rerank path is caught, logged, returns []."""
+        with patch(
+            "mnemo_mcp.reranker.CloudReranker._call_rerank",
+            side_effect=Exception("Mock Cohere Failure"),
+        ):
             reranker = CloudReranker(model="rerank-v4.0-pro")
 
             with patch("mnemo_mcp.reranker.logger") as mock_logger:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -403,6 +403,37 @@ class TestConfigTool:
         assert "valid_actions" in result
         assert "suggestion" not in result
 
+    async def test_models_action_configured_only(self, ctx_with_db):
+        """models action lists configured-provider models via mcp_core.llm."""
+        from unittest.mock import patch
+
+        ctx, _ = ctx_with_db
+        with patch(
+            "mcp_core.llm.list_models",
+            return_value=["gemini/gemini-3-flash-preview"],
+        ) as mock_list:
+            result = json.loads(await config(action="models", ctx=ctx))
+        assert result["models"] == ["gemini/gemini-3-flash-preview"]
+        assert "passthrough" in result["note"]
+        assert mock_list.call_args.kwargs["configured_only"] is True
+
+    async def test_models_action_all_bypasses_configured_only(self, ctx_with_db):
+        """key='all' lists the full catalog (configured_only=False)."""
+        from unittest.mock import patch
+
+        ctx, _ = ctx_with_db
+        with patch("mcp_core.llm.list_models", return_value=["a", "b"]) as mock_list:
+            result = json.loads(await config(action="models", key="all", ctx=ctx))
+        assert result["models"] == ["a", "b"]
+        assert mock_list.call_args.kwargs["configured_only"] is False
+        assert mock_list.call_args.kwargs["modes"] == ("chat", "embedding", "rerank")
+
+    async def test_models_action_in_valid_actions(self, ctx_with_db):
+        """'models' appears in the unknown-action valid_actions list."""
+        ctx, _ = ctx_with_db
+        result = json.loads(await config(action="bogus", ctx=ctx))
+        assert "models" in result["valid_actions"]
+
 
 class TestHelpTool:
     async def test_memory_topic(self):

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,67 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -233,25 +294,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cohere"
-version = "7.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastavro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/c0/3c9b38c7332dfb1523a079fa3c5ea701a5ea82997d12d057c4002b6a0c75/cohere-7.0.3.tar.gz", hash = "sha256:f74c6be98ee5d0d1310c3892171def2f184d5a9b7ab81d906407ffc7a5e62adc", size = 208811, upload-time = "2026-06-01T21:52:38.093Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/0d/f543e349da10761c498e3a773e728c2d6b1aeb47195f2f09c6145452d51c/cohere-7.0.3-py3-none-any.whl", hash = "sha256:c880a45c4cd670d5e7c9297de122005f21e2d9624fda9314cb3e4e0406bc9ec5", size = 351965, upload-time = "2026-06-01T21:52:36.429Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -430,25 +472,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastavro"
-version = "1.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/8b/fa2d3287fd2267be6261d0177c6809a7fa12c5600ddb33490c8dc29e77b2/fastavro-1.12.1.tar.gz", hash = "sha256:2f285be49e45bc047ab2f6bed040bb349da85db3f3c87880e4b92595ea093b2b", size = 1025661, upload-time = "2025-10-10T15:40:55.41Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/57/26d5efef9182392d5ac9f253953c856ccb66e4c549fd3176a1e94efb05c9/fastavro-1.12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:78df838351e4dff9edd10a1c41d1324131ffecbadefb9c297d612ef5363c049a", size = 1000599, upload-time = "2025-10-10T15:41:36.554Z" },
-    { url = "https://files.pythonhosted.org/packages/33/cb/8ab55b21d018178eb126007a56bde14fd01c0afc11d20b5f2624fe01e698/fastavro-1.12.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:780476c23175d2ae457c52f45b9ffa9d504593499a36cd3c1929662bf5b7b14b", size = 3335933, upload-time = "2025-10-10T15:41:39.07Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/03/9c94ec9bf873eb1ffb0aa694f4e71940154e6e9728ddfdc46046d7e8ced4/fastavro-1.12.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0714b285160fcd515eb0455540f40dd6dac93bdeacdb03f24e8eac3d8aa51f8d", size = 3402066, upload-time = "2025-10-10T15:41:41.608Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c8/cb472347c5a584ccb8777a649ebb28278fccea39d005fc7df19996f41df8/fastavro-1.12.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a8bc2dcec5843d499f2489bfe0747999108f78c5b29295d877379f1972a3d41a", size = 3240038, upload-time = "2025-10-10T15:41:43.743Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/77/569ce9474c40304b3a09e109494e020462b83e405545b78069ddba5f614e/fastavro-1.12.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3b1921ac35f3d89090a5816b626cf46e67dbecf3f054131f84d56b4e70496f45", size = 3369398, upload-time = "2025-10-10T15:41:45.719Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1f/9589e35e9ea68035385db7bdbf500d36b8891db474063fb1ccc8215ee37c/fastavro-1.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:5aa777b8ee595b50aa084104cd70670bf25a7bbb9fd8bb5d07524b0785ee1699", size = 444220, upload-time = "2025-10-10T15:41:47.39Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d2/78435fe737df94bd8db2234b2100f5453737cffd29adee2504a2b013de84/fastavro-1.12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c3d67c47f177e486640404a56f2f50b165fe892cc343ac3a34673b80cc7f1dd6", size = 1086611, upload-time = "2025-10-10T15:41:48.818Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/be/428f99b10157230ddac77ec8cc167005b29e2bd5cbe228345192bb645f30/fastavro-1.12.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5217f773492bac43dae15ff2931432bce2d7a80be7039685a78d3fab7df910bd", size = 3541001, upload-time = "2025-10-10T15:41:50.871Z" },
-    { url = "https://files.pythonhosted.org/packages/16/08/a2eea4f20b85897740efe44887e1ac08f30dfa4bfc3de8962bdcbb21a5a1/fastavro-1.12.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:469fecb25cba07f2e1bfa4c8d008477cd6b5b34a59d48715e1b1a73f6160097d", size = 3432217, upload-time = "2025-10-10T15:41:53.149Z" },
-    { url = "https://files.pythonhosted.org/packages/87/bb/b4c620b9eb6e9838c7f7e4b7be0762834443adf9daeb252a214e9ad3178c/fastavro-1.12.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d71c8aa841ef65cfab709a22bb887955f42934bced3ddb571e98fdbdade4c609", size = 3366742, upload-time = "2025-10-10T15:41:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d1/e69534ccdd5368350646fea7d93be39e5f77c614cca825c990bd9ca58f67/fastavro-1.12.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b81fc04e85dfccf7c028e0580c606e33aa8472370b767ef058aae2c674a90746", size = 3383743, upload-time = "2025-10-10T15:41:57.68Z" },
-]
-
-[[package]]
 name = "fastmcp"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -512,6 +535,25 @@ server = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
@@ -529,51 +571,53 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ba/b0b3de23f40bc55a7057bd38434e25c34fa48e17f20ee273bbde5e0650f3/frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7", size = 49651, upload-time = "2025-10-06T05:36:28.855Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/1b5531611e83ba7d13ccc9988967ea1b51186af64c42b7a7af465dcc9568/frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496", size = 39628, upload-time = "2025-10-06T05:36:45.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cf/174c91dbc9cc49bc7b7aab74d8b734e974d1faa8f191c74af9b7e80848e6/frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231", size = 43882, upload-time = "2025-10-06T05:36:46.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/17/502cd212cbfa96eb1388614fe39a3fc9ab87dbbe042b66f97acb57474834/frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62", size = 39676, upload-time = "2025-10-06T05:36:47.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d6/f03961ef72166cec1687e84e8925838442b615bd0b8854b54923ce5b7b8a/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c", size = 50742, upload-time = "2025-10-06T05:36:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/00/04ca1c3a7a124b6de4f8a9a17cc2fcad138b4608e7a3fc5877804b8715d7/frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b", size = 43492, upload-time = "2025-10-06T05:37:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5e/c69f733a86a94ab10f68e496dc6b7e8bc078ebb415281d5698313e3af3a1/frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888", size = 48034, upload-time = "2025-10-06T05:37:06.343Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6c/be9d79775d8abe79b05fa6d23da99ad6e7763a1d080fbae7290b286093fd/frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042", size = 41749, upload-time = "2025-10-06T05:37:07.431Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
-]
-
-[[package]]
-name = "google-auth"
-version = "2.49.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
-]
-
-[package.optional-dependencies]
-requests = [
-    { name = "requests" },
-]
-
-[[package]]
-name = "google-genai"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "google-auth", extra = ["requests"] },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "sniffio" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
 ]
 
 [[package]]
@@ -774,6 +818,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -889,6 +945,29 @@ wheels = [
 ]
 
 [[package]]
+name = "litellm"
+version = "1.88.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ea/f99ececb7f22703fe120f1d8be9ffb749ec9453fbbbbbebc0d6a6b4d7864/litellm-1.88.1.tar.gz", hash = "sha256:89c6b74cc7912d6365793006ff951c0450fe847625008dfe49de8a7dc4529aa5", size = 13885969, upload-time = "2026-06-09T01:06:25.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/9a/8f8909201b4bebaf96498c09226f6baa8540086a4c4188ad57d7dfbd97c1/litellm-1.88.1-py3-none-any.whl", hash = "sha256:369b84e57d9426582ddc35e731956ddb6618cda97cc44e4e4d2dfa75982a6e3a", size = 15276206, upload-time = "2026-06-09T01:06:16.72Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -997,20 +1076,17 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.2.2b1"
+version = "2.2.2b2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "boto3" },
-    { name = "cohere" },
     { name = "cryptography" },
-    { name = "google-genai" },
     { name = "httpx" },
     { name = "idna" },
     { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
-    { name = "n24q02m-mcp-core" },
-    { name = "openai" },
+    { name = "n24q02m-mcp-core", extra = ["llm"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments" },
@@ -1040,15 +1116,12 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.43.25" },
-    { name = "cohere", specifier = ">=7.0.3" },
     { name = "cryptography", specifier = ">=48.0.0" },
-    { name = "google-genai", specifier = ">=2.8.0" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", specifier = ">=1.17.3,<2" },
-    { name = "openai", specifier = ">=2.41.0" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b1,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1117,14 +1190,60 @@ wheels = [
 ]
 
 [[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/22/929c141d6c0dba87d3e1d38fbdf1ba8baba86b7776469f2bc2d3227a1e67/multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23", size = 76174, upload-time = "2026-01-26T02:44:18.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/75/bc704ae15fee974f8fccd871305e254754167dce5f9e42d88a2def741a1d/multidict-6.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84e61e3af5463c19b67ced91f6c634effb89ef8bfc5ca0267f954451ed4bb6a2", size = 45116, upload-time = "2026-01-26T02:44:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445", size = 43524, upload-time = "2026-01-26T02:44:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3c/414842ef8d5a1628d68edee29ba0e5bcf235dbfb3ccd3ea303a7fe8c72ff/multidict-6.7.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:432feb25a1cb67fe82a9680b4d65fb542e4635cb3166cd9c01560651ad60f177", size = 249368, upload-time = "2026-01-26T02:44:22.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/32/befed7f74c458b4a525e60519fe8d87eef72bb1e99924fa2b0f9d97a221e/multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23", size = 256952, upload-time = "2026-01-26T02:44:24.306Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/c878a44ba877f366630c860fdf74bfb203c33778f12b6ac274936853c451/multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060", size = 240317, upload-time = "2026-01-26T02:44:25.772Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/57421b4d7ad2e9e60e25922b08ceb37e077b90444bde6ead629095327a6f/multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d", size = 267132, upload-time = "2026-01-26T02:44:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/fe/ec0edd52ddbcea2a2e89e174f0206444a61440b40f39704e64dc807a70bd/multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed", size = 268140, upload-time = "2026-01-26T02:44:29.588Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429", size = 254277, upload-time = "2026-01-26T02:44:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b2/5fb8c124d7561a4974c342bc8c778b471ebbeb3cc17df696f034a7e9afe7/multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6", size = 252291, upload-time = "2026-01-26T02:44:32.31Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/51d4e4e06bcce92577fcd488e22600bd38e4fd59c20cb49434d054903bd2/multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9", size = 250156, upload-time = "2026-01-26T02:44:33.734Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6b/420e173eec5fba721a50e2a9f89eda89d9c98fded1124f8d5c675f7a0c0f/multidict-6.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:90efbcf47dbe33dcf643a1e400d67d59abeac5db07dc3f27d6bdeae497a2198c", size = 249742, upload-time = "2026-01-26T02:44:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a3/ec5b5bd98f306bc2aa297b8c6f11a46714a56b1e6ef5ebda50a4f5d7c5fb/multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84", size = 262221, upload-time = "2026-01-26T02:44:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/e8c0d0da0cd1e28d10e624604e1a36bcc3353aaebdfdc3a43c72bc683a12/multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d", size = 258664, upload-time = "2026-01-26T02:44:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/52/da/151a44e8016dd33feed44f730bd856a66257c1ee7aed4f44b649fb7edeb3/multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33", size = 249490, upload-time = "2026-01-26T02:44:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/87/af/a3b86bf9630b732897f6fc3f4c4714b90aa4361983ccbdcd6c0339b21b0c/multidict-6.7.1-cp313-cp313-win32.whl", hash = "sha256:e1c5988359516095535c4301af38d8a8838534158f649c05dd1050222321bcb3", size = 41695, upload-time = "2026-01-26T02:44:41.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/e994121b0e90e46134673422dd564623f93304614f5d11886b1b3e06f503/multidict-6.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:960c83bf01a95b12b08fd54324a4eb1d5b52c88932b5cba5d6e712bb3ed12eb5", size = 45884, upload-time = "2026-01-26T02:44:42.488Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/61/42d3e5dbf661242a69c97ea363f2d7b46c567da8eadef8890022be6e2ab0/multidict-6.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:563fe25c678aaba333d5399408f5ec3c383ca5b663e7f774dd179a520b8144df", size = 43122, upload-time = "2026-01-26T02:44:43.664Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b3/e6b21c6c4f314bb956016b0b3ef2162590a529b84cb831c257519e7fde44/multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1", size = 83175, upload-time = "2026-01-26T02:44:44.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/23ecd2abfe0957b234f6c960f4ade497f55f2c16aeb684d4ecdbf1c95791/multidict-6.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:57b46b24b5d5ebcc978da4ec23a819a9402b4228b8a90d9c656422b4bdd8a963", size = 48460, upload-time = "2026-01-26T02:44:46.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/a0ed92b23f3a042c36bc4227b72b97eca803f5f1801c1ab77c8a212d455e/multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34", size = 46930, upload-time = "2026-01-26T02:44:47.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/02ec7ace29162e447f6382c495dc95826bf931d3818799bbef11e8f7df1a/multidict-6.7.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3bd231490fa7217cc832528e1cd8752a96f0125ddd2b5749390f7c3ec8721b65", size = 242582, upload-time = "2026-01-26T02:44:48.604Z" },
+    { url = "https://files.pythonhosted.org/packages/58/18/64f5a795e7677670e872673aca234162514696274597b3708b2c0d276cce/multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292", size = 250031, upload-time = "2026-01-26T02:44:50.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/e192291dbbe51a8290c5686f482084d31bcd9d09af24f63358c3d42fd284/multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43", size = 228596, upload-time = "2026-01-26T02:44:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/3562a15a60cf747397e7f2180b0a11dc0c38d9175a650e75fa1b4d325e15/multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca", size = 257492, upload-time = "2026-01-26T02:44:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/24/02/7d0f9eae92b5249bb50ac1595b295f10e263dd0078ebb55115c31e0eaccd/multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd", size = 255899, upload-time = "2026-01-26T02:44:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/9b60ed9e23e64c73a5cde95269ef1330678e9c6e34dd4eb6b431b85b5a10/multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7", size = 247970, upload-time = "2026-01-26T02:44:56.783Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/06/538e58a63ed5cfb0bd4517e346b91da32fde409d839720f664e9a4ae4f9d/multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3", size = 245060, upload-time = "2026-01-26T02:44:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2f/d743a3045a97c895d401e9bd29aaa09b94f5cbdf1bd561609e5a6c431c70/multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4", size = 235888, upload-time = "2026-01-26T02:44:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/38/83/5a325cac191ab28b63c52f14f1131f3b0a55ba3b9aa65a6d0bf2a9b921a0/multidict-6.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:eb304767bca2bb92fb9c5bd33cedc95baee5bb5f6c88e63706533a1c06ad08c8", size = 243554, upload-time = "2026-01-26T02:45:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/9d2327086bd15da2725ef6aae624208e2ef828ed99892b17f60c344e57ed/multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c", size = 252341, upload-time = "2026-01-26T02:45:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2c/2a1aa0280cf579d0f6eed8ee5211c4f1730bd7e06c636ba2ee6aafda302e/multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52", size = 246391, upload-time = "2026-01-26T02:45:03.862Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/03/7ca022ffc36c5a3f6e03b179a5ceb829be9da5783e6fe395f347c0794680/multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108", size = 243422, upload-time = "2026-01-26T02:45:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1d/b31650eab6c5778aceed46ba735bd97f7c7d2f54b319fa916c0f96e7805b/multidict-6.7.1-cp313-cp313t-win32.whl", hash = "sha256:df9f19c28adcb40b6aae30bbaa1478c389efd50c28d541d76760199fc1037c32", size = 47770, upload-time = "2026-01-26T02:45:06.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
 name = "n24q02m-mcp-core"
-version = "1.17.3"
+version = "1.18.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
     { name = "fastmcp" },
     { name = "filelock" },
+    { name = "httpcore" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "platformdirs" },
@@ -1132,9 +1251,14 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/17/f474bb0609c058a4560ca5044ff0b05e01393856a6629dc82533c6746051/n24q02m_mcp_core-1.17.3.tar.gz", hash = "sha256:f2615d430d1bf32fd8cd62061b9b1d502edf965e1859f67b4af3a4ffb3bc0741", size = 206260, upload-time = "2026-06-07T11:03:51.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/aa/e8eb296141165057abb74f2e62f392c341b14e3259cb1677547b3a6760f1/n24q02m_mcp_core-1.18.0b1.tar.gz", hash = "sha256:832b29c70cae6a610a83c3a5c06bcb7220e6eaf43ea5dfa91ef47adc75ac332e", size = 252457, upload-time = "2026-06-10T13:31:50.457Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/b1/c741492101d1c7c9293b2acdf0926d822d9d414cb02051a43174cb38ddf0/n24q02m_mcp_core-1.17.3-py3-none-any.whl", hash = "sha256:bde01fd9e640f3a25d844d3b7aada05854ac11d1727c0fd1c088ab55881cc6a3", size = 128349, upload-time = "2026-06-07T11:03:52.635Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/ce4c37b7c120eb6e0aee229665841bfcb2482bc650d49168c74a22253a77/n24q02m_mcp_core-1.18.0b1-py3-none-any.whl", hash = "sha256:6d4f84e4369aab5aa5d1213a1c7b34d5c61672eaa3834ee92bc9b4414626eb79", size = 135751, upload-time = "2026-06-10T13:31:49.33Z" },
+]
+
+[package.optional-dependencies]
+llm = [
+    { name = "litellm" },
 ]
 
 [[package]]
@@ -1293,6 +1417,49 @@ wheels = [
 ]
 
 [[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/09/f049e45385503fe67db75a6b6186a7b9f0c3930366dc960522c312a825b1/propcache-0.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:099aaf4b4d1a02265b92a977edf00b5c4f63b3b17ac6de39b0d637c9cac0188a", size = 94457, upload-time = "2026-05-08T21:00:36.355Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/83d1d05655baf63113731bd5a1008435e14f8d1e5a06cbe4ec5b23ad7a31/propcache-0.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68ce1c44c7a813a7f71ea04315a8c7b330b63db99d059a797a4651bb6f69f117", size = 53835, upload-time = "2026-05-08T21:00:38.072Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/12/a6ba6482bb5ea3260c000c9b20881c95fa11c6b30173715668259f844ed7/propcache-0.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fc299c129490f55f254cd90be0deca4764e36e9a7c08b4aa588479a3bbed3098", size = 54545, upload-time = "2026-05-08T21:00:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/19/7fa086f5764c59ec8a8e157cd93aa8497acc00aba9dcdec56bfffb32602d/propcache-0.5.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6ae2198be502c10f09b2516e7b5d019816924bc3183a43ce792a7bd6625e6f4", size = 59886, upload-time = "2026-05-08T21:00:40.621Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e4/5d7663dc8235956c8f5281698a3af1d351d8820341ddd890f59d9a9127f2/propcache-0.5.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6041d31504dc1779d700e1edcfb08eea334b357620b06681a4eabb57a74e574e", size = 63261, upload-time = "2026-05-08T21:00:41.775Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/15a03adee24d6350da4292caeac44c34c033d2afe5e87eb370f38854560f/propcache-0.5.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7eabc04151c78a9f4d5bbb5f1faf571e4defeb4b585e0fe95b60ff2dbe4d3d7", size = 64184, upload-time = "2026-05-08T21:00:43.018Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4db0ba63d693afd40d249bd93f842b5f144f8fcbb83de05660373bcf30517b1d", size = 61534, upload-time = "2026-05-08T21:00:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/22/63e8cd1bae4c2d2be6493b6b7d10566ddafad88137cfbc99964a1119853c/propcache-0.5.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dbcf7675229b35d31abb6547d8ebc8c27a830ac3f9a794edff6254873ec7c0a", size = 61500, upload-time = "2026-05-08T21:00:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5a/28e5d9acbac1cc9ccb67045e8c1b943aa8d79fdf39c93bd73cacd68008ea/propcache-0.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d310c013aad2c72f1c3f2f8dd3279d460a858c551f97aeb8c63e4693cca7b4d2", size = 59994, upload-time = "2026-05-08T21:00:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/db650677f554a95b9c01a7c9d93d629e93a15562f5deb4573c9ee136fed2/propcache-0.5.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:06187263ddad280d05b4d8a8b3bb7d164cbebd469236544a42e6d9b28ac6a4fa", size = 56884, upload-time = "2026-05-08T21:00:48.376Z" },
+    { url = "https://files.pythonhosted.org/packages/80/45/70b39b89516ff8b96bf732fa6fded8cef20f293cb1508690101c3c07ec51/propcache-0.5.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3115559b8effafd63b142ea5ed53d63a16ea6469cbc63dce4ee194b42db5d853", size = 63464, upload-time = "2026-05-08T21:00:49.954Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e2/fa59d3a89eac5534293124af4f1d0d0ada091ce4a0ab4610ce03fd2bdd8d/propcache-0.5.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c60462af8e6dc30c35407c7237ea908d777b22862bbee27bc4699c0d8bcdc45a", size = 61588, upload-time = "2026-05-08T21:00:51.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/97/efb547a55c4bc7381cfb202d6a2239ac621045277bc1ea5dfd3a7f0516c0/propcache-0.5.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40314bca9ac559716fe374094fc81c11dcc34b64fd6c585360f5775690505704", size = 64667, upload-time = "2026-05-08T21:00:52.602Z" },
+    { url = "https://files.pythonhosted.org/packages/92/56/f5c7d9b4b7595d5127da38974d791b2153f3d1eae6c674af3583ace92ad3/propcache-0.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cfa21e036ce1e1db2be04ba3b85d2df1bb1702fa01932d984c5464c665228ff4", size = 62463, upload-time = "2026-05-08T21:00:54.303Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/484a3a65fc9f9f60c41dcd17b428bace5389544e2c680994534a20755066/propcache-0.5.2-cp313-cp313-win32.whl", hash = "sha256:f156a3529f38063b6dbaf356e15602a7f95f8055b1295a438433a6386f10463d", size = 38621, upload-time = "2026-05-08T21:00:55.808Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fd/3f0f10dba4dabad3bf53102be007abf55481067952bde0fdddff439e7c61/propcache-0.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:dfed59d0a5aeb01e242e66ff0300bc4a265a7c05f612d30016f0b60b1017d757", size = 41649, upload-time = "2026-05-08T21:00:57.061Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ec/6ce619cc32bb500a482f811f9cd509368b4e58e638d13f2c68f370d6b475/propcache-0.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:ba338430e87ceb9c8f0cf754de38a9860560261e56c00376debd628698a7364f", size = 37636, upload-time = "2026-05-08T21:00:58.646Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/c1d268bbbf2ef981c5bf0fbbe746db617c66e3bcefe431a1aa8943fbe23a/propcache-0.5.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a592f5f3da71c8691c788c13cb6734b6d17663d2e1cb8caddf0673d01ef8847d", size = 98872, upload-time = "2026-05-08T21:00:59.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d4/52c871e73e864e6b34c0e2d58ac1ec5ccd149497ddc7ad2137ae98323a35/propcache-0.5.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6a997d0489e9668a384fcfd5061b857aa5361de73191cac204d04b889cfbbafa", size = 56257, upload-time = "2026-05-08T21:01:01.195Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f0/9b90ca2a210b3d09bcfcd96ecd0f55545c091535abce2a45de2775cfd357/propcache-0.5.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:10734b5484ea113152ee25a91dccedf81631791805d2c9ccb054958e51842c94", size = 56696, upload-time = "2026-05-08T21:01:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0e/6e9d4ba07c8e56e21ddec1e75f12148142b21ca83a51871babce095334f4/propcache-0.5.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cafca7e56c12bb02ae16d283742bef25a61122e9dab2b5b3f2ccbe589ce32164", size = 62378, upload-time = "2026-05-08T21:01:04.475Z" },
+    { url = "https://files.pythonhosted.org/packages/65/19/c10badaa463dde8a27ce884f8ee2ec37e6035b7c9f5ff0c8f74f06f08dac/propcache-0.5.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f064f8d2b59177878b7615df1735cd8fe3462ed6be8c7b217d17a276489c2b7f", size = 65283, upload-time = "2026-05-08T21:01:05.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b6/93bea99ca80e19cef6512a8580e5b7857bbe09422d9daa7fd4ef5723306c/propcache-0.5.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f78abfa8dfc32376fd1aacf597b2f2fbbe0ea751419aee718af5d4f82537ef8c", size = 66616, upload-time = "2026-05-08T21:01:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/5c7462e50625f051f37fb38b8224f7639f667184bbd34424ec83819bb1b7/propcache-0.5.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7467da8a9822bf1a55336f877340c5bcbd3c482afc43a99771169f74a26dedc", size = 63773, upload-time = "2026-05-08T21:01:08.514Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/99238894047b13c823be25027e736626cd414a52a5e30d2c3347c2733529/propcache-0.5.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a6ddc6ac9e25de626c1f129c1b467d7ecd33ce2237d3fd0c4e429feef0a7ee1f", size = 63664, upload-time = "2026-05-08T21:01:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1e/a3a1a63116a2b8edb415a8bb9a6f0c34bd03830b1e18e8ce2904e1dc1cf4/propcache-0.5.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f22cbbac9e26a8e864c0985ff1268d5d939d53d9d9411a9824279097e03a2cb", size = 62643, upload-time = "2026-05-08T21:01:11.132Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/03/893cf147de2fc6543c5eaa07ad833170e7e2a2385725bbebe8c0503723bb/propcache-0.5.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:fc76378c62a0f04d0cd82fbb1a2cd2d7e28fcb40d5873f28a6c44e388aaa2751", size = 59595, upload-time = "2026-05-08T21:01:12.387Z" },
+    { url = "https://files.pythonhosted.org/packages/86/3b/04c1a2e12c57766568ba75ba72b3bf2042818d4c1425fab6fc07155c7cff/propcache-0.5.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:acd2c8edba48e31e58a363b8cf4e5c7db3b04b3f9e371f601df30d9b0d244836", size = 65711, upload-time = "2026-05-08T21:01:13.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/34/80f8d0099f8d6bacc4de1624c85672681c8cd1149ca2da0e38fd120b817f/propcache-0.5.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:452b5065457eb9991ec5eb38ff41d6cd4c991c9ac7c531c4d5849ae473a9a13f", size = 64247, upload-time = "2026-05-08T21:01:14.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1a/8b08f3a5f1037e9e370c55883ceeeee0f6dd0416fb2d2d67b8bfc91f2a79/propcache-0.5.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3430bb2bfe1331885c427745a751e774ee679fd4344f80b97bf879815fe8fa55", size = 67102, upload-time = "2026-05-08T21:01:16.281Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/8bdb7bb7756d76e005490649d10e4a8369e610c74d619f71e1aedf889e9c/propcache-0.5.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cef6cea3922890dd6c9654971001fa797b526c16ab5e1e46c05fd6f877be7568", size = 64964, upload-time = "2026-05-08T21:01:17.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/aa/50fb0b5d3968b61a510926ff8b8465f1d6e976b3ab74496d7a4b9fc42515/propcache-0.5.2-cp313-cp313t-win32.whl", hash = "sha256:72d61e16dd78228b58c5d47be830ff3da7e5f139abdf0aef9d86cde1c5cf2191", size = 42546, upload-time = "2026-05-08T21:01:18.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4c/0ddbae64321bd4a95bcbfc19307238016b5b1fee645c84626c8d539e5b74/propcache-0.5.2-cp313-cp313t-win_amd64.whl", hash = "sha256:0958834041a0166d343b8d2cedcd8bcbaeb4fdbe0cf08320c5379f143c3be6e7", size = 46330, upload-time = "2026-05-08T21:01:20.162Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d9/9cddc8efb78d8af264c5ec9f6d10b62f57c515feda8d321595f56010fb23/propcache-0.5.2-cp313-cp313t-win_arm64.whl", hash = "sha256:6de8bd93ddde9b992cf2b2e0d796d501a19026b5b9fd87356d7d0779531a8d96", size = 40521, upload-time = "2026-05-08T21:01:21.399Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1339,27 +1506,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
-]
-
-[[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1946,15 +2092,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
-]
-
-[[package]]
 name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2065,18 +2202,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260408"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]
@@ -2226,6 +2351,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/62/fcf0ce677f17e5c471c06311dd25964be38a4c586993632910d2e75278bc/yarl-1.24.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:491ac9141decf49ee8030199e1ee251cdff0e131f25678817ff6aa5f837a3536", size = 128978, upload-time = "2026-05-19T21:29:23.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/8e63299bb71ed61a834121d9d3fe6c9fcf2a6a5d09754ff4f20f2d20baf5/yarl-1.24.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e89418f65eda18f99030386305bd44d7d504e328a7945db1ead514fbe03a0607", size = 91733, upload-time = "2026-05-19T21:29:25.375Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/24/16748d5dab6daec8b0ed81ccec639a1cded0f18dcc62a4f696b4fe366c37/yarl-1.24.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cdfcce633b4a4bb8281913c57fcafd4b5933fbc19111a5e3930bbd299d6102f1", size = 91113, upload-time = "2026-05-19T21:29:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/b63fff7b71211e866624b21432d5943cbb633eb0c2872d9ee3070648f22c/yarl-1.24.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:863297ddede92ee49024e9a9b11ecb59f310ca85b60d8537f56bed9bbb5b1986", size = 103899, upload-time = "2026-05-19T21:29:28.842Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/ba1974b8533909636f7733fe86cf677e3619527c3c2fa913e0ea89c48757/yarl-1.24.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:374423f70754a2c96942ede36a29d37dc6b0cb8f92f8d009ddf3ed78d3da5488", size = 97862, upload-time = "2026-05-19T21:29:31.086Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/123ac993b5c2ba6f554a140305620cb8f150fa543711bbc49be3ec0a65a4/yarl-1.24.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33a29b5d00ccbf3219bb3e351d7875739c19481e030779f48cc46a7a71681a9b", size = 111060, upload-time = "2026-05-19T21:29:32.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/37/c472d3af3509688392134a88a825276770a187f1daa4de3f6dc0a327a751/yarl-1.24.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a9532c57211730c515341af11fef6e9b61d157487272a096d0c04da445642592", size = 110613, upload-time = "2026-05-19T21:29:34.379Z" },
+    { url = "https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91e72cf093fd833483a97ee648e0c053c7c629f51ff4a0e7edd84f806b0c5617", size = 107012, upload-time = "2026-05-19T21:29:36.216Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ab/9d4f69d571a94f4d112fa7e2e007200f5a54d319f58c82ac7b7baa61f5c6/yarl-1.24.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b3177bc0a768ef3bacceb4f272632990b7bea352f1b2f1eee9d6d6ff16516f92", size = 105887, upload-time = "2026-05-19T21:29:38.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9a/000b2b66c0d772a499fc531d21dab92dfeb73b640a12eed6ba89f49bb2d0/yarl-1.24.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e196952aacaf3b232e265ff02980b64d483dc0972bd49bcb061171ff22ac203a", size = 103620, upload-time = "2026-05-19T21:29:40.368Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7c/7c1050f73450fbdaa3f0c72017059f00ce5e13366692f3dba25275a1083d/yarl-1.24.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:204e7a61ce99919c0de1bf904ab5d7aa188a129ea8f690a8f76cfb6e2844dc44", size = 100599, upload-time = "2026-05-19T21:29:42.66Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b1/29e5756b3926705f5f6089bd5b9f50a56eaac550da6e260bf713ead44d04/yarl-1.24.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b156914620f0b9d78dc1adb3751141daee561cfec796088abb89ed49d220f1a", size = 110604, upload-time = "2026-05-19T21:29:44.632Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4b/8415bc96e9b150cde942fbac9a8182985e58f40ce5c54c34ed015407d3ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8372a2b976cf70654b2be6619ab6068acabb35f724c0fda7b277fbf53d66a5cf", size = 105161, upload-time = "2026-05-19T21:29:46.755Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d4/cde059abfa229553b7298a2eadde2752e723d50aeedaef86ce59da2718ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f9a1e9b622ca284143aab5d885848686dcd85453bb1ca9abcdb7503e64dc0056", size = 110619, upload-time = "2026-05-19T21:29:48.972Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/d6a6c9a61549f7b6c7e6dc6937d195bcf069582b47b7200dcd0e7b256acf/yarl-1.24.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:810e19b685c8c3c5862f6a38160a1f4e4c0916c9390024ec347b6157a45a0992", size = 107362, upload-time = "2026-05-19T21:29:51Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dd/3ae5fe417e9d1c353a548553326eb9935e76b6b727161563b424cc296df3/yarl-1.24.2-cp313-cp313-win_amd64.whl", hash = "sha256:7d37fb7c38f2b6edab0f845c4f85148d4c44204f52bc127021bd2bc9fdbf1656", size = 92667, upload-time = "2026-05-19T21:29:52.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cc/a7beb239f78f27fca1b053c8e8595e4179c02e62249b4687ec218c370c50/yarl-1.24.2-cp313-cp313-win_arm64.whl", hash = "sha256:1e831894be7c2954240e49791fa4b50c05a0dc881de2552cfe3ffd8631c7f461", size = 87069, upload-time = "2026-05-19T21:29:54.442Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Tóm tắt

Migrate mnemo-mcp LLM/embedding/rerank dispatch sang `mcp_core.llm` (litellm library-mode passthrough, `n24q02m-mcp-core[llm]`). Gỡ native SDK (google-genai/openai/cohere/anthropic) — mọi call qua litellm passthrough với open provider/model.

## Thay đổi

- `llm.py` / `embedder.py` / `reranker.py` / `graph.py` — delegate sang `mcp_core.llm.{acompletion,aembedding,arerank}` (lazy import), CANONICAL None-safe response-shape parse (litellm trả pydantic HOẶC dict).
- `graph._has_llm_provider` thêm `ANTHROPIC_API_KEY` (Anthropic = LLM-only, chat qua litellm passthrough; KHÔNG thêm vào config.py vì sẽ flip embedding mode→cloud→fail do Anthropic không có embedding API).
- `graph._resolve_llm_model` normalise `=`-form (`gemini=model` → `gemini/model`).
- pyproject: `n24q02m-mcp-core[llm]` extra; gỡ native SDK deps.

## Test

- `uv run pytest` — 1285 passed / 0 fail (local).
- 2-stage review (subagent-driven): spec ✅ + quality ✅ (Anthropic gate logic + =-form normalisation verified, no regression).

## Behavior change

- LLM/embed/rerank backend từ native SDK → litellm passthrough. Response parse robust cho cả pydantic & dict shape. 768-dim storage giữ nguyên.

Part of litellm passthrough redesign (mcp-core[llm] extra). Companion: wet-mcp #1315 (merged), crg, imagine.