### PR TITLE
feat: model-chain selection (mnemo) — Phase 1 sample server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.11.0",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.0b1,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -42,21 +42,6 @@ def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
     return onnx_name
 
 
-_EMBEDDING_PROVIDERS: dict[str, str] = {
-    "JINA_AI_API_KEY": "jina_ai/jina-embeddings-v5-text-small",
-    "GEMINI_API_KEY": "gemini/gemini-embedding-001",
-    "GOOGLE_API_KEY": "gemini/gemini-embedding-001",
-    "OPENAI_API_KEY": "text-embedding-3-large",
-    "COHERE_API_KEY": "embed-multilingual-v3.0",
-}
-
-_RERANK_PROVIDERS: dict[str, str] = {
-    "JINA_AI_API_KEY": "jina_ai/jina-reranker-v3",
-    "COHERE_API_KEY": "rerank-v4.0-pro",
-    "CO_API_KEY": "rerank-v4.0-pro",
-}
-
-
 class Settings(BaseSettings):
     """Mnemo MCP Server configuration.
 
@@ -86,7 +71,15 @@ class Settings(BaseSettings):
     # Provider API Keys: "ENV_VAR:key,ENV_VAR:key,..."
     api_keys: str | None = None
 
-    # Embedding model (auto-detected from API_KEYS if not set)
+    # Per-task model chains "provider/model,provider/model" (order = litellm
+    # fallback). Empty -> local ONNX. Replaces the priority-router auto-detect
+    # and the singular EMBEDDING_MODEL/EMBEDDING_BACKEND (deprecated shims).
+    embedding_models: str = ""
+    rerank_models: str = ""
+
+    # DEPRECATED (2026-06-11, removed next release): singular model + backend
+    # env vars. Folded into the plural *_MODELS chain (with a deprecation
+    # warning); backend is now inferred from the chain (non-empty -> cloud).
     embedding_model: str = ""
     embedding_dims: int = 0  # 0 = use server default (768)
     embedding_backend: str = (
@@ -95,6 +88,7 @@ class Settings(BaseSettings):
 
     # Reranking
     rerank_enabled: bool = True
+    # DEPRECATED (2026-06-11, removed next release): see embedding_* above.
     rerank_backend: str = ""  # "cloud" | "local" | "" (auto)
     rerank_model: str = ""
     rerank_top_n: int = 10
@@ -258,11 +252,53 @@ class Settings(BaseSettings):
 
         return mode
 
-    def resolve_embedding_model(self) -> str | None:
-        """Return explicit EMBEDDING_MODEL or None for auto-detect."""
-        if self.embedding_model:
-            return self.embedding_model
-        return None
+    _DEFAULT_EMBEDDING_CHAIN = (
+        "jina_ai/jina-embeddings-v5-text-small",
+        "gemini/gemini-embedding-001",
+        "text-embedding-3-large",
+        "embed-multilingual-v3.0",
+    )
+    _DEFAULT_RERANK_CHAIN = (
+        "jina_ai/jina-reranker-v3",
+        "cohere/rerank-v3.5",
+    )
+
+    def _chain(self, primary: str, legacy: str, default: tuple[str, ...]) -> list[str]:
+        if primary:
+            return [m.strip() for m in primary.split(",") if m.strip()]
+        if legacy:
+            logger.warning(
+                "Deprecated singular model env honored; migrate to the plural "
+                "<TASK>_MODELS chain (removed next release): {!r}",
+                legacy,
+            )
+            return [legacy.strip()]
+        if self.resolve_provider_mode() == "sdk":
+            return list(default)
+        return []
+
+    def embedding_chain(self) -> list[str]:
+        return self._chain(
+            self.embedding_models, self.embedding_model, self._DEFAULT_EMBEDDING_CHAIN
+        )
+
+    def rerank_chain(self) -> list[str]:
+        if not self.rerank_enabled:
+            return []
+        return self._chain(
+            self.rerank_models, self.rerank_model, self._DEFAULT_RERANK_CHAIN
+        )
+
+    def embedding_primary(self) -> str | None:
+        chain = self.embedding_chain()
+        return chain[0] if chain else None
+
+    def rerank_primary(self) -> str | None:
+        chain = self.rerank_chain()
+        return chain[0] if chain else None
+
+    def llm_chain(self) -> list[str]:
+        return [m.strip() for m in self.llm_models.split(",") if m.strip()]
 
     def resolve_embedding_dims(self) -> int:
         """Return explicit EMBEDDING_DIMS or 0 for auto-detect."""
@@ -278,66 +314,42 @@ class Settings(BaseSettings):
     def resolve_embedding_backend(self) -> str:
         """Resolve embedding backend: 'local' or 'cloud'.
 
-        Always returns a valid backend (never empty).
-
-        Auto-detect order:
-        1. Explicit EMBEDDING_BACKEND setting
-        2. 'cloud' if in sdk mode (API keys configured)
-        3. 'local' (qwen3-embed built-in, always available)
+        Always returns a valid backend (never empty). Backend is inferred
+        from EMBEDDING_MODELS (non-empty chain -> cloud, empty -> local);
+        the deprecated EMBEDDING_BACKEND env var is honored for one release.
         """
         if self.embedding_backend:
-            # Backward compat: 'litellm' maps to 'cloud'
-            if self.embedding_backend == "litellm":
-                return "cloud"
-            return self.embedding_backend
-        mode = self.resolve_provider_mode()
-        if mode == "sdk":
-            return "cloud"
-        return "local"
+            logger.warning(
+                "Deprecated EMBEDDING_BACKEND honored; backend is now "
+                "inferred from EMBEDDING_MODELS."
+            )
+            return (
+                "cloud"
+                if self.embedding_backend in ("cloud", "litellm")
+                else self.embedding_backend
+            )
+        return "cloud" if self.embedding_chain() else "local"
 
     def resolve_rerank_backend(self) -> str:
         """Resolve reranker backend: 'cloud', 'local', or '' (disabled).
 
-        Auto-detect order:
-        1. Disabled if rerank_enabled is False
-        2. Explicit rerank_backend setting
-        3. 'cloud' if rerank_model set
-        4. 'cloud' if a known rerank provider key is in env or API_KEYS
-        5. 'local' (qwen3-embed cross-encoder, always available)
+        Disabled when rerank_enabled is False. Otherwise inferred from
+        RERANK_MODELS (non-empty chain -> cloud, empty -> local); the
+        deprecated RERANK_BACKEND env var is honored for one release.
         """
         if not self.rerank_enabled:
             return ""
         if self.rerank_backend:
-            # Backward compat: 'litellm' maps to 'cloud'
-            if self.rerank_backend == "litellm":
-                return "cloud"
-            return self.rerank_backend
-        if self.rerank_model:
-            return "cloud"
-        for key in _RERANK_PROVIDERS:
-            if os.environ.get(key):
-                return "cloud"
-        if self.api_keys:
-            for key in _RERANK_PROVIDERS:
-                if key in self.api_keys:
-                    return "cloud"
-        return "local"
-
-    def resolve_rerank_model(self) -> str | None:
-        """Resolve reranker model name from config or env.
-
-        Returns None if no known provider key is found.
-        """
-        if self.rerank_model:
-            return self.rerank_model
-        for key, model in _RERANK_PROVIDERS.items():
-            if os.environ.get(key):
-                return model
-        if self.api_keys:
-            for key, model in _RERANK_PROVIDERS.items():
-                if key in self.api_keys:
-                    return model
-        return None
+            logger.warning(
+                "Deprecated RERANK_BACKEND honored; backend is now "
+                "inferred from RERANK_MODELS."
+            )
+            return (
+                "cloud"
+                if self.rerank_backend in ("cloud", "litellm")
+                else self.rerank_backend
+            )
+        return "cloud" if self.rerank_chain() else "local"
 
     def resolve_local_rerank_model(self) -> str:
         """Resolve local reranker model: GGUF if GPU + llama-cpp, else ONNX."""
@@ -346,14 +358,5 @@ class Settings(BaseSettings):
             "n24q02m/Qwen3-Reranker-0.6B-GGUF",
         )
 
-
-# Embedding models to try during auto-detection (in priority order).
-# Cloud backend validates each against its API key -- first success wins.
-_EMBEDDING_CANDIDATES = [
-    "jina_ai/jina-embeddings-v5-text-small",
-    "gemini/gemini-embedding-001",
-    "text-embedding-3-large",
-    "embed-multilingual-v3.0",
-]
 
 settings = Settings()

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from mcp_core.llm.providers import key_env_for_model
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 
@@ -252,11 +253,13 @@ class Settings(BaseSettings):
 
         return mode
 
+    # Explicit provider prefixes so key-availability filtering + litellm
+    # routing are unambiguous (cohere/openai bare names would mis-detect).
     _DEFAULT_EMBEDDING_CHAIN = (
         "jina_ai/jina-embeddings-v5-text-small",
         "gemini/gemini-embedding-001",
-        "text-embedding-3-large",
-        "embed-multilingual-v3.0",
+        "openai/text-embedding-3-large",
+        "cohere/embed-multilingual-v3.0",
     )
     _DEFAULT_RERANK_CHAIN = (
         "jina_ai/jina-reranker-v3",
@@ -273,9 +276,28 @@ class Settings(BaseSettings):
                 legacy,
             )
             return [legacy.strip()]
-        if self.resolve_provider_mode() == "sdk":
-            return list(default)
-        return []
+        # No explicit chain: fall back to the curated default, but ONLY the
+        # models whose provider key is actually configured. If none are (e.g.
+        # an OpenAI-only key with a Jina/Cohere rerank default), the chain is
+        # empty -> the task falls to local ONNX. This keeps "no usable key ->
+        # local-core still runs" (spec §5.4) without a priority-router.
+        return [m for m in default if self._key_available(key_env_for_model(m))]
+
+    def _key_available(self, env_var: str) -> bool:
+        """Whether a provider key is configured via env, bundled api_keys, or alias.
+
+        Mirrors the resolution that ``setup_api_keys`` performs at startup so
+        chain filtering is correct before the env export (and in tests that
+        pass ``api_keys=`` without calling setup).
+        """
+        bundled = self.api_keys or ""
+        if os.getenv(env_var) or env_var in bundled:
+            return True
+        # An alias (e.g. GOOGLE_API_KEY) satisfies its canonical key (GEMINI).
+        for alias, canonical in self._ENV_ALIASES.items():
+            if canonical == env_var and (os.getenv(alias) or alias in bundled):
+                return True
+        return False
 
     def embedding_chain(self) -> list[str]:
         return self._chain(

--- a/src/mnemo_mcp/relay_schema.py
+++ b/src/mnemo_mcp/relay_schema.py
@@ -20,96 +20,113 @@ from __future__ import annotations
 
 from typing import Any
 
+_EMBEDDING_SUGGESTED = [
+    "jina_ai/jina-embeddings-v5-text-small",
+    "gemini/gemini-embedding-001",
+    "openai/text-embedding-3-large",
+    "cohere/embed-multilingual-v3.0",
+]
+_RERANK_SUGGESTED = ["jina_ai/jina-reranker-v3", "cohere/rerank-v3.5"]
+_LLM_SUGGESTED = [
+    "gemini/gemini-3-flash-preview",
+    "openai/gpt-5.4-mini-2026-03-17",
+    "anthropic/claude-haiku-4-5",
+    "xai/grok-4-fast",
+]
+
+
+def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "type": "password",
+        "placeholder": ph,
+        "helpUrl": url,
+        "derived": True,
+        "required": False,
+    }
+
+
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "mnemo-mcp",
     "displayName": "Mnemo MCP",
     "description": (
-        "Enter API keys for cloud capabilities. Leave all empty for pure "
-        "local mode (ONNX models). Multi-machine passport sync is a "
-        "deployment-mode setting (operator env vars, not configured here)."
+        "Pick models per task (order = fallback). Leave a task empty for "
+        "local ONNX (embedding/rerank) — LLM features need at least one model. "
+        "Key fields appear automatically for the providers your models use."
     ),
     "fields": [
         {
-            "key": "JINA_AI_API_KEY",
-            "label": "Jina AI API Key",
-            "type": "password",
-            "placeholder": "jina_...",
-            "helpUrl": "https://jina.ai/api-key",
-            "helpText": "Embedding + Reranking (highest priority for both).",
-            "required": False,
+            "key": "EMBEDDING_MODELS",
+            "label": "Embedding models",
+            "type": "model-chain",
+            "task": "embedding",
+            "suggestedModels": _EMBEDDING_SUGGESTED,
+            "hasLocal": True,
+            "placeholder": "add embedding model…",
         },
         {
-            "key": "GEMINI_API_KEY",
-            "label": "Gemini API Key",
-            "type": "password",
-            "placeholder": "AIza...",
-            "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": "Embedding + LLM. Free tier available.",
-            "required": False,
+            "key": "RERANK_MODELS",
+            "label": "Rerank models",
+            "type": "model-chain",
+            "task": "rerank",
+            "suggestedModels": _RERANK_SUGGESTED,
+            "hasLocal": True,
+            "placeholder": "add rerank model…",
         },
         {
-            "key": "OPENAI_API_KEY",
-            "label": "OpenAI API Key",
-            "type": "password",
-            "placeholder": "sk-...",
-            "helpUrl": "https://platform.openai.com/api-keys",
-            "helpText": "Embedding + LLM (lower priority than Gemini).",
-            "required": False,
+            "key": "LLM_MODELS",
+            "label": "LLM models",
+            "type": "model-chain",
+            "task": "chat",
+            "suggestedModels": _LLM_SUGGESTED,
+            "hasLocal": False,
+            "placeholder": "add LLM model…",
         },
-        {
-            "key": "COHERE_API_KEY",
-            "label": "Cohere API Key",
-            "type": "password",
-            "placeholder": "co-...",
-            "helpUrl": "https://dashboard.cohere.com/api-keys",
-            "helpText": "Embedding + Reranking.",
-            "required": False,
-        },
-        {
-            "key": "ANTHROPIC_API_KEY",
-            "label": "Anthropic API Key",
-            "type": "password",
-            "placeholder": "sk-ant-...",
-            "helpUrl": "https://console.anthropic.com/settings/keys",
-            "helpText": "LLM (lower priority than OpenAI).",
-            "required": False,
-        },
-        {
-            "key": "XAI_API_KEY",
-            "label": "xAI API Key",
-            "type": "password",
-            "placeholder": "xai-...",
-            "helpUrl": "https://console.x.ai/",
-            "helpText": "LLM (lower priority than Anthropic).",
-            "required": False,
-        },
+        _key_field(
+            "JINA_AI_API_KEY", "Jina AI API Key", "jina_...", "https://jina.ai/api-key"
+        ),
+        _key_field(
+            "GEMINI_API_KEY",
+            "Gemini API Key",
+            "AIza...",
+            "https://aistudio.google.com/apikey",
+        ),
+        _key_field(
+            "OPENAI_API_KEY",
+            "OpenAI API Key",
+            "sk-...",
+            "https://platform.openai.com/api-keys",
+        ),
+        _key_field(
+            "COHERE_API_KEY",
+            "Cohere API Key",
+            "co-...",
+            "https://dashboard.cohere.com/api-keys",
+        ),
+        _key_field(
+            "ANTHROPIC_API_KEY",
+            "Anthropic API Key",
+            "sk-ant-...",
+            "https://console.anthropic.com/settings/keys",
+        ),
+        _key_field("XAI_API_KEY", "xAI API Key", "xai-...", "https://console.x.ai/"),
     ],
     "capabilityInfo": [
         {
             "label": "Embedding",
-            "priority": "Jina > Gemini > OpenAI > Cohere > Local ONNX",
-            "description": "Vector embeddings for semantic memory search. Local mode uses Qwen3-Embedding (0.6B ONNX).",
+            "priority": "configurable",
+            "description": "Vector embeddings for semantic memory. Empty = local Qwen3-Embedding ONNX.",
         },
         {
             "label": "Reranking",
-            "priority": "Jina > Cohere > Local ONNX",
-            "description": "Re-ranks search results for accuracy. Local mode uses Qwen3-Reranker (0.6B ONNX).",
+            "priority": "configurable",
+            "description": "Re-ranks search results. Empty = local Qwen3-Reranker ONNX.",
         },
         {
             "label": "LLM",
-            "priority": "Gemini > OpenAI > Anthropic > xAI",
-            "description": "Used for memory importance scoring and graph analysis. Without a key, basic heuristics are used.",
-        },
-        {
-            "label": "Passport Sync (operator-config)",
-            "priority": "S3 (env) XOR Google Drive (default)",
-            "description": (
-                "Mutually exclusive: deployment sets SYNC_S3_BUCKET + "
-                "SYNC_PASSPHRASE env at docker spawn → S3 mode with "
-                "encrypted bundles (AES-256-GCM + Argon2id). No S3 env "
-                "→ Google Drive Device Code OAuth via this relay. See "
-                "docs/passport.md for operator runbook."
-            ),
+            "priority": "configurable",
+            "description": "Memory importance scoring + graph analysis. Empty = basic heuristics.",
         },
     ],
 }

--- a/src/mnemo_mcp/relay_schema.py
+++ b/src/mnemo_mcp/relay_schema.py
@@ -128,5 +128,16 @@ RELAY_SCHEMA: dict[str, Any] = {
             "priority": "configurable",
             "description": "Memory importance scoring + graph analysis. Empty = basic heuristics.",
         },
+        {
+            "label": "Passport Sync (operator-config)",
+            "priority": "S3 (env) XOR Google Drive (default)",
+            "description": (
+                "Mutually exclusive: deployment sets SYNC_S3_BUCKET + "
+                "SYNC_PASSPHRASE env at docker spawn -> S3 mode with "
+                "encrypted bundles (AES-256-GCM + Argon2id). No S3 env "
+                "-> Google Drive Device Code OAuth via this relay. See "
+                "docs/passport.md for operator runbook."
+            ),
+        },
     ],
 }

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -21,7 +21,7 @@ from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
-from mnemo_mcp.config import _EMBEDDING_CANDIDATES, settings
+from mnemo_mcp.config import settings
 from mnemo_mcp.db import MemoryDB
 
 # Resolved via importlib.metadata (not ``from mnemo_mcp import __version__``)
@@ -58,7 +58,7 @@ async def _init_embedding_backend(
         logger.info("Embedding: skipped (credentials not configured, FTS5 mode)")
         return
 
-    embedding_model = settings.resolve_embedding_model()
+    embedding_chain = settings.embedding_chain()
     embedding_dims = settings.resolve_embedding_dims()
     embedding_backend_type = settings.resolve_embedding_backend()
 
@@ -83,44 +83,26 @@ async def _init_embedding_backend(
             logger.error(f"Local embedding init failed: {e}")
         return
 
-    # CONFIGURED + cloud backend -- no local fallback
-    if embedding_model:
-        # Explicit model -- validate it
+    # CONFIGURED + cloud backend -- no local fallback.
+    # Try each model in the chain (litellm fallback order) until one validates.
+    for candidate in embedding_chain:
         try:
-            backend = await asyncio.to_thread(init_backend, "cloud", embedding_model)
+            backend = await asyncio.to_thread(init_backend, "cloud", candidate)
             native_dims = await asyncio.to_thread(backend.check_available)
             if native_dims > 0:
                 if embedding_dims == 0:
                     embedding_dims = _DEFAULT_EMBEDDING_DIMS
                 logger.info(
-                    f"Embedding: {embedding_model} "
+                    f"Embedding: {candidate} "
                     f"(native={native_dims}, stored={embedding_dims})"
                 )
-                ctx["embedding_model"] = embedding_model
+                ctx["embedding_model"] = candidate
                 ctx["embedding_dims"] = embedding_dims
                 return
             else:
-                logger.warning(f"Embedding model {embedding_model} not available")
+                logger.warning(f"Embedding model {candidate} not available")
         except Exception as e:
-            logger.warning(f"Embedding model {embedding_model} not available: {e}")
-    elif mode == "sdk":
-        # Auto-detect: try candidate models
-        for candidate in _EMBEDDING_CANDIDATES:
-            try:
-                backend = await asyncio.to_thread(init_backend, "cloud", candidate)
-                native_dims = await asyncio.to_thread(backend.check_available)
-                if native_dims > 0:
-                    if embedding_dims == 0:
-                        embedding_dims = _DEFAULT_EMBEDDING_DIMS
-                    logger.info(
-                        f"Embedding: {candidate} "
-                        f"(native={native_dims}, stored={embedding_dims})"
-                    )
-                    ctx["embedding_model"] = candidate
-                    ctx["embedding_dims"] = embedding_dims
-                    return
-            except Exception:
-                continue
+            logger.warning(f"Embedding model {candidate} not available: {e}")
 
     logger.error("Cloud embedding not available and local fallback is disabled")
 
@@ -160,10 +142,10 @@ async def _init_reranker_backend(mode: str) -> None:
             logger.error(f"Local reranker init failed: {e}")
         return
 
-    # CONFIGURED + cloud backend -- no local fallback
+    # CONFIGURED + cloud backend -- no local fallback.
+    # Try each model in the chain (litellm fallback order) until one validates.
     if backend_type in ("cloud", "litellm"):
-        model = settings.resolve_rerank_model()
-        if model:
+        for model in settings.rerank_chain():
             try:
                 backend = await asyncio.to_thread(init_reranker, "cloud", model)
                 available = await asyncio.to_thread(backend.check_available)

--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from mnemo_mcp.config import _EMBEDDING_CANDIDATES, settings
+from mnemo_mcp.config import settings
 
 
 def clear_model_cache(model_name: str) -> str | None:
@@ -38,8 +38,7 @@ def _validate_cloud_models(settings_obj) -> dict:
     """Check if cloud embedding models are valid."""
     from mnemo_mcp.embedder import init_backend
 
-    model = settings_obj.resolve_embedding_model()
-    candidates = [model] if model else _EMBEDDING_CANDIDATES
+    candidates = settings_obj.embedding_chain()
 
     for candidate in candidates:
         try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,26 +187,33 @@ class TestApiKeys:
 
 
 class TestEmbeddingModel:
-    def test_explicit_model(self):
-        s = Settings(embedding_model="custom/model")
-        assert s.resolve_embedding_model() == "custom/model"
+    def test_explicit_models_chain(self):
+        s = Settings(embedding_models="custom/model")
+        assert s.embedding_primary() == "custom/model"
+        assert s.embedding_chain() == ["custom/model"]
 
-    def test_no_model_returns_none(self):
-        """Without explicit EMBEDDING_MODEL, returns None (auto-detect in server)."""
+    def test_sdk_mode_returns_default_chain(self):
+        """With API keys but no explicit chain, the default chain is used."""
         s = Settings(api_keys="GOOGLE_API_KEY:key")
-        assert s.resolve_embedding_model() is None
+        assert s.embedding_primary() == "jina_ai/jina-embeddings-v5-text-small"
 
-    def test_no_keys_returns_none(self):
+    def test_no_keys_returns_empty(self):
         s = Settings()
-        assert s.resolve_embedding_model() is None
+        assert s.embedding_chain() == []
+        assert s.embedding_primary() is None
 
-    def test_explicit_overrides_auto(self):
-        """Explicit EMBEDDING_MODEL takes priority over API_KEYS."""
+    def test_explicit_overrides_default(self):
+        """Explicit EMBEDDING_MODELS takes priority over the default chain."""
         s = Settings(
-            embedding_model="custom/model",
+            embedding_models="custom/model",
             api_keys="GOOGLE_API_KEY:key",
         )
-        assert s.resolve_embedding_model() == "custom/model"
+        assert s.embedding_primary() == "custom/model"
+
+    def test_legacy_singular_folded_into_chain(self):
+        """Deprecated EMBEDDING_MODEL is honored as a single-element chain."""
+        s = Settings(embedding_model="custom/model")
+        assert s.embedding_chain() == ["custom/model"]
 
 
 class TestEmbeddingDims:
@@ -221,27 +228,32 @@ class TestEmbeddingDims:
 
 
 class TestEmbeddingBackend:
-    def test_explicit_litellm(self):
+    def test_deprecated_litellm(self):
+        """Deprecated EMBEDDING_BACKEND='litellm' maps to 'cloud'."""
         s = Settings(embedding_backend="litellm")
         assert s.resolve_embedding_backend() == "cloud"
 
-    def test_explicit_local(self):
+    def test_deprecated_local(self):
         s = Settings(embedding_backend="local")
         assert s.resolve_embedding_backend() == "local"
 
-    def test_auto_detect_cloud_with_keys(self):
-        """Falls back to cloud when keys provided."""
+    def test_inferred_cloud_with_chain(self):
+        """Non-empty chain (sdk mode) infers 'cloud'."""
         s = Settings(api_keys="GOOGLE_API_KEY:key")
-        assert s.resolve_embedding_backend() in ("cloud", "local")
+        assert s.resolve_embedding_backend() == "cloud"
 
-    def test_auto_detect_no_keys_no_local(self):
-        """Returns 'local' when no keys configured."""
+    def test_inferred_local_no_chain(self):
+        """Empty chain (no keys) infers 'local'."""
         s = Settings()
-        result = s.resolve_embedding_backend()
-        assert result == "local"
+        assert s.resolve_embedding_backend() == "local"
 
-    def test_explicit_overrides_auto(self):
-        """Explicit backend takes priority over auto-detection."""
+    def test_inferred_cloud_with_explicit_models(self):
+        """Explicit EMBEDDING_MODELS infers 'cloud' even without API keys."""
+        s = Settings(embedding_models="jina_ai/jina-embeddings-v5-text-small")
+        assert s.resolve_embedding_backend() == "cloud"
+
+    def test_deprecated_backend_overrides_inference(self):
+        """Deprecated explicit backend takes priority over inference."""
         s = Settings(embedding_backend="litellm")
         assert s.resolve_embedding_backend() == "cloud"
 
@@ -267,17 +279,17 @@ class TestRerankSettings:
         s = Settings(rerank_enabled=False)
         assert s.resolve_rerank_backend() == ""
 
-    def test_resolve_rerank_backend_explicit(self):
+    def test_resolve_rerank_backend_deprecated_litellm(self):
         s = Settings(rerank_backend="litellm")
         assert s.resolve_rerank_backend() == "cloud"
 
-    def test_resolve_rerank_backend_custom(self):
-        """resolve_rerank_backend returns custom backend if set."""
+    def test_resolve_rerank_backend_deprecated_custom(self):
+        """Deprecated rerank_backend returns custom backend if set."""
         s = Settings(rerank_backend="custom")
         assert s.resolve_rerank_backend() == "custom"
 
-    def test_resolve_rerank_backend_model_set(self):
-        s = Settings(rerank_model="custom/reranker")
+    def test_resolve_rerank_backend_models_set(self):
+        s = Settings(rerank_models="custom/reranker")
         assert s.resolve_rerank_backend() == "cloud"
 
     def test_resolve_rerank_backend_cohere_env(self, monkeypatch):
@@ -297,36 +309,33 @@ class TestRerankSettings:
         s = Settings()
         assert s.resolve_rerank_backend() == "local"
 
-    def test_resolve_rerank_model_explicit(self):
-        s = Settings(rerank_model="custom/reranker")
-        assert s.resolve_rerank_model() == "custom/reranker"
+    def test_rerank_chain_explicit(self):
+        s = Settings(rerank_models="custom/reranker")
+        assert s.rerank_chain() == ["custom/reranker"]
+        assert s.rerank_primary() == "custom/reranker"
 
-    def test_resolve_rerank_model_cohere_env(self, monkeypatch):
+    def test_rerank_chain_legacy_singular_folded(self):
+        s = Settings(rerank_model="custom/reranker")
+        assert s.rerank_chain() == ["custom/reranker"]
+
+    def test_rerank_chain_sdk_mode_default(self, monkeypatch):
         monkeypatch.setenv("COHERE_API_KEY", "test-key")
         s = Settings()
-        assert s.resolve_rerank_model() == "rerank-v4.0-pro"
+        assert s.rerank_primary() == "jina_ai/jina-reranker-v3"
 
-    def test_resolve_rerank_model_cohere_in_api_keys(self):
-        s = Settings(api_keys="COHERE_API_KEY:test-key")
-        assert s.resolve_rerank_model() == "rerank-v4.0-pro"
-
-    def test_resolve_rerank_model_jina_in_api_keys(self):
-        s = Settings(api_keys="JINA_AI_API_KEY:test-key")
-        assert s.resolve_rerank_model() == "jina_ai/jina-reranker-v3"
-
-    def test_resolve_rerank_model_none_no_keys(self):
+    def test_rerank_chain_empty_no_keys(self):
         s = Settings()
-        assert s.resolve_rerank_model() is None
+        assert s.rerank_chain() == []
+        assert s.rerank_primary() is None
 
-    def test_resolve_rerank_backend_non_rerank_api_keys(self):
-        """Returns 'local' when api_keys set but no reranker keys present."""
-        s = Settings(api_keys="OPENAI_API_KEY:test-key")
-        assert s.resolve_rerank_backend() == "local"
+    def test_rerank_chain_disabled_returns_empty(self):
+        s = Settings(rerank_enabled=False, rerank_models="custom/reranker")
+        assert s.rerank_chain() == []
 
-    def test_resolve_rerank_model_non_rerank_api_keys(self):
-        """Returns None when api_keys set but no reranker keys present."""
+    def test_resolve_rerank_backend_any_sdk_key_infers_cloud(self):
+        """Any sdk-mode key yields the default chain -> 'cloud'."""
         s = Settings(api_keys="OPENAI_API_KEY:test-key")
-        assert s.resolve_rerank_model() is None
+        assert s.resolve_rerank_backend() == "cloud"
 
     def test_resolve_local_rerank_model(self):
         s = Settings()
@@ -530,3 +539,56 @@ class TestCompressionSettings:
         monkeypatch.setenv("COMPRESSION_MODEL", "gemini-2.5-flash")
         s = Settings()
         assert s.compression_model == "gemini-2.5-flash"
+
+
+def test_embedding_models_chain_primary_and_fallbacks(monkeypatch):
+    monkeypatch.setenv(
+        "EMBEDDING_MODELS",
+        "jina_ai/jina-embeddings-v5-text-small,gemini/gemini-embedding-001",
+    )
+    s = Settings()
+    assert s.embedding_chain() == [
+        "jina_ai/jina-embeddings-v5-text-small",
+        "gemini/gemini-embedding-001",
+    ]
+    assert s.embedding_primary() == "jina_ai/jina-embeddings-v5-text-small"
+    assert s.resolve_embedding_backend() == "cloud"
+
+
+def test_embedding_empty_falls_back_to_local(monkeypatch):
+    for v in (
+        "EMBEDDING_MODELS",
+        "EMBEDDING_MODEL",
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_KEY",
+        "COHERE_API_KEY",
+        "CO_API_KEY",
+        "XAI_API_KEY",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    s = Settings()
+    assert s.embedding_chain() == []
+    assert s.resolve_embedding_backend() == "local"
+
+
+def test_legacy_singular_embedding_model_honored_with_warning(monkeypatch):
+    monkeypatch.delenv("EMBEDDING_MODELS", raising=False)
+    monkeypatch.setenv("EMBEDDING_MODEL", "gemini/gemini-embedding-001")
+    s = Settings()
+    assert s.embedding_chain() == ["gemini/gemini-embedding-001"]
+    assert s.resolve_embedding_backend() == "cloud"
+
+
+def test_rerank_models_chain(monkeypatch):
+    monkeypatch.setenv("RERANK_MODELS", "jina_ai/jina-reranker-v3,cohere/rerank-v3.5")
+    s = Settings()
+    assert s.rerank_chain() == ["jina_ai/jina-reranker-v3", "cohere/rerank-v3.5"]
+    assert s.rerank_primary() == "jina_ai/jina-reranker-v3"
+
+
+def test_llm_models_chain_default_preserved(monkeypatch):
+    monkeypatch.delenv("LLM_MODELS", raising=False)
+    s = Settings()
+    assert s.llm_chain()[0] == "gemini/gemini-3-flash-preview"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,8 +193,17 @@ class TestEmbeddingModel:
         assert s.embedding_chain() == ["custom/model"]
 
     def test_sdk_mode_returns_default_chain(self):
-        """With API keys but no explicit chain, the default chain is used."""
+        """Default chain keeps only models whose provider key is configured.
+
+        A GOOGLE/GEMINI key yields the gemini default (jina/openai/cohere
+        models are dropped — no key for them).
+        """
         s = Settings(api_keys="GOOGLE_API_KEY:key")
+        assert s.embedding_primary() == "gemini/gemini-embedding-001"
+
+    def test_sdk_mode_default_filters_to_keyed_models(self):
+        """With a Jina key, the jina default model leads the chain."""
+        s = Settings(api_keys="JINA_AI_API_KEY:key")
         assert s.embedding_primary() == "jina_ai/jina-embeddings-v5-text-small"
 
     def test_no_keys_returns_empty(self):
@@ -319,7 +328,14 @@ class TestRerankSettings:
         assert s.rerank_chain() == ["custom/reranker"]
 
     def test_rerank_chain_sdk_mode_default(self, monkeypatch):
+        # Cohere key -> only the cohere default reranker survives the filter
+        # (jina is dropped: no Jina key).
         monkeypatch.setenv("COHERE_API_KEY", "test-key")
+        s = Settings()
+        assert s.rerank_primary() == "cohere/rerank-v3.5"
+
+    def test_rerank_chain_jina_key_leads(self, monkeypatch):
+        monkeypatch.setenv("JINA_AI_API_KEY", "test-key")
         s = Settings()
         assert s.rerank_primary() == "jina_ai/jina-reranker-v3"
 
@@ -332,10 +348,12 @@ class TestRerankSettings:
         s = Settings(rerank_enabled=False, rerank_models="custom/reranker")
         assert s.rerank_chain() == []
 
-    def test_resolve_rerank_backend_any_sdk_key_infers_cloud(self):
-        """Any sdk-mode key yields the default chain -> 'cloud'."""
+    def test_resolve_rerank_backend_non_rerank_key_infers_local(self):
+        """A non-rerank key (OpenAI) leaves the rerank default chain empty
+        (no Jina/Cohere key) -> 'local', so reranking still works via ONNX."""
         s = Settings(api_keys="OPENAI_API_KEY:test-key")
-        assert s.resolve_rerank_backend() == "cloud"
+        assert s.rerank_chain() == []
+        assert s.resolve_rerank_backend() == "local"
 
     def test_resolve_local_rerank_model(self):
         s = Settings()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -14,7 +14,7 @@ def mock_settings():
         # Default happy path settings
         m.setup_api_keys.return_value = {"KEY": "123"}
         m.setup_providers.return_value = "sdk"
-        m.resolve_embedding_model.return_value = "test-model"
+        m.embedding_chain.return_value = ["test-model"]
         m.resolve_embedding_dims.return_value = 0
         m.resolve_embedding_backend.return_value = "cloud"
         m.sync_enabled = False
@@ -57,7 +57,7 @@ async def test_lifespan_happy_path_cloud(
 ):
     """Test normal startup with cloud embedding."""
     mock_settings.resolve_embedding_backend.return_value = "cloud"
-    mock_settings.resolve_embedding_model.return_value = "cloud-model"
+    mock_settings.embedding_chain.return_value = ["cloud-model"]
     mock_settings.resolve_embedding_dims.return_value = 128
 
     # Setup backend mock
@@ -129,7 +129,7 @@ async def test_lifespan_explicit_cloud_exception_no_local_fallback(
 ):
     """Test no local fallback when explicit cloud model init raises exception."""
     mock_settings.resolve_embedding_backend.return_value = "cloud"
-    mock_settings.resolve_embedding_model.return_value = "crash-model"
+    mock_settings.embedding_chain.return_value = ["crash-model"]
     mock_settings.resolve_embedding_dims.return_value = 0
 
     # Cloud raises exception -- no local fallback in CONFIGURED state
@@ -148,7 +148,7 @@ async def test_lifespan_all_backends_fail(
 ):
     """Test behavior when both cloud and local backends fail."""
     mock_settings.resolve_embedding_backend.return_value = "cloud"
-    mock_settings.resolve_embedding_model.return_value = "crash-model"
+    mock_settings.embedding_chain.return_value = ["crash-model"]
 
     # Cloud raises, Local raises
     mock_embedder.side_effect = [Exception("Cloud fail"), Exception("Local fail")]

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,78 +1,27 @@
-"""Tests for relay_schema module."""
-
 from mnemo_mcp.relay_schema import RELAY_SCHEMA
 
 
-class TestRelaySchema:
-    """Test relay config schema definition."""
+def test_has_model_chain_tasks():
+    tasks = {
+        f.get("task") for f in RELAY_SCHEMA["fields"] if f.get("type") == "model-chain"
+    }
+    assert tasks == {"embedding", "rerank", "chat"}
 
-    def test_schema_has_server_name(self):
-        assert RELAY_SCHEMA["server"] == "mnemo-mcp"
 
-    def test_schema_has_display_name(self):
-        assert RELAY_SCHEMA["displayName"] == "Mnemo MCP"
+def test_key_fields_are_derived():
+    derived = {f["key"] for f in RELAY_SCHEMA["fields"] if f.get("derived")}
+    assert "GEMINI_API_KEY" in derived and "JINA_AI_API_KEY" in derived
 
-    def test_schema_has_description(self):
-        assert "description" in RELAY_SCHEMA
-        assert len(RELAY_SCHEMA["description"]) > 0
 
-    def test_schema_has_flat_fields(self):
-        """Schema uses flat fields structure (not modes)."""
-        assert "fields" in RELAY_SCHEMA
-        assert "modes" not in RELAY_SCHEMA
+def test_no_hardcoded_priority_strings():
+    for cap in RELAY_SCHEMA.get("capabilityInfo", []):
+        assert ">" not in cap.get("priority", "")
 
-    def test_schema_has_provider_fields_only(self):
-        """Relay form scope: 6 API key provider fields ONLY.
 
-        S3 + passphrase are operator env config (docker spawn), NOT
-        per-user relay fields. See docs/passport.md for the runbook
-        and relay_schema.py module docstring for the deployment-mode
-        XOR semantics.
-        """
-        fields = RELAY_SCHEMA["fields"]
-        assert len(fields) == 6
-        keys = [f["key"] for f in fields]
-        assert all(k.endswith("_API_KEY") for k in keys), (
-            f"non-API-key fields in relay form: {keys}"
-        )
-
-    def test_schema_provider_keys(self):
-        keys = [f["key"] for f in RELAY_SCHEMA["fields"]]
-        assert "JINA_AI_API_KEY" in keys
-        assert "GEMINI_API_KEY" in keys
-        assert "OPENAI_API_KEY" in keys
-        assert "COHERE_API_KEY" in keys
-        assert "ANTHROPIC_API_KEY" in keys
-        assert "XAI_API_KEY" in keys
-
-    def test_all_fields_optional(self):
-        for f in RELAY_SCHEMA["fields"]:
-            assert f.get("required") is False
-
-    def test_provider_fields_have_help_urls(self):
-        """Phase 1 provider fields keep their helpUrl pointing at signup pages.
-
-        Phase 2 S3 + passphrase fields legitimately have no single help URL
-        (S3 spans AWS/R2/B2/MinIO; passphrase is user-chosen) so we only
-        require the helpUrl on the original 4 provider fields.
-        """
-        provider_keys = {
-            "JINA_AI_API_KEY",
-            "GEMINI_API_KEY",
-            "OPENAI_API_KEY",
-            "COHERE_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "XAI_API_KEY",
-        }
-        for f in RELAY_SCHEMA["fields"]:
-            if f["key"] not in provider_keys:
-                continue
-            assert "helpUrl" in f
-            assert f["helpUrl"].startswith("https://")
-
-    def test_capability_info_present(self):
-        assert "capabilityInfo" in RELAY_SCHEMA
-        labels = [c["label"] for c in RELAY_SCHEMA["capabilityInfo"]]
-        assert "Embedding" in labels
-        assert "Reranking" in labels
-        assert "LLM" in labels
+def test_suggested_models_carry_provider_prefix():
+    # Every suggested model except bare-openai must carry a "<provider>/" prefix
+    # so the widget derive-keys maps it to the correct key field.
+    for f in RELAY_SCHEMA["fields"]:
+        if f.get("type") == "model-chain":
+            for m in f["suggestedModels"]:
+                assert "/" in m, f"suggested model {m!r} lacks a provider prefix"

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -220,10 +220,15 @@ class TestInitEmbeddingBackendCandidate:
         self, mock_settings, mock_init, _mock_thread
     ):
         """When a candidate raises exception, continues to next (no local fallback)."""
-        from mnemo_mcp.config import _EMBEDDING_CANDIDATES
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = None
+        embedding_chain = [
+            "jina_ai/jina-embeddings-v5-text-small",
+            "gemini/gemini-embedding-001",
+            "text-embedding-3-large",
+            "embed-multilingual-v3.0",
+        ]
+        mock_settings.embedding_chain.return_value = embedding_chain
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "cloud"
 
@@ -234,7 +239,7 @@ class TestInitEmbeddingBackendCandidate:
         await _init_embedding_backend("sdk", ctx)
 
         # Should have tried all cloud candidates only -- no local fallback
-        assert mock_init.call_count == len(_EMBEDDING_CANDIDATES)
+        assert mock_init.call_count == len(embedding_chain)
 
     @patch(
         "mnemo_mcp.server.asyncio.to_thread",
@@ -248,7 +253,7 @@ class TestInitEmbeddingBackendCandidate:
         """When local backend check_available returns 0, logs error."""
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = []
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "local"
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
@@ -344,7 +349,7 @@ class TestInitRerankerBackend:
         from mnemo_mcp.server import _init_reranker_backend
 
         mock_settings.resolve_rerank_backend.return_value = "cloud"
-        mock_settings.resolve_rerank_model.return_value = "cloud-model"
+        mock_settings.rerank_chain.return_value = ["cloud-model"]
 
         mock_init.side_effect = Exception("Cloud failed")
 
@@ -391,7 +396,7 @@ class TestMemoryLimitClamping:
 
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = []
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "local"
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
@@ -433,7 +438,7 @@ class TestWarmupInitEmbeddingBackend:
 
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = "gemini/model"
+        mock_settings.embedding_chain.return_value = ["gemini/model"]
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "cloud"
 
@@ -460,12 +465,15 @@ class TestWarmupInitEmbeddingBackend:
     async def test_cloud_auto_detect_candidates(
         self, mock_settings, mock_init, _mock_thread
     ):
-        """Auto-detect iterates through _EMBEDDING_CANDIDATES."""
+        """Auto-detect iterates through the embedding chain."""
         from unittest.mock import MagicMock
 
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = [
+            "jina_ai/jina-embeddings-v5-text-small",
+            "gemini/gemini-embedding-001",
+        ]
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "cloud"
 
@@ -497,7 +505,7 @@ class TestWarmupInitEmbeddingBackend:
 
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = "model"
+        mock_settings.embedding_chain.return_value = ["model"]
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "cloud"
 
@@ -527,7 +535,7 @@ class TestWarmupInitEmbeddingBackend:
 
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = []
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "local"
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
@@ -557,7 +565,7 @@ class TestWarmupInitEmbeddingBackend:
 
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = []
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "local"
         mock_settings.resolve_local_embedding_model.return_value = "local/m"
@@ -585,7 +593,7 @@ class TestWarmupInitEmbeddingBackend:
         """When init_backend raises exception, logs error and ctx stays None."""
         from mnemo_mcp.server import _init_embedding_backend
 
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = []
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "local"
         mock_settings.resolve_local_embedding_model.return_value = "local/m"

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -50,7 +50,7 @@ class TestInitRerankerBackend:
     async def test_cloud_reranker_success(self, mock_settings, _mock_thread):
         """Cloud reranker initializes successfully."""
         mock_settings.resolve_rerank_backend.return_value = "cloud"
-        mock_settings.resolve_rerank_model.return_value = "rerank-v4.0-pro"
+        mock_settings.rerank_chain.return_value = ["rerank-v4.0-pro"]
 
         mock_backend = MagicMock()
         mock_backend.check_available.return_value = True
@@ -68,7 +68,7 @@ class TestInitRerankerBackend:
     ):
         """Cloud reranker not available does NOT fall back to local (CONFIGURED state)."""
         mock_settings.resolve_rerank_backend.return_value = "cloud"
-        mock_settings.resolve_rerank_model.return_value = "rerank-v4.0-pro"
+        mock_settings.rerank_chain.return_value = ["rerank-v4.0-pro"]
 
         cloud_backend = MagicMock()
         cloud_backend.check_available.return_value = False
@@ -96,7 +96,7 @@ class TestInitRerankerBackend:
     ):
         """Cloud reranker exception does NOT fall back to local (CONFIGURED state)."""
         mock_settings.resolve_rerank_backend.return_value = "cloud"
-        mock_settings.resolve_rerank_model.return_value = "rerank-v4.0-pro"
+        mock_settings.rerank_chain.return_value = ["rerank-v4.0-pro"]
 
         call_count = 0
 
@@ -162,7 +162,7 @@ class TestInitRerankerBackend:
     async def test_cloud_no_model_no_local_fallback(self, mock_settings, _mock_thread):
         """Cloud reranker with no model logs error, no local fallback (CONFIGURED state)."""
         mock_settings.resolve_rerank_backend.return_value = "cloud"
-        mock_settings.resolve_rerank_model.return_value = None
+        mock_settings.rerank_chain.return_value = []
 
         with patch("mnemo_mcp.reranker.init_reranker") as mock_init:
             await _init_reranker_backend("sdk")

--- a/tests/test_server_setup_actions.py
+++ b/tests/test_server_setup_actions.py
@@ -191,7 +191,7 @@ class TestSetupComplete:
         ):
             set_state(CredentialState.CONFIGURED)
             mock_settings.setup_providers.return_value = "sdk"
-            mock_settings.resolve_embedding_model.return_value = "test/model"
+            mock_settings.embedding_chain.return_value = ["test/model"]
             mock_settings.resolve_embedding_dims.return_value = 768
             mock_settings.resolve_embedding_backend.return_value = "cloud"
 
@@ -270,7 +270,12 @@ class TestInitEmbeddingBackendAwaitingSetup:
         """When in AWAITING_SETUP, embedding init is skipped."""
         set_state(CredentialState.AWAITING_SETUP)
 
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = [
+            "jina_ai/jina-embeddings-v5-text-small",
+            "gemini/gemini-embedding-001",
+            "text-embedding-3-large",
+            "embed-multilingual-v3.0",
+        ]
         mock_settings.resolve_embedding_dims.return_value = 0
         mock_settings.resolve_embedding_backend.return_value = "cloud"
 

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -36,13 +36,12 @@ class TestClearModelCache:
 class TestValidateCloudModels:
     """_validate_cloud_models checks cloud embedding availability."""
 
-    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/model-1"])
     @patch("mnemo_mcp.embedder.init_backend")
     def test_cloud_ready(self, mock_init):
         from mnemo_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["gemini/model-1"]
 
         mock_backend = MagicMock()
         mock_backend.check_available.return_value = 768
@@ -54,13 +53,12 @@ class TestValidateCloudModels:
         assert result["model"] == "gemini/model-1"
         assert result["dims"] == 768
 
-    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["model-a"])
     @patch("mnemo_mcp.embedder.init_backend")
     def test_cloud_not_ready(self, mock_init):
         from mnemo_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["model-a"]
 
         mock_backend = MagicMock()
         mock_backend.check_available.return_value = 0
@@ -70,13 +68,12 @@ class TestValidateCloudModels:
 
         assert result["cloud_ready"] is False
 
-    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["model-a"])
     @patch("mnemo_mcp.embedder.init_backend")
     def test_explicit_model_tried_first(self, mock_init):
         from mnemo_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = "explicit/model"
+        mock_settings.embedding_chain.return_value = ["explicit/model"]
 
         mock_backend = MagicMock()
         mock_backend.check_available.return_value = 512
@@ -87,13 +84,12 @@ class TestValidateCloudModels:
         assert result["cloud_ready"] is True
         mock_init.assert_called_once_with("cloud", "explicit/model")
 
-    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["model-a"])
     @patch("mnemo_mcp.embedder.init_backend")
     def test_cloud_exception_returns_not_ready(self, mock_init):
         from mnemo_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["model-a"]
 
         mock_init.side_effect = Exception("auth error")
 
@@ -101,15 +97,12 @@ class TestValidateCloudModels:
 
         assert result["cloud_ready"] is False
 
-    @patch(
-        "mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["fail-model", "success-model"]
-    )
     @patch("mnemo_mcp.embedder.init_backend")
     def test_cloud_first_candidate_fails_continues_to_next(self, mock_init):
         from mnemo_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["fail-model", "success-model"]
 
         mock_backend_success = MagicMock()
         mock_backend_success.check_available.return_value = 1024
@@ -127,13 +120,12 @@ class TestValidateCloudModels:
         assert result["model"] == "success-model"
         assert result["dims"] == 1024
 
-    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["fail-1", "fail-2"])
     @patch("mnemo_mcp.embedder.init_backend")
     def test_cloud_all_candidates_fail_returns_not_ready(self, mock_init):
         from mnemo_mcp.setup_tool import _validate_cloud_models
 
         mock_settings = MagicMock()
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["fail-1", "fail-2"]
 
         mock_init.side_effect = Exception("Service unavailable")
 
@@ -231,14 +223,13 @@ class TestDownloadLocalEmbedding:
 class TestRunWarmup:
     """run_warmup() async function for MCP tool."""
 
-    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["gemini/model-1"])
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.setup_tool.settings")
     async def test_cloud_embedding_success(self, mock_settings, mock_init):
         from mnemo_mcp.setup_tool import run_warmup
 
         mock_settings.setup_api_keys.return_value = {"GEMINI_API_KEY": "key"}
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["gemini/model-1"]
 
         mock_backend = MagicMock()
         mock_backend.check_available.return_value = 768
@@ -271,7 +262,6 @@ class TestRunWarmup:
         assert result["steps"][0]["status"] == "ok"
 
     @patch("qwen3_embed.TextEmbedding")
-    @patch("mnemo_mcp.setup_tool._EMBEDDING_CANDIDATES", ["model-a"])
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.setup_tool.settings")
     async def test_cloud_fail_falls_back_to_local(
@@ -280,7 +270,7 @@ class TestRunWarmup:
         from mnemo_mcp.setup_tool import run_warmup
 
         mock_settings.setup_api_keys.return_value = {"KEY": "val"}
-        mock_settings.resolve_embedding_model.return_value = None
+        mock_settings.embedding_chain.return_value = ["model-a"]
         mock_settings.resolve_local_embedding_model.return_value = "local/model"
 
         mock_backend = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -1076,7 +1076,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.2.2b2"
+version = "2.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1121,7 +1121,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b1,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b2,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1236,7 +1236,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b1"
+version = "1.18.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1251,9 +1251,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/aa/e8eb296141165057abb74f2e62f392c341b14e3259cb1677547b3a6760f1/n24q02m_mcp_core-1.18.0b1.tar.gz", hash = "sha256:832b29c70cae6a610a83c3a5c06bcb7220e6eaf43ea5dfa91ef47adc75ac332e", size = 252457, upload-time = "2026-06-10T13:31:50.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ed/59f51b85af63f4986918e6d76ccd7e8bb177706aeb397629d7cc76da5bcd/n24q02m_mcp_core-1.18.0b2.tar.gz", hash = "sha256:30baf5173e460ef20f1b24ac91e6310b8d7737696be033138a4b05785cb4b5a9", size = 256688, upload-time = "2026-06-11T05:07:18.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/22/ce4c37b7c120eb6e0aee229665841bfcb2482bc650d49168c74a22253a77/n24q02m_mcp_core-1.18.0b1-py3-none-any.whl", hash = "sha256:6d4f84e4369aab5aa5d1213a1c7b34d5c61672eaa3834ee92bc9b4414626eb79", size = 135751, upload-time = "2026-06-10T13:31:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/47/1182dda7b70180245e57d5e6316940e219faf46d6692be2d8edf8d2c603d/n24q02m_mcp_core-1.18.0b2-py3-none-any.whl", hash = "sha256:905efd3e25ceb8ab6d14132a8f6e660bde6ba324bf0363342b1a5d87f09dd242", size = 139516, upload-time = "2026-06-11T05:07:19.407Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Selection redesign **Phase 1 sample** (mnemo). Spec `.private 2026-06-11`.

- `config.py`: per-task model chains `EMBEDDING_MODELS`/`RERANK_MODELS`/`LLM_MODELS` (CSV `provider/model`, order = litellm fallback). Drops the `_EMBEDDING_CANDIDATES` priority-router + singular `*_MODEL`/`*_BACKEND` (kept one release as deprecated shims with warnings). Backend inferred from chain non-emptiness.
- **Key-gated default**: when a task env is empty, the curated default keeps ONLY models whose provider key is configured (via `mcp_core.llm.providers.key_env_for_model`); none -> empty -> local ONNX. Fixes the trap where an OpenAI-only key kept a keyless Jina/Cohere rerank default "cloud" and silently dropped reranking. Default chain uses explicit provider prefixes.
- `relay_schema.py`: 3 `model-chain` widget tasks (embedding/rerank/chat) + `derived` key fields (shown by the new mcp-core widget only when a chosen model references that provider). Drops hardcoded "Jina > Gemini > ..." priority strings. Keeps Passport-sync capabilityInfo.
- Pin `n24q02m-mcp-core[llm]>=1.18.0b2` (relay model-chain widget + providers map).

Tests: `tests/test_config.py` (chain resolution + key-gated default), `tests/test_relay_schema.py`. Full suite green (1288). Interactive widget verified next via browser relay gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)