### PR TITLE
fix: make BYO embedding registration tolerant of re-init

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -54,15 +54,20 @@ def _maybe_register_custom_embed(model_id: str) -> None:
     if dim <= 0:
         dim = _DEFAULT_EMBEDDING_DIMS
 
-    CustomModelSpec(
-        model_id=model_id,
-        hf=model_id,
-        model_file=settings.local_embedding_model_file,
-        dim=dim,
-        pooling=settings.local_embedding_pooling,
-        normalization=settings.local_embedding_normalize,
-    ).register()
-    logger.info(f"Registered custom local embedding model: {model_id}")
+    try:
+        CustomModelSpec(
+            model_id=model_id,
+            hf=model_id,
+            model_file=settings.local_embedding_model_file,
+            dim=dim,
+            pooling=settings.local_embedding_pooling,
+            normalization=settings.local_embedding_normalize,
+        ).register()
+        logger.info(f"Registered custom local embedding model: {model_id}")
+    except ValueError as e:
+        # Already registered (embedding backend re-init) or invalid spec --
+        # non-fatal; the existing registration is reused.
+        logger.debug(f"Custom embedding registration skipped: {e}")
 
 
 def _maybe_register_custom_rerank(model_id: str) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -760,6 +760,25 @@ class TestMaybeRegisterCustomEmbed:
             assert mock_add.call_args.kwargs["pooling"] == PoolingType.CLS
             assert mock_add.call_args.kwargs["normalization"] is True
 
+    def test_reregistration_is_graceful(self):
+        """A second register (backend re-init) swallows 'already registered'."""
+        import qwen3_embed
+
+        with patch.object(
+            qwen3_embed.TextEmbedding,
+            "add_custom_model",
+            side_effect=ValueError("Model Org/custom-embed is already registered"),
+        ):
+            with patch("mnemo_mcp.server.settings") as mock_settings:
+                mock_settings.local_embedding_dim = 768
+                mock_settings.resolve_embedding_dims.return_value = 768
+                mock_settings.local_embedding_model_file = "onnx/model.onnx"
+                mock_settings.local_embedding_pooling = "CLS"
+                mock_settings.local_embedding_normalize = True
+
+                # Must not raise -- re-init reuses the existing registration.
+                _maybe_register_custom_embed("Org/custom-embed")
+
 
 class TestMaybeRegisterCustomRerank:
     """BYO local reranker registration (no model download)."""


### PR DESCRIPTION
@
## Problem
`_maybe_register_custom_embed` (shipped in B1, #774) had the same latent bug just fixed for the reranker helper (#781): `CustomModelSpec.register()` ran with no guard, so a second embedding-backend init (re-configure) raised `"already registered"`. `_init_embedding_backend` caught that in its broad `except` and mislogged it as an init failure -- aborting custom-embedding re-init.

Surfaced while fixing the reranker twin; fixing now (same root cause, same one-line fix) rather than deferring.

## Fix
Wrap registration in `try/except ValueError` so re-registration is a graceful no-op reusing the existing entry. Mirrors `wet-mcp` (which already guarded) + the reranker helper.

## Tests
New `test_reregistration_is_graceful`. Full suite `1299 passed, 5 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@