### PR TITLE
fix: bump mcp-core to 1.18.0b5 for vertex_express support

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -161,7 +161,7 @@ class Settings(BaseSettings):
     sync_s3_prefix: str = "passport/"
 
     # Phase 2: passport bundle passphrase (Argon2id-derived hash stored
-    # in encrypted config.enc; raw passphrase NEVER written to disk).
+    # in encrypted config.json; raw passphrase NEVER written to disk).
     sync_passphrase: str = ""  # set ONLY for in-process derivation
 
     # Phase 3: temporal KG.

--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -7,7 +7,7 @@ mnemo-mcp works fully in local mode (Qwen3-Embedding ONNX), so credentials
 are optional. In stdio mode, credentials are read from env vars only -- no
 local form spawn. In HTTP mode, ``run_http_server`` renders the relay schema
 form for the user to paste API keys; ``save_credentials`` persists them to
-``config.enc``. GDrive device-code progress is surfaced through
+``config.json``. GDrive device-code progress is surfaced through
 ``setup_complete_hook``.
 
 See ``~/projects/.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md``
@@ -318,14 +318,14 @@ def store_for_sub(sub: str, config: dict[str, str]) -> None:
 
 
 def save_credentials(config: dict[str, str], context: dict[str, str]) -> dict | None:
-    """Save credentials from OAuth form to config.enc and apply to environment.
+    """Save credentials from OAuth form to config.json and apply to environment.
 
     ``context`` carries the per-authorize ``sub``. In multi-user remote mode
     (``PUBLIC_URL`` set), credentials are scoped per-subject under
     ``$MNEMO_DATA_DIR/subs/<sub>/config.json`` and we skip the shared
     single-user state machine + GDrive device-code flow (each subject runs
     their own OAuth via the relay form). In single-user local mode, the
-    SQLite memory DB and optional API keys live in one shared ``config.enc``
+    SQLite memory DB and optional API keys live in one shared ``config.json``
     on the host so the subject is intentionally unused.
 
     Called by the local OAuth AS when the user submits API keys via the
@@ -375,7 +375,7 @@ def _harden_passphrase(config: dict[str, str]) -> dict[str, str]:
     swap it for ``SYNC_PASSPHRASE_SALT`` + ``SYNC_PASSPHRASE_HASH`` (both
     hex-encoded). Subsequent unlock attempts call
     :func:`mnemo_mcp.sync.bundle.verify_passphrase` against the stored
-    pair so a leaked ``config.enc`` never exposes the raw passphrase.
+    pair so a leaked ``config.json`` never exposes the raw passphrase.
 
     The raw passphrase is deliberately NOT kept in-memory beyond this
     function: the orchestrator passes the user-provided passphrase

--- a/src/mnemo_mcp/relay_setup.py
+++ b/src/mnemo_mcp/relay_setup.py
@@ -2,7 +2,7 @@
 
 Resolution order (relay only when ALL local sources are empty):
 1. ENV VARS          -- User explicitly set (highest priority, skip everything)
-2. RELAY CONFIG      -- Saved from previous relay setup (~/.config/mcp/config.enc)
+2. RELAY CONFIG      -- Saved from previous relay setup (~/.mnemo-mcp/config.json)
 3. RELAY SETUP       -- Interactive, ONLY when steps 1-2 are ALL empty (30s timeout)
 4. LOCAL MODE        -- Fallback (Qwen3-Embedding ONNX)
 """

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1968,10 +1968,10 @@ def _resolve_sync_passphrase() -> str | None:
     2. ``settings.sync_passphrase`` Pydantic value (env-driven).
 
     Note: we deliberately do NOT load the Argon2id-derived hash from
-    ``config.enc`` here - that hash is for verification only, never
+    ``config.json`` here - that hash is for verification only, never
     decryption. The user must supply the raw passphrase per session
     (HTTP relay form keeps the raw value in process memory only) so a
-    leaked ``config.enc`` cannot decrypt past bundles.
+    leaked ``config.json`` cannot decrypt past bundles.
     """
     raw = os.environ.get("SYNC_PASSPHRASE", "").strip()
     if raw:
@@ -2314,14 +2314,14 @@ async def run_http(port: int = 0) -> None:
     """Run as HTTP server with local OAuth 2.1 AS.
 
     Single-user mode (default): bind ``127.0.0.1`` and persist credentials
-    to one shared ``config.enc`` on the host.
+    to one shared ``config.json`` on the host.
 
     Multi-user remote mode (``PUBLIC_URL`` set): bind ``0.0.0.0:8080`` (or
     ``MCP_PORT``) and scope credential storage per-JWT-sub via
     ``save_credentials``. The ``MCP_DCR_SERVER_SECRET`` env var is required
     as proof of intentional multi-user deployment -- without it, refuse to
     start so a misconfigured single-user instance never accidentally
-    accepts other users' OAuth flows into the same shared ``config.enc``.
+    accepts other users' OAuth flows into the same shared ``config.json``.
     """
     from mcp_core.transport.local_server import run_http_server
 

--- a/src/mnemo_mcp/sync/__init__.py
+++ b/src/mnemo_mcp/sync/__init__.py
@@ -117,7 +117,7 @@ def resolve_active_backend() -> str:
     Pure function — no side effects, safe to call from lifespan startup,
     scheduler loop, MCP tool handlers, anywhere. The env var takes
     precedence over the pydantic field so an operator can override a
-    persisted setting without rewriting ``config.enc``.
+    persisted setting without rewriting ``config.json``.
     """
     import os as _os
 

--- a/src/mnemo_mcp/sync/bundle.py
+++ b/src/mnemo_mcp/sync/bundle.py
@@ -40,7 +40,7 @@ Passphrase handling:
   cost - matches OWASP 2024 recommendations).
 - :func:`hash_passphrase` + :func:`verify_passphrase` provide a constant-
   time gate so the relay form can store an Argon2id hash in
-  ``config.enc`` instead of the raw passphrase. The gate uses
+  ``config.json`` instead of the raw passphrase. The gate uses
   :func:`hmac.compare_digest` so timing attacks against the digest leak
   no information about the passphrase.
 """
@@ -245,10 +245,10 @@ def _unframe_payload(framed: bytes) -> dict[str, bytes]:
 
 
 def hash_passphrase(passphrase: str, salt: bytes | None = None) -> tuple[str, str]:
-    """Argon2id-hash ``passphrase`` for storage in encrypted ``config.enc``.
+    """Argon2id-hash ``passphrase`` for storage in encrypted ``config.json``.
 
     Returns ``(salt_hex, digest_hex)`` so callers can store both fields
-    in ``config.enc`` and pass them back to :func:`verify_passphrase`
+    in ``config.json`` and pass them back to :func:`verify_passphrase`
     on subsequent unlock attempts.
 
     The salt is generated fresh when ``salt`` is None (production path);
@@ -265,7 +265,7 @@ def verify_passphrase(passphrase: str, salt_hex: str, digest_hex: str) -> bool:
     """Constant-time check ``passphrase`` against a stored Argon2id digest.
 
     Returns False on any malformed input (hex parse fail, wrong length)
-    so a corrupted ``config.enc`` cannot trigger an exception that would
+    so a corrupted ``config.json`` cannot trigger an exception that would
     otherwise look like a passphrase-mismatch oracle to a calling tool.
     """
     if not passphrase:

--- a/uv.lock
+++ b/uv.lock
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b2"
+version = "1.18.0b5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1232,9 +1232,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/ed/59f51b85af63f4986918e6d76ccd7e8bb177706aeb397629d7cc76da5bcd/n24q02m_mcp_core-1.18.0b2.tar.gz", hash = "sha256:30baf5173e460ef20f1b24ac91e6310b8d7737696be033138a4b05785cb4b5a9", size = 256688, upload-time = "2026-06-11T05:07:18.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ee/982810a18e8ed8fb72bd93d0bc4cf4cea96ac3a705879ffe90739aeee767/n24q02m_mcp_core-1.18.0b5.tar.gz", hash = "sha256:05c68523b428bc5145d32d4cb6daeb2808550691956a194b399daa66b5675368", size = 274193, upload-time = "2026-06-14T04:00:56.416Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/47/1182dda7b70180245e57d5e6316940e219faf46d6692be2d8edf8d2c603d/n24q02m_mcp_core-1.18.0b2-py3-none-any.whl", hash = "sha256:905efd3e25ceb8ab6d14132a8f6e660bde6ba324bf0363342b1a5d87f09dd242", size = 139516, upload-time = "2026-06-11T05:07:19.407Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2b/dca7a6cfea2c356e0b9165a4940e6efb1cea1a099348dcb06061d7c92153/n24q02m_mcp_core-1.18.0b5-py3-none-any.whl", hash = "sha256:6640023ed5308d837b6d6e76d1431763efe9fab99a5908051971720f4bd9d9fc", size = 150469, upload-time = "2026-06-14T04:00:57.785Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bump n24q02m-mcp-core 1.18.0b2 -> 1.18.0b5 to enable the vertex_express adapter (mcp_core/llm/vertex_express.py) so the LLM_MODELS chain primary vertex_express/gemini-3.5-flash works. Verified on staging: b2 lacks vertex_express, chat falls back to xai/grok-4.3. Lock-only change.