### PR TITLE
feat: register a BYO local reranker via CustomRerankerSpec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # SQLite vector search
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
-    "qwen3-embed>=1.12.0b1",
+    "qwen3-embed>=1.12.0b2",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
     "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -99,7 +99,8 @@ class Settings(BaseSettings):
     # BYO (bring-your-own) LOCAL model override. When set, the local
     # embed/rerank backend loads this model id instead of the bundled
     # Qwen3 default. A non-built-in id is registered with qwen3-embed via
-    # CustomModelSpec (server.py) using the companion vars below.
+    # CustomModelSpec / CustomRerankerSpec (server.py) using the companion
+    # vars below.
     local_embedding_model: str = ""
     local_rerank_model: str = ""
 
@@ -108,6 +109,9 @@ class Settings(BaseSettings):
     local_embedding_dim: int = 0  # 0 = use EMBEDDING_DIMS / server default
     local_embedding_normalize: bool = True
     local_embedding_model_file: str = "onnx/model.onnx"
+    # Companion var for registering a custom LOCAL reranker (BYO ONNX cross-
+    # encoder). A cross-encoder needs no dim/pooling -- just the ONNX file path.
+    local_rerank_model_file: str = "onnx/model.onnx"
 
     # Reranking
     rerank_enabled: bool = True

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -65,6 +65,28 @@ def _maybe_register_custom_embed(model_id: str) -> None:
     logger.info(f"Registered custom local embedding model: {model_id}")
 
 
+def _maybe_register_custom_rerank(model_id: str) -> None:
+    """Register a BYO local reranker with qwen3-embed.
+
+    Built-in ``n24q02m/Qwen3-Reranker-*`` ids are already known to qwen3-embed,
+    so they are skipped. Any other id (set via ``LOCAL_RERANK_MODEL``) is
+    registered via ``CustomRerankerSpec`` using ``LOCAL_RERANK_MODEL_FILE``, so
+    ``TextCrossEncoder(model_id)`` can load it. A cross-encoder needs no
+    dim/pooling.
+    """
+    if model_id.startswith("n24q02m/Qwen3-Reranker-"):
+        return
+
+    from qwen3_embed import CustomRerankerSpec
+
+    CustomRerankerSpec(
+        model_id=model_id,
+        hf=model_id,
+        model_file=settings.local_rerank_model_file,
+    ).register()
+    logger.info(f"Registered custom local reranker: {model_id}")
+
+
 async def _init_embedding_backend(
     mode: str,
     ctx: dict,
@@ -162,6 +184,7 @@ async def _init_reranker_backend(mode: str) -> None:
         # Local-only path
         local_model = settings.resolve_local_rerank_model()
         try:
+            await asyncio.to_thread(_maybe_register_custom_rerank, local_model)
             backend = await asyncio.to_thread(init_reranker, "local", local_model)
             available = await asyncio.to_thread(backend.check_available)
             if available:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from mnemo_mcp.server import (
     _handle_search,
     _handle_update,
     _maybe_register_custom_embed,
+    _maybe_register_custom_rerank,
     config,
     help,
     main,
@@ -758,3 +759,29 @@ class TestMaybeRegisterCustomEmbed:
             assert description.dim == 1024
             assert mock_add.call_args.kwargs["pooling"] == PoolingType.CLS
             assert mock_add.call_args.kwargs["normalization"] is True
+
+
+class TestMaybeRegisterCustomRerank:
+    """BYO local reranker registration (no model download)."""
+
+    def test_builtin_id_skips_registration(self):
+        import qwen3_embed
+
+        with patch.object(qwen3_embed.TextCrossEncoder, "add_custom_model") as mock_add:
+            _maybe_register_custom_rerank("n24q02m/Qwen3-Reranker-0.6B-ONNX-YesNo")
+            mock_add.assert_not_called()
+
+    def test_custom_id_registers_with_model_file(self):
+        import qwen3_embed
+
+        with patch.object(qwen3_embed.TextCrossEncoder, "add_custom_model") as mock_add:
+            with patch("mnemo_mcp.server.settings") as mock_settings:
+                mock_settings.local_rerank_model_file = "onnx/model_quantized.onnx"
+
+                _maybe_register_custom_rerank("Org/custom-reranker")
+
+            mock_add.assert_called_once()
+            description = mock_add.call_args.args[0]
+            assert description.model == "Org/custom-reranker"
+            assert description.model_file == "onnx/model_quantized.onnx"
+            assert description.sources.hf == "Org/custom-reranker"

--- a/uv.lock
+++ b/uv.lock
@@ -1076,7 +1076,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b4"
+version = "2.3.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1126,7 +1126,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
-    { name = "qwen3-embed", specifier = ">=1.12.0b1" },
+    { name = "qwen3-embed", specifier = ">=1.12.0b2" },
     { name = "sqlite-vec" },
     { name = "tiktoken", specifier = ">=0.13.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "qwen3-embed"
-version = "1.12.0b1"
+version = "1.12.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1768,9 +1768,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/80/fbbd7adf445a547fd4119e58b2c352b8c921df2028727453aba81c57bd0b/qwen3_embed-1.12.0b1.tar.gz", hash = "sha256:b3949f6df0e634eba5c343b04a120699122eb0b1e840a78e9117c1f6804d8580", size = 203461, upload-time = "2026-06-12T11:19:37.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/b1/20c225672a262c9facb1301dc9166e6be6dbb07a15990d2e205408afd0dd/qwen3_embed-1.12.0b2.tar.gz", hash = "sha256:ec39c0b9c270646b4ec4285df0d0ff9bec0ce916bd71967c73111d6a3a72553c", size = 204642, upload-time = "2026-06-12T12:41:00.208Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/b3/42c80b5789441061acb449eb743ae5762b7154e9c19f259ef851707fb231/qwen3_embed-1.12.0b1-py3-none-any.whl", hash = "sha256:c00fc1ef8070f1615e803926bbda4a3050bbfdcf9282c974b192591d554e6444", size = 64546, upload-time = "2026-06-12T11:19:36.324Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f8/95bbbdbfe1b7fff17d72c6264de3920b944607d2c334357039aa15370b17/qwen3_embed-1.12.0b2-py3-none-any.whl", hash = "sha256:1b0a6971047dccf6e5e29fd724b247cfccbcdad4df4c68c93082f920391915c6", size = 65310, upload-time = "2026-06-12T12:41:01.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
@
## What
Completes the BYO consumer story for **rerankers** (the embedding side shipped earlier). `LOCAL_RERANK_MODEL` could already select a different reranker id, but a non-built-in id was never registered with qwen3-embed — so loading it raised "model not supported".

- New `_maybe_register_custom_rerank(model_id)` (mirrors `_maybe_register_custom_embed`): registers a non-builtin `LOCAL_RERANK_MODEL` via `qwen3_embed.CustomRerankerSpec` before the local reranker initializes (wrapped in the existing init try-block).
- Companion env `LOCAL_RERANK_MODEL_FILE` (default `onnx/model.onnx`). A cross-encoder needs no dim/pooling.
- Built-in `n24q02m/Qwen3-Reranker-*` ids are left untouched.
- Bump `qwen3-embed>=1.12.0b2` (adds `CustomRerankerSpec`).

## Tests
2 new tests in `tests/test_server.py` (builtin-skip / registers). Lint + ty green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@