### PR TITLE
🎨 Palette: Improve DX by structuring suggestions in API error responses

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import os
 import sys
+import typing
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from importlib import resources as pkg_resources
@@ -1510,14 +1511,14 @@ async def memory(
                 "update",
             ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
-            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                    "hint": "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID.",
-                }
-            )
+            resp: dict[str, typing.Any] = {
+                "error": f"Unknown action '{action}'.",
+                "valid_actions": valid_actions,
+                "hint": "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID.",
+            }
+            if closest:
+                resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            return _json(resp)
 
 
 @mcp.tool(
@@ -1605,14 +1606,14 @@ async def config(
                 "warmup",
             ]
             closest = difflib.get_close_matches(action, valid_actions, n=1)
-            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-            return _json(
-                {
-                    "error": f"Unknown action '{action}'.{suggestion}",
-                    "valid_actions": valid_actions,
-                    "hint": "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync.",
-                }
-            )
+            resp: dict[str, typing.Any] = {
+                "error": f"Unknown action '{action}'.",
+                "valid_actions": valid_actions,
+                "hint": "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync.",
+            }
+            if closest:
+                resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            return _json(resp)
 
 
 async def _handle_config_status(ctx: Context | None) -> str:
@@ -2103,13 +2104,13 @@ async def help(topic: str = "memory") -> str:
         import difflib
 
         closest = difflib.get_close_matches(topic, list(valid_topics.keys()), n=1)
-        suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-        return _json(
-            {
-                "error": f"Unknown topic '{topic}'.{suggestion}",
-                "valid_topics": list(valid_topics.keys()),
-            }
-        )
+        resp: dict[str, typing.Any] = {
+            "error": f"Unknown topic '{topic}'.",
+            "valid_topics": list(valid_topics.keys()),
+        }
+        if closest:
+            resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+        return _json(resp)
 
     doc_file = docs_package / filename
     content = await asyncio.to_thread(doc_file.read_text, encoding="utf-8")

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -205,7 +205,8 @@ class TestConfigActions:
         assert "error" in result
         assert "Unknown action" in result["error"]
         assert "valid_actions" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Did you mean 'sync'?" in result["suggestion"]
 
     async def test_config_unknown_action_no_match(self, ctx_with_db):
         """Config with completely invalid action returns error without suggestion."""
@@ -228,7 +229,8 @@ class TestHelpTool:
         assert "error" in result
         assert "Unknown topic" in result["error"]
         assert "valid_topics" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Did you mean 'memory'?" in result["suggestion"]
 
     async def test_help_no_match(self):
         """Completely invalid topic returns error without suggestion."""

--- a/uv.lock
+++ b/uv.lock
@@ -997,7 +997,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.2.2b1"
+version = "2.2.2b2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This pull request refactors the error responses in `src/mnemo_mcp/server.py` to extract dynamically generated "Did you mean X?" suggestions from generic error strings into a dedicated, top-level JSON key (`suggestion`).

**Why this change was made:**
Previously, these hints were appended to the `error` string. While visually useful for a human reading plain text, it complicates parsing for clients consuming the API programmatically. By structuring this fallback suggestion as a discrete JSON property, clients can consistently identify actionable advice and render it appropriately within the UI or act upon it.

**Changes:**
- Updated the fallback blocks utilizing `difflib.get_close_matches` within `src/mnemo_mcp/server.py` (specifically for `action` parameter parsing in `memory` and `config` tools, and `topic` in the `help` tool).
- Added `suggestion` to the structured error dictionaries conditionally only if a close match is available.
- Updated `test_server_lifespan.py` to assert the presence and correct formatting of the new `suggestion` key in error responses.

---
*PR created automatically by Jules for task [789391294568761846](https://jules.google.com/task/789391294568761846) started by @n24q02m*