### PR TITLE
fix: sync README tagline to current capability description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/mnemo-mcp
 
-**Persistent memory MCP server with hybrid retrieval (FTS5 + sqlite-vec + RRF fusion + cross-encoder rerank + temporal decay) and embedded sync. Open, free, unlimited.**
+**Persistent AI memory with hybrid search and embedded sync. Open, free, unlimited.**
 
 <!-- Badge Row 1: Status -->
 [![CI](https://github.com/n24q02m/mnemo-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/mnemo-mcp/actions/workflows/ci.yml)


### PR DESCRIPTION
Sync the README tagline to the cleaned-up, jargon-free repo description (drop dated/internal jargon and brittle tool counts; frame by capability).