### PR TITLE
🎨 Palette: Standardize API error responses ('hint' -> 'suggestion')

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1612,7 +1612,9 @@ async def memory(
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
             else:
-                resp["suggestion"] = "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID."
+                resp["suggestion"] = (
+                    "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID."
+                )
             return _json(resp)
 
 
@@ -1708,7 +1710,9 @@ async def config(
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
             else:
-                resp["suggestion"] = "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync."
+                resp["suggestion"] = (
+                    "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync."
+                )
             return _json(resp)
 
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1608,10 +1608,11 @@ async def memory(
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
-                "hint": "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID.",
             }
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            else:
+                resp["suggestion"] = "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID."
             return _json(resp)
 
 
@@ -1703,10 +1704,11 @@ async def config(
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
-                "hint": "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync.",
             }
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            else:
+                resp["suggestion"] = "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync."
             return _json(resp)
 
 
@@ -2003,12 +2005,11 @@ async def _handle_config_sync_now(ctx: Context | None, backend: str | None) -> s
         return _json(
             {
                 "error": "SYNC_PASSPHRASE not set",
-                "hint": (
+                "suggestion": (
                     "Set SYNC_PASSPHRASE env var (stdio mode) or submit "
                     "the relay form passphrase field (HTTP mode) before "
                     "triggering passport sync."
                 ),
-                "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
             }
         )
 
@@ -2043,11 +2044,10 @@ async def _handle_config_export_passport(ctx: Context | None) -> str:
         return _json(
             {
                 "error": "SYNC_PASSPHRASE not set",
-                "hint": (
+                "suggestion": (
                     "Set SYNC_PASSPHRASE env var or submit the relay form "
                     "passphrase before exporting a passport."
                 ),
-                "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
             }
         )
 
@@ -2071,11 +2071,10 @@ async def _handle_config_import_passport(
         return _json(
             {
                 "error": "SYNC_PASSPHRASE not set",
-                "hint": (
+                "suggestion": (
                     "Set SYNC_PASSPHRASE env var or submit the relay form "
                     "passphrase before importing a passport."
                 ),
-                "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
             }
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -342,7 +342,8 @@ class TestMemoryUnknownAction:
         assert "error" in result
         assert "valid_actions" in result
         assert "add" in result["valid_actions"]
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Common actions:" in result["suggestion"]
 
 
 class TestConfigTool:
@@ -403,7 +404,8 @@ class TestConfigTool:
         result = json.loads(await config(action="invalid", ctx=ctx))
         assert "error" in result
         assert "valid_actions" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Common actions:" in result["suggestion"]
 
     async def test_models_action_removed(self, ctx_with_db):
         """The 'models' catalog-listing action no longer exists."""

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -209,12 +209,13 @@ class TestConfigActions:
         assert "Did you mean 'sync'?" in result["suggestion"]
 
     async def test_config_unknown_action_no_match(self, ctx_with_db):
-        """Config with completely invalid action returns error without suggestion."""
+        """Config with completely invalid action returns error with default suggestion."""
         ctx, _ = ctx_with_db
         result = json.loads(await config(action="xyzxyzxyz", ctx=ctx))
         assert "error" in result
         assert "Unknown action" in result["error"]
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Common actions:" in result["suggestion"]
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b9"
+version = "2.3.0b11"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This change updates the `_handle_memory` and `_handle_config` tool handlers (including `export_passport` and `import_passport`) to consistently use the `'suggestion'` JSON key when surfacing hints/suggestions during errors, such as unknown actions or missing configurations. 

This brings the whole API payload schema into alignment, improving Developer/Agent Experience by ensuring that recovery advice is reliably accessible under a predictable key. Related unit test assertions have also been updated to check for this behavior.

---
*PR created automatically by Jules for task [751639024058481837](https://jules.google.com/task/751639024058481837) started by @n24q02m*