### PR TITLE
fix: clarify embedding-model switch requires reindex (B2 guard)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Khong co prefix (khac voi cac project khac):
 
 1. **Cloud** (`EMBEDDING_MODELS` chain) -- thu lan luot theo thu tu, fallback qua litellm.
 2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available
-- Tat ca embeddings luu tai 768 dims. Doi provider khong break vector table.
+- Tat ca embeddings luu tai 768 dims. Doi embedding MODEL = doi vector space -> B2 identity guard chan boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo; KHONG cho mix vector 2 model khac nhau (cung dims van rac search).
 
 ## CD Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Khong co prefix (khac voi cac project khac):
 
 1. **Cloud** (`EMBEDDING_MODELS` chain) -- thu lan luot theo thu tu, fallback qua litellm.
 2. **Local** -- Qwen3-Embedding-0.6B ONNX, dung khi chain rong, zero config, luon available
-- Tat ca embeddings luu tai 768 dims. Doi provider khong break vector table.
+- Tat ca embeddings luu tai 768 dims. Doi embedding MODEL = doi vector space -> B2 identity guard chan boot (set REINDEX_ON_MODEL_CHANGE=true de re-embed). 768-dim chung chi giu table khong vo; KHONG cho mix vector 2 model khac nhau (cung dims van rac search).
 
 ## CD Pipeline
 


### PR DESCRIPTION
The CLAUDE.md/AGENTS.md note "switching backend does NOT invalidate existing vectors" / "doi provider khong lam hu vector table" is misleading: it is true for the table *schema* (fixed 768 dims) but omits that switching the embedding **model** changes the vector space. The B2 identity guard blocks boot on model change (different model = different space, same dims still corrupts search) and requires `REINDEX_ON_MODEL_CHANGE=true` to re-embed. This clarifies the note in both CLAUDE.md and AGENTS.md.