### PR TITLE
fix: correct credential storage and relay setup docs to match runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ src/mnemo_mcp/
   embedder.py      # Dual-backend: multi-provider cloud (Jina/Gemini/OpenAI/Cohere) + qwen3-embed local
   reranker.py      # Dual-backend reranking: cloud (Jina/Cohere) + local (qwen3-embed cross-encoder)
   graph.py         # Knowledge graph: entity/relation extraction via LLM
-  relay_setup.py   # Zero-config relay: create session, poll for config
+  relay_setup.py   # Legacy ECDH relay client (ensure_config); no live caller -- HTTP setup uses the OAuth-AS browser form at <PUBLIC_URL>/authorize
   relay_schema.py  # Relay form schema (local + cloud modes)
   sync/            # Sync backends: gdrive.py (OAuth Device Code, httpx) + s3.py (R2/B2/MinIO) + delta/bundle/base
   token_store.py   # OAuth token storage (secure file-based, chmod 600)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ src/mnemo_mcp/
   embedder.py      # Dual-backend: multi-provider cloud (Jina/Gemini/OpenAI/Cohere) + qwen3-embed local
   reranker.py      # Dual-backend reranking: cloud (Jina/Cohere) + local (qwen3-embed cross-encoder)
   graph.py         # Knowledge graph: entity/relation extraction via LLM
-  relay_setup.py   # Zero-config relay: create session, poll for config
+  relay_setup.py   # Legacy ECDH relay client (ensure_config); no live caller -- HTTP setup uses the OAuth-AS browser form at <PUBLIC_URL>/authorize
   relay_schema.py  # Relay form schema (local + cloud modes)
   sync/            # Sync backends: gdrive.py (OAuth Device Code, httpx) + s3.py (R2/B2/MinIO) + delta/bundle/base
   token_store.py   # OAuth token storage (secure file-based, chmod 600)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -381,12 +381,12 @@ inspect divergence without losing the local change.
 The relay form collects `SYNC_PASSPHRASE` as a single password input.
 Before persistence, `credential_state._harden_passphrase` swaps it for
 `SYNC_PASSPHRASE_SALT` + `SYNC_PASSPHRASE_HASH` (Argon2id-derived hex).
-The raw passphrase NEVER lands in `config.enc`; the user must supply it
+The raw passphrase NEVER lands in `config.json`; the user must supply it
 again per session (env var in stdio mode, relay form in HTTP mode).
 
 Verification uses `bundle.verify_passphrase` which is constant-time
 (`hmac.compare_digest`) so timing attacks cannot leak digest contents.
-A leaked `config.enc` exposes only the Argon2id digest (which still
+A leaked `config.json` exposes only the Argon2id digest (which still
 needs to be brute-forced against the 64 MiB / 3-iter Argon2id cost).
 
 ### Background sync scheduler

--- a/docs/passport.md
+++ b/docs/passport.md
@@ -36,7 +36,7 @@ Resolution rule (`sync.resolve_active_backend`):
   Device Code flow for the end-user's Google account.
 
 Env var takes precedence over the pydantic field so an operator can
-override a persisted bucket from `config.enc` without rewriting it.
+override a persisted bucket from `config.json` without rewriting it.
 
 ### Per-mode runbook
 
@@ -70,7 +70,7 @@ docker run \
 ```
 
 The `SYNC_PASSPHRASE` env var lives ONLY in the container process — it
-is hashed via Argon2id for any persisted `config.enc` record. No
+is hashed via Argon2id for any persisted `config.json` record. No
 end-user input is needed for passport sync in S3 mode.
 
 ### Switching modes (local → prod migration)
@@ -125,7 +125,7 @@ sync mode.
    var (stdio mode).
 2. **Argon2id-hashed** by `credential_state._harden_passphrase` before
    persistence. Only the hash (`SYNC_PASSPHRASE_SALT` +
-   `SYNC_PASSPHRASE_HASH`) lands in `config.enc`. The raw passphrase
+   `SYNC_PASSPHRASE_HASH`) lands in `config.json`. The raw passphrase
    never touches disk.
 3. **Verified** on each sync via `bundle.verify_passphrase` (constant-
    time `hmac.compare_digest`).
@@ -135,7 +135,7 @@ sync mode.
    state without touching remote bundles.
 
 This is by design: a recovery path would also let an attacker decrypt
-your bundles if they obtained either backend access or `config.enc`.
+your bundles if they obtained either backend access or `config.json`.
 
 ## Delta vs full sync
 

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -18,7 +18,7 @@ Active actions: `status`, `sync`, `set`, `warmup`, `setup_sync`,
 > require `SYNC_PASSPHRASE` to be set in the process environment (stdio
 > mode) or supplied via the relay form passphrase field (HTTP mode). The
 > raw passphrase is held in process memory only; only the
-> Argon2id-derived hash lands in `config.enc`.
+> Argon2id-derived hash lands in `config.json`.
 
 ### `status` - Show current configuration
 
@@ -264,7 +264,7 @@ Configure via environment variables before starting the server:
 | `COMPRESSION_ENABLED` | `true` | Enable LLM compression on capture |
 | `COMPRESSION_PROVIDER` | (auto) | Explicit provider override (gemini/openai/anthropic/xai) |
 | `COMPRESSION_MODEL` | (auto) | Explicit model override |
-| `SYNC_BACKEND` | `gdrive` | **DEPRECATED (2026-05-14)**: backend now auto-resolved from `SYNC_S3_BUCKET` presence (XOR). Kept for backward compat with persisted `config.enc`. |
+| `SYNC_BACKEND` | `gdrive` | **DEPRECATED (2026-05-14)**: backend now auto-resolved from `SYNC_S3_BUCKET` presence (XOR). Kept for backward compat with persisted `config.json`. |
 | `SYNC_S3_BUCKET` | (none) | S3 bucket name. **Setting this activates S3 mode (XOR with GDrive).** Required for Method 2/3 docker deploy. |
 | `SYNC_S3_REGION` | `us-east-1` | S3 region (use `auto` for R2) |
 | `SYNC_S3_ENDPOINT` | (none) | Custom endpoint URL for R2 / B2 / MinIO |


### PR DESCRIPTION
Aligns the architecture docs with the actual runtime behavior. No code logic changes.

## Credential storage: config.enc -> config.json

Credentials are persisted via `mcp_core.storage.per_plugin_store.PerPluginStore`, which stores them at:

- `~/.mnemo-mcp/config.json` (AES-GCM, machine-bound key) for stdio / single-user
- `~/.mnemo-mcp/subs/<sub>/config.json` (AES-GCM, PBKDF2 from `CREDENTIAL_SECRET`) for multi-user

The shared `config.enc` path is deprecated and no longer written. Several docs still referenced `config.enc`:

- `docs/ARCHITECTURE.md` (passphrase storage gate) -- the trust-model table in the same file already said `config.json`, so this also fixes an internal inconsistency.
- `docs/passport.md` (passphrase lifecycle, S3 mode, backend resolution, recovery FAQ)
- `src/mnemo_mcp/docs/config.md` (passport-sync note + deprecated `SYNC_BACKEND` row)

## Relay setup note

`AGENTS.md` / `CLAUDE.md` described `relay_setup.py` as "Zero-config relay: create session, poll for config". That describes the ECDH relay client (`ensure_config` via `create_session` / `poll_for_result`), which is no longer wired at startup. The live HTTP setup UX is the OAuth-AS browser credential form served at `<PUBLIC_URL>/authorize`. The note now reflects that.