### PR TITLE
fix: default local reranker to YesNo ONNX variant (#725-enabled)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # SQLite vector search
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
-    "qwen3-embed>=1.11.1",
+    "qwen3-embed>=1.11.2b3",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
     "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -377,9 +377,14 @@ class Settings(BaseSettings):
         return "cloud" if self.rerank_chain() else "local"
 
     def resolve_local_rerank_model(self) -> str:
-        """Resolve local reranker model: GGUF if GPU + llama-cpp, else ONNX."""
+        """Resolve local reranker model: GGUF if GPU + llama-cpp, else ONNX.
+
+        The ONNX default is the YesNo variant (~598 MB at inference vs ~12 GB
+        for the full-vocab build); it is mathematically equivalent and, since
+        qwen3-embed 1.11.2b3, produces batch-invariant scores (issue #725).
+        """
         return _resolve_local_model(
-            "n24q02m/Qwen3-Reranker-0.6B-ONNX",
+            "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo",
             "n24q02m/Qwen3-Reranker-0.6B-GGUF",
         )
 

--- a/src/mnemo_mcp/reranker.py
+++ b/src/mnemo_mcp/reranker.py
@@ -143,7 +143,9 @@ LiteLLMReranker = CloudReranker
 class Qwen3Reranker:
     """Local ONNX cross-encoder reranking via qwen3-embed."""
 
-    DEFAULT_MODEL = "n24q02m/Qwen3-Reranker-0.6B-ONNX"
+    # YesNo variant: ~598 MB at inference vs ~12 GB for the full-vocab build,
+    # mathematically equivalent, batch-invariant since qwen3-embed 1.11.2b3 (#725).
+    DEFAULT_MODEL = "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
 
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or self.DEFAULT_MODEL

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -193,12 +193,12 @@ class TestQwen3Reranker:
     def test_default_model_name(self):
         """Default model name is used when none specified."""
         reranker = Qwen3Reranker()
-        assert reranker._model_name == "n24q02m/Qwen3-Reranker-0.6B-ONNX"
+        assert reranker._model_name == "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
 
     def test_none_model_uses_default(self):
         """None model name falls back to default."""
         reranker = Qwen3Reranker(None)
-        assert reranker._model_name == "n24q02m/Qwen3-Reranker-0.6B-ONNX"
+        assert reranker._model_name == "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
 
     def test_lazy_load(self):
         """Model is not loaded until _get_model is called."""

--- a/uv.lock
+++ b/uv.lock
@@ -1126,7 +1126,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
-    { name = "qwen3-embed", specifier = ">=1.11.1" },
+    { name = "qwen3-embed", specifier = ">=1.11.2b3" },
     { name = "sqlite-vec" },
     { name = "tiktoken", specifier = ">=0.13.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.11.1"
+version = "1.11.2b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1768,9 +1768,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/0d/8877e7e9c19daae9c7b97cc5d18c706df02c22d73c2d11c880a72023daad/qwen3_embed-1.11.1.tar.gz", hash = "sha256:b86adf71b3fa158dbcd51b72db624352cb9a9b410de0c2e1b6d78144d7e8f256", size = 187826, upload-time = "2026-06-09T02:53:40.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/d7/b3a9d12b8f3b4853d944c0c2ccc6ca5da6d3685fd6226ca31e3ded363846/qwen3_embed-1.11.2b3.tar.gz", hash = "sha256:f6ba46d82a700802e21af9b0dd97487452380ad59244c30c7fc32146c83915f4", size = 186919, upload-time = "2026-06-11T13:13:37.795Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/4a/c46780c74524ac20be54c1ac68383e21453c5b229ce7b4bf38ed235061bb/qwen3_embed-1.11.1-py3-none-any.whl", hash = "sha256:9a459e62aef1d948ec5344aacdb19286c418454e91b3452822a4caf9ceb73dbd", size = 60923, upload-time = "2026-06-09T02:53:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/3de1a318fc166f6105717904fbe04b591ce10de4efb39017dcf6eaaeded1/qwen3_embed-1.11.2b3-py3-none-any.whl", hash = "sha256:dd849152ac99964b9b77b83007eef78ee52d677e78117fe1da86bce27e75f925", size = 60801, upload-time = "2026-06-11T13:13:38.721Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Flips the default local ONNX reranker from the full-vocab build (~12GB RAM peak at inference) to the **YesNo** variant (~598MB). The two are mathematically equivalent (same weights; `sigmoid(no_logit - yes_logit)`).

Previously gated on a determinism bug: under batched inference the YesNo variant produced batch-dependent scores. Fixed upstream in **qwen3-embed 1.11.2b3** (per-row scoring, n24q02m/qwen3-embed#725). This PR bumps the pin floor to `>=1.11.2b3` so the fix is guaranteed present before flipping the default.

- `config.py::resolve_local_rerank_model()` — ONNX default -> `...-ONNX-YesNo` (GGUF path unchanged; no YesNo GGUF variant)
- `reranker.py::Qwen3Reranker.DEFAULT_MODEL` + tests — kept in sync
- `pyproject.toml` — `qwen3-embed>=1.11.2b3`

Unit suite: 1286 passed, 5 skipped. ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)