### PR TITLE
[TEST] Fix untested add_memory tool and entity history handler

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1215,10 +1215,10 @@ async def _handle_consolidate(
 
 @mcp.tool(
     description=(
-        "Store NEW information. Use for preferences, decisions, facts.\n"
+        "Store new information in the persistent memory graph.\n"
         "\n"
         "ACTION GUIDE — when to use:\n"
-        "- Use when saving new information for the first time.\n"
+        "- Use when saving new facts, preferences, constraints, or context.\n"
         "  Example: content='User prefers dark mode', category='preference', tags=['ui']"
     ),
     annotations=ToolAnnotations(

--- a/tests/test_add_memory_tool_coverage.py
+++ b/tests/test_add_memory_tool_coverage.py
@@ -1,0 +1,135 @@
+"""Coverage tests for add_memory tool and _handle_add/history in server.py."""
+
+import json
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.server import _handle_add, _handle_history, add_memory
+
+
+@pytest.fixture
+def mock_ctx(tmp_path):
+    """Mock MCP Context with DB."""
+    db = MemoryDB(tmp_path / "test_add.db", embedding_dims=0)
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {
+        "db": db,
+        "embedding_model": None,
+        "embedding_dims": 0,
+    }
+    yield ctx, db
+    db.close()
+
+
+class TestAddMemoryCoverage:
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_add_memory_wrapper(self, _mock_thread, mock_ctx):
+        """Verify add_memory tool wrapper calls _handle_add."""
+        ctx, db = mock_ctx
+        result = await add_memory(content="wrapper test", ctx=ctx)
+        data = json.loads(result)
+        assert data["status"] == "saved"
+        assert data["id"]
+
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_handle_add_success(self, _mock_thread, mock_ctx):
+        """Verify _handle_add with full metadata."""
+        ctx, db = mock_ctx
+        result = await _handle_add(
+            ctx, content="full metadata", category="test", tags=["a", "b"]
+        )
+        data = json.loads(result)
+        assert data["status"] == "saved"
+        assert data["category"] == "test"
+
+        # Verify it's actually in DB
+        mem = db.get(data["id"])
+        assert mem["content"] == "full metadata"
+        assert mem["category"] == "test"
+        assert json.loads(mem["tags"]) == ["a", "b"]
+
+    async def test_handle_add_missing_content(self, mock_ctx):
+        """Verify error when content is missing (covers line 443)."""
+        ctx, db = mock_ctx
+        result = await _handle_add(ctx, content="")
+        data = json.loads(result)
+        assert "error" in data
+        assert "content is required" in data["error"]
+
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_handle_add_dedup_warning(self, _mock_thread, mock_ctx):
+        """Verify dedup warnings (covers lines 460-462)."""
+        ctx, db = mock_ctx
+
+        # Mock check_duplicate to return a duplicate warning
+        with patch.object(db, "check_duplicate") as mock_check:
+            mock_check.return_value = {"duplicate": True, "id": "old-id"}
+            result = await _handle_add(ctx, content="duplicate content")
+            data = json.loads(result)
+            assert data["dedup_warning"] == {"duplicate": True, "id": "old-id"}
+
+        # Mock check_duplicate to return a similar warning
+        with patch.object(db, "check_duplicate") as mock_check:
+            mock_check.return_value = {"similar": True, "id": "sim-id"}
+            result = await _handle_add(ctx, content="similar content")
+            data = json.loads(result)
+            assert data["dedup_warning"] == {"similar": True, "id": "sim-id"}
+
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_handle_add_dedup_exception(self, _mock_thread, mock_ctx):
+        """Verify dedup exception handling (covers lines 461-462)."""
+        ctx, db = mock_ctx
+        with patch.object(db, "check_duplicate", side_effect=Exception("Dedup boom")):
+            with patch("mnemo_mcp.server.logger") as mock_logger:
+                result = await _handle_add(ctx, content="dedup exception test")
+                data = json.loads(result)
+                assert data["status"] == "saved"
+                mock_logger.warning.assert_called()
+
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_handle_add_value_error(self, _mock_thread, mock_ctx):
+        """Verify ValueError handling (covers lines 496-501)."""
+        ctx, db = mock_ctx
+        with patch.object(db, "add", side_effect=ValueError("Test value error")):
+            result = await _handle_add(ctx, content="test content")
+            data = json.loads(result)
+            assert data["error"] == "Test value error"
+
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_handle_add_unexpected_exception(self, _mock_thread, mock_ctx):
+        """Verify unexpected Exception handling (covers lines 502-508)."""
+        ctx, db = mock_ctx
+        with patch.object(db, "add", side_effect=Exception("Unexpected boom")):
+            result = await _handle_add(ctx, content="test content")
+            data = json.loads(result)
+            assert "Internal error" in data["error"]
+
+    @patch("mnemo_mcp.server._enrich_memory", new_callable=AsyncMock)
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_handle_add_triggers_enrich(self, _mock_thread, mock_enrich, mock_ctx):
+        """Verify background enrichment is triggered."""
+        ctx, db = mock_ctx
+        await _handle_add(ctx, content="trigger enrich")
+        mock_enrich.assert_called_once()
+
+    async def test_handle_history_missing_entity_id(self, mock_ctx):
+        """Verify error when entity_id is missing in _handle_history (covers line 1117)."""
+        ctx, db = mock_ctx
+        result = await _handle_history(ctx, entity_id=None)
+        data = json.loads(result)
+        assert "error" in data
+        assert "entity_id required" in data["error"]
+
+    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    async def test_handle_history_success(self, _mock_thread, mock_ctx):
+        """Verify _handle_history success case (covers lines 1124-1127)."""
+        ctx, db = mock_ctx
+        # We need to mock history_for_entity because it's imported inside the function
+        with patch("mnemo_mcp.temporal.queries.history_for_entity", return_value=[{"id": "mem1"}]):
+            result = await _handle_history(ctx, entity_id="ent1")
+            data = json.loads(result)
+            assert data["entity_id"] == "ent1"
+            assert data["count"] == 1

--- a/tests/test_add_memory_tool_coverage.py
+++ b/tests/test_add_memory_tool_coverage.py
@@ -1,7 +1,6 @@
 """Coverage tests for add_memory tool and _handle_add/history in server.py."""
 
 import json
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,7 +24,10 @@ def mock_ctx(tmp_path):
 
 
 class TestAddMemoryCoverage:
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
     async def test_add_memory_wrapper(self, _mock_thread, mock_ctx):
         """Verify add_memory tool wrapper calls _handle_add."""
         ctx, db = mock_ctx
@@ -34,7 +36,10 @@ class TestAddMemoryCoverage:
         assert data["status"] == "saved"
         assert data["id"]
 
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
     async def test_handle_add_success(self, _mock_thread, mock_ctx):
         """Verify _handle_add with full metadata."""
         ctx, db = mock_ctx
@@ -59,7 +64,10 @@ class TestAddMemoryCoverage:
         assert "error" in data
         assert "content is required" in data["error"]
 
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
     async def test_handle_add_dedup_warning(self, _mock_thread, mock_ctx):
         """Verify dedup warnings (covers lines 460-462)."""
         ctx, db = mock_ctx
@@ -78,7 +86,10 @@ class TestAddMemoryCoverage:
             data = json.loads(result)
             assert data["dedup_warning"] == {"similar": True, "id": "sim-id"}
 
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
     async def test_handle_add_dedup_exception(self, _mock_thread, mock_ctx):
         """Verify dedup exception handling (covers lines 461-462)."""
         ctx, db = mock_ctx
@@ -89,7 +100,10 @@ class TestAddMemoryCoverage:
                 assert data["status"] == "saved"
                 mock_logger.warning.assert_called()
 
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
     async def test_handle_add_value_error(self, _mock_thread, mock_ctx):
         """Verify ValueError handling (covers lines 496-501)."""
         ctx, db = mock_ctx
@@ -98,7 +112,10 @@ class TestAddMemoryCoverage:
             data = json.loads(result)
             assert data["error"] == "Test value error"
 
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
     async def test_handle_add_unexpected_exception(self, _mock_thread, mock_ctx):
         """Verify unexpected Exception handling (covers lines 502-508)."""
         ctx, db = mock_ctx
@@ -108,8 +125,13 @@ class TestAddMemoryCoverage:
             assert "Internal error" in data["error"]
 
     @patch("mnemo_mcp.server._enrich_memory", new_callable=AsyncMock)
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
-    async def test_handle_add_triggers_enrich(self, _mock_thread, mock_enrich, mock_ctx):
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
+    async def test_handle_add_triggers_enrich(
+        self, _mock_thread, mock_enrich, mock_ctx
+    ):
         """Verify background enrichment is triggered."""
         ctx, db = mock_ctx
         await _handle_add(ctx, content="trigger enrich")
@@ -123,12 +145,18 @@ class TestAddMemoryCoverage:
         assert "error" in data
         assert "entity_id required" in data["error"]
 
-    @patch("mnemo_mcp.server.asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw))
+    @patch(
+        "mnemo_mcp.server.asyncio.to_thread",
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+    )
     async def test_handle_history_success(self, _mock_thread, mock_ctx):
         """Verify _handle_history success case (covers lines 1124-1127)."""
         ctx, db = mock_ctx
         # We need to mock history_for_entity because it's imported inside the function
-        with patch("mnemo_mcp.temporal.queries.history_for_entity", return_value=[{"id": "mem1"}]):
+        with patch(
+            "mnemo_mcp.temporal.queries.history_for_entity",
+            return_value=[{"id": "mem1"}],
+        ):
             result = await _handle_history(ctx, entity_id="ent1")
             data = json.loads(result)
             assert data["entity_id"] == "ent1"

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -429,7 +429,7 @@ class TestImportJsonlEdgeCases:
     def test_import_invalid_type(self, tmp_db: MemoryDB):
         """Import with unsupported type returns empty result."""
         invalid_input: Any = 12345
-        result = tmp_db.import_jsonl(invalid_input, mode="merge")  # ty: ignore[invalid-argument-type]
+        result = tmp_db.import_jsonl(invalid_input, mode="merge")
         assert result["imported"] == 0
         assert result["skipped"] == 0
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -96,7 +96,7 @@ async def session(request, tmp_path):
     errlog_kwargs = {"errlog": capture} if capture else {}
 
     try:
-        async with stdio_client(params, **errlog_kwargs) as (read_stream, write_stream):  # ty: ignore[invalid-argument-type]
+        async with stdio_client(params, **errlog_kwargs) as (read_stream, write_stream):
             async with ClientSession(read_stream, write_stream) as s:
                 if setup_mode == "relay" and capture:
                     # mnemo-mcp auto-triggers relay during lifespan,


### PR DESCRIPTION
This PR addresses the issue of untested `add_memory` tool and `_handle_history` logic in `src/mnemo_mcp/server.py`.

Changes:
- Updated the description of `add_memory` tool in `src/mnemo_mcp/server.py` to match the issue requirement.
- Added a new test file `tests/test_add_memory_tool_coverage.py` that achieves high coverage for `_handle_add` and covers the missing `entity_id` check in `_handle_history`.
- Fixed unused type ignore comments in `tests/test_db_coverage.py` and `tests/test_e2e.py` to pass `ty check`.

---
*PR created automatically by Jules for task [7753664775101133925](https://jules.google.com/task/7753664775101133925) started by @n24q02m*