### PR TITLE
feat: bring-your-own local embedding model via env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # SQLite vector search
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
-    "qwen3-embed>=1.11.2b3",
+    "qwen3-embed>=1.12.0b1",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
     "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -90,6 +90,19 @@ class Settings(BaseSettings):
         ""  # "cloud" | "local" | "" (auto: API_KEYS->cloud, else local)
     )
 
+    # BYO (bring-your-own) LOCAL model override. When set, the local
+    # embed/rerank backend loads this model id instead of the bundled
+    # Qwen3 default. A non-built-in id is registered with qwen3-embed via
+    # CustomModelSpec (server.py) using the companion vars below.
+    local_embedding_model: str = ""
+    local_rerank_model: str = ""
+
+    # Companion vars for registering a custom LOCAL embedding model.
+    local_embedding_pooling: str = "MEAN"
+    local_embedding_dim: int = 0  # 0 = use EMBEDDING_DIMS / server default
+    local_embedding_normalize: bool = True
+    local_embedding_model_file: str = "onnx/model.onnx"
+
     # Reranking
     rerank_enabled: bool = True
     # DEPRECATED (2026-06-11, removed next release): see embedding_* above.
@@ -330,7 +343,9 @@ class Settings(BaseSettings):
         return self.embedding_dims
 
     def resolve_local_embedding_model(self) -> str:
-        """Resolve local embedding model: GGUF if GPU + llama-cpp, else ONNX."""
+        """Resolve local embedding model: BYO override, else GGUF/ONNX default."""
+        if self.local_embedding_model:
+            return self.local_embedding_model
         return _resolve_local_model(
             "n24q02m/Qwen3-Embedding-0.6B-ONNX",
             "n24q02m/Qwen3-Embedding-0.6B-GGUF",
@@ -382,7 +397,10 @@ class Settings(BaseSettings):
         The ONNX default is the YesNo variant (~598 MB at inference vs ~12 GB
         for the full-vocab build); it is mathematically equivalent and, since
         qwen3-embed 1.11.2b3, produces batch-invariant scores (issue #725).
+        A BYO ``LOCAL_RERANK_MODEL`` override takes precedence when set.
         """
+        if self.local_rerank_model:
+            return self.local_rerank_model
         return _resolve_local_model(
             "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo",
             "n24q02m/Qwen3-Reranker-0.6B-GGUF",

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -37,6 +37,34 @@ _DEFAULT_EMBEDDING_DIMS = 768
 # --- Lifespan ---
 
 
+def _maybe_register_custom_embed(model_id: str) -> None:
+    """Register a BYO local embedding model with qwen3-embed.
+
+    Built-in ``n24q02m/Qwen3-*`` ids are already known to qwen3-embed, so
+    they are skipped. Any other id (set via ``LOCAL_EMBEDDING_MODEL``) is
+    registered via ``CustomModelSpec`` using the companion ``LOCAL_EMBEDDING_*``
+    settings, so ``TextEmbedding(model_id)`` can load it.
+    """
+    if model_id.startswith("n24q02m/Qwen3-"):
+        return
+
+    from qwen3_embed import CustomModelSpec
+
+    dim = settings.local_embedding_dim or settings.resolve_embedding_dims()
+    if dim <= 0:
+        dim = _DEFAULT_EMBEDDING_DIMS
+
+    CustomModelSpec(
+        model_id=model_id,
+        hf=model_id,
+        model_file=settings.local_embedding_model_file,
+        dim=dim,
+        pooling=settings.local_embedding_pooling,
+        normalization=settings.local_embedding_normalize,
+    ).register()
+    logger.info(f"Registered custom local embedding model: {model_id}")
+
+
 async def _init_embedding_backend(
     mode: str,
     ctx: dict,
@@ -67,6 +95,7 @@ async def _init_embedding_backend(
         # Local-only path
         local_model = settings.resolve_local_embedding_model()
         try:
+            await asyncio.to_thread(_maybe_register_custom_embed, local_model)
             backend = await asyncio.to_thread(init_backend, "local", local_model)
             native_dims = await asyncio.to_thread(backend.check_available)
             if native_dims > 0:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,6 +49,12 @@ def clean_env(monkeypatch):
         "COMPRESSION_ENABLED",
         "COMPRESSION_PROVIDER",
         "COMPRESSION_MODEL",
+        "LOCAL_EMBEDDING_MODEL",
+        "LOCAL_RERANK_MODEL",
+        "LOCAL_EMBEDDING_POOLING",
+        "LOCAL_EMBEDDING_DIM",
+        "LOCAL_EMBEDDING_NORMALIZE",
+        "LOCAL_EMBEDDING_MODEL_FILE",
     }
     # Thoroughly clear any variant of these keys in os.environ
     for k in list(os.environ.keys()):
@@ -360,6 +366,28 @@ class TestRerankSettings:
         model = s.resolve_local_rerank_model()
         # Should return ONNX or GGUF depending on environment
         assert "Qwen3-Reranker-0.6B" in model
+
+    def test_local_embedding_model_override(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_EMBEDDING_MODEL", "Org/custom-embed")
+        s = Settings()
+        assert s.resolve_local_embedding_model() == "Org/custom-embed"
+
+    def test_local_rerank_model_override(self, monkeypatch):
+        monkeypatch.setenv("LOCAL_RERANK_MODEL", "Org/custom-reranker")
+        s = Settings()
+        assert s.resolve_local_rerank_model() == "Org/custom-reranker"
+
+    def test_local_rerank_model_default_is_yesno(self):
+        """No override keeps the YesNo ONNX default (~598MB vs ~12GB)."""
+        with (
+            patch("mnemo_mcp.config._detect_gpu", return_value=False),
+            patch("mnemo_mcp.config._has_gguf_support", return_value=False),
+        ):
+            s = Settings()
+            assert (
+                s.resolve_local_rerank_model()
+                == "n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo"
+            )
 
 
 class TestGoogleDriveCredentials:

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -35,7 +35,12 @@ def mock_db():
 
 @pytest.fixture
 def mock_embedder():
-    with patch("mnemo_mcp.embedder.init_backend") as m:
+    with (
+        patch("mnemo_mcp.embedder.init_backend") as m,
+        # Isolate the BYO custom-model registration side effect; tests here
+        # exercise backend selection, not qwen3-embed registration.
+        patch("mnemo_mcp.server._maybe_register_custom_embed"),
+    ):
         backend = MagicMock()
         backend.check_available.return_value = 100
         m.return_value = backend

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,7 @@ from mnemo_mcp.server import (
     _handle_consolidate,
     _handle_search,
     _handle_update,
+    _maybe_register_custom_embed,
     config,
     help,
     main,
@@ -725,3 +726,35 @@ class TestServerVersion:
 
         init_opts = mcp._mcp_server.create_initialization_options()
         assert init_opts.server_version == __version__
+
+
+class TestMaybeRegisterCustomEmbed:
+    """BYO local embedding model registration (no model download)."""
+
+    def test_builtin_id_skips_registration(self):
+        import qwen3_embed
+
+        with patch.object(qwen3_embed.TextEmbedding, "add_custom_model") as mock_add:
+            _maybe_register_custom_embed("n24q02m/Qwen3-Embedding-0.6B-ONNX")
+            mock_add.assert_not_called()
+
+    def test_custom_id_registers_with_dim_and_pooling(self):
+        import qwen3_embed
+        from qwen3_embed.common.model_description import PoolingType
+
+        with patch.object(qwen3_embed.TextEmbedding, "add_custom_model") as mock_add:
+            with patch("mnemo_mcp.server.settings") as mock_settings:
+                mock_settings.local_embedding_dim = 1024
+                mock_settings.resolve_embedding_dims.return_value = 768
+                mock_settings.local_embedding_model_file = "onnx/model.onnx"
+                mock_settings.local_embedding_pooling = "CLS"
+                mock_settings.local_embedding_normalize = True
+
+                _maybe_register_custom_embed("Org/custom-embed")
+
+            mock_add.assert_called_once()
+            description = mock_add.call_args.args[0]
+            assert description.model == "Org/custom-embed"
+            assert description.dim == 1024
+            assert mock_add.call_args.kwargs["pooling"] == PoolingType.CLS
+            assert mock_add.call_args.kwargs["normalization"] is True

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -241,6 +241,7 @@ class TestInitEmbeddingBackendCandidate:
         # Should have tried all cloud candidates only -- no local fallback
         assert mock_init.call_count == len(embedding_chain)
 
+    @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(
         "mnemo_mcp.server.asyncio.to_thread",
         side_effect=lambda fn, *a, **kw: fn(*a, **kw),
@@ -248,7 +249,7 @@ class TestInitEmbeddingBackendCandidate:
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.server.settings")
     async def test_local_backend_zero_dims(
-        self, mock_settings, mock_init, _mock_thread
+        self, mock_settings, mock_init, _mock_thread, _mock_register
     ):
         """When local backend check_available returns 0, logs error."""
         from mnemo_mcp.server import _init_embedding_backend
@@ -383,6 +384,7 @@ class TestMemoryLimitClamping:
         # Should not crash, limit is clamped
         assert isinstance(result["results"], list)
 
+    @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(
         "mnemo_mcp.server.asyncio.to_thread",
         side_effect=lambda fn, *a, **kw: fn(*a, **kw),
@@ -390,7 +392,7 @@ class TestMemoryLimitClamping:
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.server.settings")
     async def test_local_backend_init_fails(
-        self, mock_settings, mock_init, _mock_thread
+        self, mock_settings, mock_init, _mock_thread, _mock_register
     ):
         """When local backend init raises exception, logs error."""
 
@@ -523,13 +525,16 @@ class TestWarmupInitEmbeddingBackend:
         # Only cloud was tried (1 call)
         assert mock_init.call_count == 1
 
+    @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(
         "mnemo_mcp.server.asyncio.to_thread",
         side_effect=lambda fn, *a, **kw: fn(*a, **kw),
     )
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.server.settings")
-    async def test_direct_local_backend(self, mock_settings, mock_init, _mock_thread):
+    async def test_direct_local_backend(
+        self, mock_settings, mock_init, _mock_thread, _mock_register
+    ):
         """When backend_type is "local", skips cloud entirely."""
         from unittest.mock import MagicMock
 
@@ -551,6 +556,7 @@ class TestWarmupInitEmbeddingBackend:
         mock_init.assert_called_once_with("local", "local/m")
         assert ctx["embedding_model"] == "__local__"
 
+    @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(
         "mnemo_mcp.server.asyncio.to_thread",
         side_effect=lambda fn, *a, **kw: fn(*a, **kw),
@@ -558,7 +564,7 @@ class TestWarmupInitEmbeddingBackend:
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.server.settings")
     async def test_local_backend_failure_logs_error(
-        self, mock_settings, mock_init, _mock_thread
+        self, mock_settings, mock_init, _mock_thread, _mock_register
     ):
         """When local backend also fails, ctx stays with None model."""
         from unittest.mock import MagicMock
@@ -580,6 +586,7 @@ class TestWarmupInitEmbeddingBackend:
 
         assert ctx["embedding_model"] is None
 
+    @patch("mnemo_mcp.server._maybe_register_custom_embed")
     @patch(
         "mnemo_mcp.server.asyncio.to_thread",
         side_effect=lambda fn, *a, **kw: fn(*a, **kw),
@@ -588,7 +595,7 @@ class TestWarmupInitEmbeddingBackend:
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.server.settings")
     async def test_local_backend_init_raises_exception(
-        self, mock_settings, mock_init, mock_logger, _mock_thread
+        self, mock_settings, mock_init, mock_logger, _mock_thread, _mock_register
     ):
         """When init_backend raises exception, logs error and ctx stays None."""
         from mnemo_mcp.server import _init_embedding_backend

--- a/uv.lock
+++ b/uv.lock
@@ -1076,7 +1076,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b3"
+version = "2.3.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1126,7 +1126,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
-    { name = "qwen3-embed", specifier = ">=1.11.2b3" },
+    { name = "qwen3-embed", specifier = ">=1.12.0b1" },
     { name = "sqlite-vec" },
     { name = "tiktoken", specifier = ">=0.13.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.11.2b3"
+version = "1.12.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1768,9 +1768,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/d7/b3a9d12b8f3b4853d944c0c2ccc6ca5da6d3685fd6226ca31e3ded363846/qwen3_embed-1.11.2b3.tar.gz", hash = "sha256:f6ba46d82a700802e21af9b0dd97487452380ad59244c30c7fc32146c83915f4", size = 186919, upload-time = "2026-06-11T13:13:37.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/80/fbbd7adf445a547fd4119e58b2c352b8c921df2028727453aba81c57bd0b/qwen3_embed-1.12.0b1.tar.gz", hash = "sha256:b3949f6df0e634eba5c343b04a120699122eb0b1e840a78e9117c1f6804d8580", size = 203461, upload-time = "2026-06-12T11:19:37.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/db/3de1a318fc166f6105717904fbe04b591ce10de4efb39017dcf6eaaeded1/qwen3_embed-1.11.2b3-py3-none-any.whl", hash = "sha256:dd849152ac99964b9b77b83007eef78ee52d677e78117fe1da86bce27e75f925", size = 60801, upload-time = "2026-06-11T13:13:38.721Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b3/42c80b5789441061acb449eb743ae5762b7154e9c19f259ef851707fb231/qwen3_embed-1.12.0b1-py3-none-any.whl", hash = "sha256:c00fc1ef8070f1615e803926bbda4a3050bbfdcf9282c974b192591d554e6444", size = 64546, upload-time = "2026-06-12T11:19:36.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Spec B Part B (mnemo). Mirrors wet-mcp.

Added `LOCAL_EMBEDDING_MODEL` / `LOCAL_RERANK_MODEL` overrides honored in `resolve_local_*_model()` (YesNo rerank default preserved). Non-built-in embedding ids are registered with qwen3-embed via `CustomModelSpec` (companion env: `LOCAL_EMBEDDING_POOLING`/`_DIM`/`_NORMALIZE`/`_MODEL_FILE`) before the local backend is constructed.

Custom-RERANK registration deferred (embedding-only one-call spec upstream). Pin `qwen3-embed>=1.12.0b1`. Gate green (1291 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)