### PR TITLE
fix: type-safe entity ID accumulation in upsert_entities

### DIFF
--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -192,8 +192,9 @@ def upsert_entities(conn, entities: list[dict]) -> list[str]:
     """Insert or update entities. Returns list of entity IDs."""
     now = datetime.now(UTC).isoformat()
 
-    unique_ents = {}
-    ordered_ents = []
+    unique_ents: dict[tuple[str, str], str] = {}
+    ordered_ents: list[tuple[str, str]] = []
+    unique_keys: list[tuple[str, str]] = []
 
     for ent in entities:
         name = ent.get("name", "").strip()
@@ -203,12 +204,13 @@ def upsert_entities(conn, entities: list[dict]) -> list[str]:
         key = (name, etype)
         ordered_ents.append(key)
         if key not in unique_ents:
-            unique_ents[key] = None
+            # Reserve the slot now; the real ID is filled in after the bulk
+            # SELECT below. Tracked separately in unique_keys to preserve order.
+            unique_ents[key] = ""
+            unique_keys.append(key)
 
     if not ordered_ents:
         return []
-
-    unique_keys = list(unique_ents.keys())
 
     # Use UPSERT (INSERT ... ON CONFLICT) for bulk write in one pass.
     # This eliminates N+1 SELECTs and conditional INSERT/UPDATE overhead.


### PR DESCRIPTION
## What
`ty check` fails on `src/mnemo_mcp/graph.py:237`: `upsert_entities` declares `-> list[str]` but the `None`-seeded `unique_ents` dict makes the final comprehension infer `list[str | None | Unknown]`.

## Fix
Replace the `None` placeholder with a typed `dict[tuple[str, str], str]` (empty-string sentinel) and track ordered unique keys in a parallel `unique_keys` list. Runtime behavior is unchanged: every reserved slot is overwritten by its real ID from the bulk SELECT before the function returns.

## Why now
This latent type gap is surfaced by the `ty` version bump in the lock-file-maintenance PR (#786), which reddens `Lint & Test` on all platforms. Fixing the root cause here unblocks that PR and keeps main green when the bump lands.

## Verification
- `uv run --no-sync ty check` -> All checks passed
- `uv run --no-sync ruff check` / `ruff format --check` -> clean
- `pytest -k "entit or graph or upsert"` -> 117 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)