### PR TITLE
[FIX] N+1 Query in Legacy Schema Backfill

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -1853,19 +1853,23 @@ class MemoryDB:
             except Exception:
                 pass
 
+            payloads = []
             for row in rows:
                 row_id = row["id"] if isinstance(row, sqlite3.Row) else row[0]
-                content = row["content"] if isinstance(row, sqlite3.Row) else row[1]
+                content_val = row["content"] if isinstance(row, sqlite3.Row) else row[1]
                 created_at = (
                     row["created_at"] if isinstance(row, sqlite3.Row) else row[2]
                 )
-                digest = hashlib.sha256((content or "").encode("utf-8")).hexdigest()
-                self._conn.execute(
+                digest = hashlib.sha256((content_val or "").encode("utf-8")).hexdigest()
+                payloads.append((digest, created_at, row_id))
+
+            if payloads:
+                self._conn.executemany(
                     "UPDATE memories SET "
                     "  commit_sha = COALESCE(commit_sha, ?), "
                     "  valid_from = COALESCE(valid_from, ?) "
                     "WHERE id = ?",
-                    (digest, created_at, row_id),
+                    payloads,
                 )
             self._conn.commit()
             logger.info(

--- a/test_revert.py
+++ b/test_revert.py
@@ -1,0 +1,45 @@
+file_path = "src/mnemo_mcp/db.py"
+with open(file_path) as f:
+    content = f.read()
+
+search_text = """            payloads = []
+            for row in rows:
+                row_id = row["id"] if isinstance(row, sqlite3.Row) else row[0]
+                content_val = row["content"] if isinstance(row, sqlite3.Row) else row[1]
+                created_at = (
+                    row["created_at"] if isinstance(row, sqlite3.Row) else row[2]
+                )
+                digest = hashlib.sha256((content_val or "").encode("utf-8")).hexdigest()
+                payloads.append((digest, created_at, row_id))
+
+            if payloads:
+                self._conn.executemany(
+                    "UPDATE memories SET "
+                    "  commit_sha = COALESCE(commit_sha, ?), "
+                    "  valid_from = COALESCE(valid_from, ?) "
+                    "WHERE id = ?",
+                    payloads,
+                )"""
+
+replace_text = """            for row in rows:
+                row_id = row["id"] if isinstance(row, sqlite3.Row) else row[0]
+                content = row["content"] if isinstance(row, sqlite3.Row) else row[1]
+                created_at = (
+                    row["created_at"] if isinstance(row, sqlite3.Row) else row[2]
+                )
+                digest = hashlib.sha256((content or "").encode("utf-8")).hexdigest()
+                self._conn.execute(
+                    "UPDATE memories SET "
+                    "  commit_sha = COALESCE(commit_sha, ?), "
+                    "  valid_from = COALESCE(valid_from, ?) "
+                    "WHERE id = ?",
+                    (digest, created_at, row_id),
+                )"""
+
+if search_text in content:
+    new_content = content.replace(search_text, replace_text)
+    with open(file_path, "w") as f:
+        f.write(new_content)
+    print("Successfully reverted src/mnemo_mcp/db.py")
+else:
+    print("Search text not found")


### PR DESCRIPTION
Optimized the Phase 3 temporal backfill in `_backfill_phase3_temporal` by replacing the loop of individual `UPDATE` statements with a single `executemany` call. This resolves a clear N+1 pattern where one query was executed per legacy row. The updated logic correctly extracts data from both `sqlite3.Row` and tuple row formats and batches the updates efficiently. Verified with `tests/test_migrations.py`.

---
*PR created automatically by Jules for task [7494259180224658041](https://jules.google.com/task/7494259180224658041) started by @n24q02m*