### PR TITLE
fix: correct dedup threshold doc and add multi-user trust row

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ This plugin implements **TC-Local** (machine-bound, single trust principal). The
 |---|---|---|---|
 | stdio (default) | `~/.mnemo-mcp/config.json` | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
 | HTTP self-host | Same as stdio | Same | Only you (admin = user) |
+| HTTP multi-user remote (`PUBLIC_URL`) | Per-JWT-sub credential store | AES-GCM | Only the authenticated user (per-`sub` isolation) |
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,7 @@ caller text
 [embedding] (cloud or local Qwen3 ONNX)
    |
    v
-[dedup probe] check_duplicate(text, threshold=DEDUP_THRESHOLD/0.92)
+[dedup probe] check_duplicate(text, threshold=DEDUP_THRESHOLD/0.9)
    |
    +-- duplicate? -----> return existing memory_id, status="deduplicated"
    |


### PR DESCRIPTION
## Vấn đề (docs-vs-code)
- `docs/ARCHITECTURE.md`: dedup probe ghi `threshold=...0.92` nhưng `config.py:112 dedup_threshold = 0.9`.
- `README.md` Trust Model: chỉ 2 row (stdio + HTTP self-host), thiếu **HTTP multi-user remote** mode mà server support (`PUBLIC_URL` → per-JWT-sub isolation, `server.py:2179`).

## Fix
Sync 0.92→0.9 + thêm row multi-user.

## Lưu ý (verify-before-acting)
ARCHITECTURE mục "multi-provider LLM dispatch GEMINI>OPENAI>ANTHROPIC>XAI" KHÔNG đổi — verified `llm.py call_llm` vẫn dùng `detect_provider()` priority (không phải chain), nên mô tả đó ĐÚNG code. (Riêng việc `config.llm_models` chain chưa được `call_llm` dùng cho LLM path = code inconsistency, ngoài scope docs PR này.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)