### PR TITLE
[TEST] Untested credential_state.py set_current_sub

### DIFF
--- a/tests/test_credential_state_sub_coverage.py
+++ b/tests/test_credential_state_sub_coverage.py
@@ -1,0 +1,33 @@
+from contextvars import copy_context
+
+from mnemo_mcp.credential_state import get_current_sub, set_current_sub
+
+
+def test_current_sub_defaults_to_none():
+    """Verify that the current sub defaults to None."""
+    assert get_current_sub() is None
+
+
+def test_set_current_sub():
+    """Verify that set_current_sub updates the contextvar."""
+    set_current_sub("user_123")
+    assert get_current_sub() == "user_123"
+    set_current_sub(None)
+    assert get_current_sub() is None
+
+
+def test_current_sub_isolation():
+    """Verify that contextvars isolation works as expected."""
+
+    def run_in_context():
+        set_current_sub("context_user")
+        assert get_current_sub() == "context_user"
+
+    # Before running in context
+    assert get_current_sub() is None
+
+    ctx = copy_context()
+    ctx.run(run_in_context)
+
+    # After running in context (should still be None in the main context)
+    assert get_current_sub() is None


### PR DESCRIPTION
Added `tests/test_credential_state_sub_coverage.py` to provide 100% test coverage for the `set_current_sub` and `get_current_sub` functions in `src/mnemo_mcp/credential_state.py`. These functions are critical for per-request user isolation in multi-user HTTP mode. The tests verify the default state, basic setter/getter functionality, and context isolation using `contextvars`.

---
*PR created automatically by Jules for task [4338724265035838751](https://jules.google.com/task/4338724265035838751) started by @n24q02m*