### PR TITLE
[TEST] Untested MemoryDB.rrf_fuse function

### DIFF
--- a/coverage_output.txt
+++ b/coverage_output.txt
@@ -1,0 +1,25 @@
+============================= test session starts ==============================
+platform linux -- Python 3.13.12, pytest-9.0.3, pluggy-1.6.0
+rootdir: /app
+configfile: pyproject.toml
+plugins: cov-7.1.0, anyio-4.13.0, asyncio-1.4.0, syrupy-5.3.2, xdist-3.8.0, timeout-2.4.0
+asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
+timeout: 30.0s
+timeout method: signal
+timeout func_only: False
+collected 6 items
+
+tests/test_db_rrf.py ......
+ERROR: Coverage failure: total of 9 is less than fail-under=95
+                                                                         [100%]
+
+================================ tests coverage ================================
+_______________ coverage: platform linux, python 3.13.12-final-0 _______________
+
+Name                  Stmts   Miss Branch BrPart  Cover   Missing
+-----------------------------------------------------------------
+src/mnemo_mcp/db.py     665    587    220      0     9%   44-56, 61, 78-86, 128-171, 180-191, 201, 210-218, 222, 240-283, 292-294, 304-310, 314-381, 399-407, 447, 475-510, 515, 533-561, 611-684, 697-708, 733-757, 807-904, 922-938, 959-1034, 1045-1050, 1054-1055, 1087-1131, 1135-1146, 1162-1193, 1197-1200, 1217-1272, 1276-1287, 1291-1301, 1317-1341, 1345-1348, 1352-1368, 1374-1415, 1421-1432, 1444-1460, 1480-1505, 1535-1581, 1591-1636, 1647-1681, 1685-1717, 1721-1728, 1732, 1749-1802, 1819-1871, 1879-1887, 1896-1910
+-----------------------------------------------------------------
+TOTAL                   665    587    220      0     9%
+FAIL Required test coverage of 95.0% not reached. Total coverage: 9.27%
+============================== 6 passed in 0.15s ===============================

--- a/tests/test_db_rrf.py
+++ b/tests/test_db_rrf.py
@@ -1,0 +1,70 @@
+import pytest
+
+from mnemo_mcp.db import MemoryDB
+
+
+def test_rrf_fuse_empty():
+    """Test RRF fusion with empty lists."""
+    assert MemoryDB.rrf_fuse([], []) == []
+
+
+def test_rrf_fuse_single_list():
+    """Test RRF fusion when only one list has results."""
+    # k=60 (default)
+    # rank 1 score: 1 / (60 + 1) = 1/61
+    results = MemoryDB.rrf_fuse(["a"], [])
+    assert results == [("a", 1 / 61)]
+
+    results = MemoryDB.rrf_fuse([], ["b"])
+    assert results == [("b", 1 / 61)]
+
+
+def test_rrf_fuse_non_overlapping():
+    """Test RRF fusion with non-overlapping result sets."""
+    # fts: a (rank 1) -> 1/61
+    # vec: b (rank 1) -> 1/61
+    results = MemoryDB.rrf_fuse(["a"], ["b"])
+    # Sort order for same score is stable by input order in dict,
+    # but we should check the content.
+    assert set(results) == {("a", 1 / 61), ("b", 1 / 61)}
+
+
+def test_rrf_fuse_overlapping():
+    """Test RRF fusion with overlapping result sets."""
+    # fts: a (1), b (2)
+    # vec: b (1), c (2)
+    # a: 1/(60+1) = 1/61
+    # b: 1/(60+2) + 1/(60+1) = 1/62 + 1/61
+    # c: 1/(60+2) = 1/62
+    results = MemoryDB.rrf_fuse(["a", "b"], ["b", "c"])
+    assert results[0][0] == "b"
+    assert results[0][1] == pytest.approx(1 / 61 + 1 / 62)
+    assert results[1][0] == "a"
+    assert results[1][1] == pytest.approx(1 / 61)
+    assert results[2][0] == "c"
+    assert results[2][1] == pytest.approx(1 / 62)
+
+
+def test_rrf_fuse_custom_k():
+    """Test RRF fusion with a custom k value."""
+    # k=10
+    # a: 1/(10+1) + 1/(10+1) = 2/11
+    results = MemoryDB.rrf_fuse(["a"], ["a"], k=10)
+    assert results == [("a", 2 / 11)]
+
+
+def test_rrf_fuse_ranking_order():
+    """Test RRF fusion ranking order logic."""
+    fts = ["a", "b", "c"]
+    vec = ["c", "b", "a"]
+    # a: 1/61 + 1/63
+    # b: 1/62 + 1/62 = 2/62
+    # c: 1/63 + 1/61
+    # 1/61 + 1/63 > 2/62
+    results = MemoryDB.rrf_fuse(fts, vec)
+    assert len(results) == 3
+    assert results[0][0] in ("a", "c")
+    assert results[1][0] in ("a", "c")
+    assert results[2][0] == "b"
+    assert results[0][1] == results[1][1]
+    assert results[0][1] > results[2][1]


### PR DESCRIPTION
Added comprehensive unit tests for the Reciprocal Rank Fusion (RRF) logic in MemoryDB. The tests cover empty input lists, single-sided result sets, non-overlapping IDs, overlapping IDs with rank-based scoring verification, and custom smoothing constant (k). These tests ensure the mathematical correctness of the hybrid search fusion algorithm.

---
*PR created automatically by Jules for task [13522179097107636087](https://jules.google.com/task/13522179097107636087) started by @n24q02m*