### PR TITLE
fix: drop vestigial mcp-core checkout from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Checkout mcp-core
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          repository: n24q02m/mcp-core
-          path: .mcp-core
-
-      - name: Patch pyproject.toml for CI
-        shell: bash
-        run: |
-          python3 -c "import re; content=open('pyproject.toml').read(); content=re.sub(r'path\s*=\s*[\'\"].*?mcp-core/packages/core-py[\'\"]', 'path = \".mcp-core/packages/core-py\"', content); open('pyproject.toml', 'w').write(content)"
-
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 


### PR DESCRIPTION
Removes the dead `Checkout mcp-core` + `Patch pyproject.toml for CI` steps. They no longer serve a purpose (no `[tool.uv.sources]` path to rewrite; `uv sync --no-sources` installs mcp-core from PyPI) and only caused `ty check` to type-check mcp-core main HEAD's vendored tests against the older PyPI `mcp_core`, yielding unrelated `unknown-argument` errors (PerPluginStore/JWTIssuer API drift). Local `ty check` passes clean after removal. Brings CI in line with wet-mcp/crg/imagine.