### PR TITLE
feat: add JSONL import/export to MemoryDBD1 for CF memory migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ package-lock.json
 .wrangler-dryrun/
 # Deploy-time config with REAL resource IDs filled in (never commit live IDs)
 wrangler.deploy.jsonc
+# Live OAuth token dumped by scripts/cf_full_flow_mnemo.py --save-only (a real JWT)
+scripts/.mnemo_cf_token
 
 # Build artifacts
 dist/

--- a/src/mnemo_mcp/db_cf.py
+++ b/src/mnemo_mcp/db_cf.py
@@ -620,5 +620,121 @@ class MemoryDBD1:
             "db_path": "cf-d1",
         }
 
+    # ------------------------------------------------------------------
+    # JSONL export / import -- parity with db.MemoryDB.export_jsonl /
+    # import_jsonl, scoped to self.sub. Export reads only this sub's rows;
+    # import writes every row under this sub (any `sub` in the payload is
+    # ignored), so a single-user dump lands under the importing session's
+    # identity (DECISION D3). This is the path the export_memories /
+    # import_memories tools take on the CF backend; without it those tools
+    # AttributeError on cf-d1 and a memory migration has no canonical route.
+    # ------------------------------------------------------------------
+
+    def export_jsonl(self) -> tuple[str, int]:
+        """Export this sub's memories as JSONL (mirrors db.py:1309 field set)."""
+        query = (
+            "SELECT json_object("
+            "'id', id, 'content', content, 'category', category, "
+            "'tags', json(tags), 'source', source, "
+            "'created_at', created_at, 'updated_at', updated_at, "
+            "'access_count', access_count, 'last_accessed', last_accessed"
+            ") AS json_data "
+            "FROM memories WHERE sub = ? ORDER BY created_at"
+        )
+        rows = self._d1.execute(query, [self.sub])
+        out = "".join(r["json_data"] + "\n" for r in rows)
+        return out, len(rows)
+
+    @staticmethod
+    def _parse_import_data(data: str | list | dict) -> tuple[list[dict], int]:
+        """Parse JSONL string / list / dict into dicts (mirrors db.py:1350)."""
+        if isinstance(data, list):
+            return data, 0
+        if isinstance(data, dict):
+            return [data], 0
+        if isinstance(data, str):
+            items: list[dict] = []
+            rejected = 0
+            for raw in data.strip().split("\n"):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    items.append(json.loads(line))
+                except Exception:
+                    rejected += 1
+            return items, rejected
+        return [], 0
+
+    def _count_rows(self) -> int:
+        rows = self._d1.execute(
+            "SELECT COUNT(*) AS n FROM memories WHERE sub = ?", [self.sub]
+        )
+        return rows[0]["n"] if rows else 0
+
+    def import_jsonl(self, data: str | list | dict, mode: str = "merge") -> dict:
+        """Import memories under self.sub (mirrors db.py:1434).
+
+        ``mode='merge'`` keeps existing ids (INSERT OR IGNORE); ``'replace'``
+        clears this sub's rows first (INSERT OR REPLACE). Rows are inserted
+        WITHOUT embeddings -- parity with the local import, which writes rows
+        only -- and FTS is trigger-maintained, so imports are immediately
+        keyword-searchable. Vectorize is left untouched: a stale vector for a
+        replaced id is harmless because search() hydrates from D1 and drops
+        vector hits with no matching row. Counts are derived from a
+        before/after row count since D1 executemany returns no rowcount.
+        """
+        items, rejected = self._parse_import_data(data)
+        now = _now_iso()
+        to_insert: list[list] = []
+        for mem in items:
+            try:
+                content = mem.get("content", "")
+                if not content or len(content) > MAX_CONTENT_LENGTH:
+                    rejected += 1
+                    continue
+                tags = mem.get("tags", [])
+                tags_json = (
+                    "[]"
+                    if tags == []
+                    else (json.dumps(tags) if isinstance(tags, list) else tags)
+                )
+                to_insert.append(
+                    [
+                        mem.get("id", uuid.uuid4().hex),
+                        self.sub,
+                        content,
+                        mem.get("category", "general"),
+                        tags_json,
+                        mem.get("source"),
+                        mem.get("created_at", now),
+                        mem.get("updated_at", now),
+                        mem.get("access_count", 0),
+                        mem.get("last_accessed", now),
+                        mem.get("importance", 0.5),
+                    ]
+                )
+            except Exception:
+                rejected += 1
+
+        if mode == "replace":
+            self._d1.execute("DELETE FROM memories WHERE sub = ?", [self.sub])
+        before = self._count_rows()
+        if to_insert:
+            op = "REPLACE" if mode == "replace" else "IGNORE"
+            self._d1.executemany(
+                f"INSERT OR {op} INTO memories "
+                "(id, sub, content, category, tags, source, "
+                "created_at, updated_at, access_count, last_accessed, importance) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                to_insert,
+            )
+        after = self._count_rows()
+        imported = after - before
+        skipped = len(to_insert) - imported
+        if imported > 0:
+            logger.info(f"[AUDIT] import count={imported} sub={self.sub} mode={mode}")
+        return {"imported": imported, "skipped": skipped, "rejected": rejected}
+
     def close(self) -> None:
         return None

--- a/tests/test_db_cf_coverage.py
+++ b/tests/test_db_cf_coverage.py
@@ -135,3 +135,170 @@ def test_close_is_noop_and_conn_shim_surface(fake_d1_http, fake_vectorize_http):
     assert conn.close() is None
     conn.executescript("CREATE TABLE IF NOT EXISTS _cov_probe(x);")
     assert db.close() is None
+
+
+# --- JSONL export / import (parity with db.MemoryDB, scoped to self.sub) ------
+
+
+def test_export_jsonl_scopes_to_sub(fake_d1_http, fake_vectorize_http):
+    """Export emits only the calling sub's rows, one canonical JSON object each."""
+    import json as _json
+
+    a = _db(fake_d1_http, fake_vectorize_http, sub="user1")
+    a.add("alpha note", category="fact", tags=["x"])
+    a.add("beta note", category="pref")
+    # A second sub sharing the same D1 must not bleed into user1's export.
+    _db(fake_d1_http, fake_vectorize_http, sub="user2").add("other-sub note")
+
+    jsonl, count = a.export_jsonl()
+    assert count == 2
+    objs = [_json.loads(line) for line in jsonl.strip().split("\n")]
+    assert {o["content"] for o in objs} == {"alpha note", "beta note"}
+    # Canonical field set (no `sub` leaked into the payload); tags re-parsed to list.
+    assert set(objs[0]) == {
+        "id",
+        "content",
+        "category",
+        "tags",
+        "source",
+        "created_at",
+        "updated_at",
+        "access_count",
+        "last_accessed",
+    }
+    assert any(o["tags"] == ["x"] for o in objs)
+
+
+def test_import_jsonl_merge_inserts_then_skips_existing(
+    fake_d1_http, fake_vectorize_http
+):
+    db = _db(fake_d1_http, fake_vectorize_http)
+    rows = [
+        {"id": "m1", "content": "first imported", "category": "fact"},
+        {"id": "m2", "content": "second imported", "category": "plan"},
+    ]
+    r1 = db.import_jsonl(rows, mode="merge")
+    assert r1 == {"imported": 2, "skipped": 0, "rejected": 0}
+    assert db.stats()["total_memories"] == 2
+    # Re-importing the same ids in merge mode skips them (INSERT OR IGNORE).
+    r2 = db.import_jsonl(rows, mode="merge")
+    assert r2 == {"imported": 0, "skipped": 2, "rejected": 0}
+    assert db.stats()["total_memories"] == 2
+
+
+def test_import_jsonl_injects_caller_sub_not_payload(fake_d1_http, fake_vectorize_http):
+    """A `sub` embedded in the payload is ignored; rows land under the importer."""
+    importer = _db(fake_d1_http, fake_vectorize_http, sub="owner")
+    importer.import_jsonl(
+        [{"id": "p1", "content": "claimed by other", "sub": "intruder"}]
+    )
+    assert importer.stats()["total_memories"] == 1
+    # The intruder sub must see nothing.
+    assert (
+        _db(fake_d1_http, fake_vectorize_http, sub="intruder").stats()["total_memories"]
+        == 0
+    )
+
+
+def test_import_jsonl_replace_clears_sub_first(fake_d1_http, fake_vectorize_http):
+    db = _db(fake_d1_http, fake_vectorize_http)
+    db.add("stale memory", category="fact")
+    res = db.import_jsonl(
+        [{"id": "n1", "content": "fresh memory", "category": "fact"}], mode="replace"
+    )
+    assert res["imported"] == 1
+    stats = db.stats()
+    assert stats["total_memories"] == 1
+    assert db.search("fresh", limit=5)[0]["content"] == "fresh memory"
+    assert db.search("stale", limit=5) == []
+
+
+def test_import_jsonl_rejects_oversized_and_empty(fake_d1_http, fake_vectorize_http):
+    db = _db(fake_d1_http, fake_vectorize_http)
+    res = db.import_jsonl(
+        [
+            {"id": "ok", "content": "fine"},
+            {"id": "big", "content": "x" * 5001},
+            {"id": "empty", "content": ""},
+        ]
+    )
+    assert res == {"imported": 1, "skipped": 0, "rejected": 2}
+    assert db.stats()["total_memories"] == 1
+
+
+def test_import_jsonl_string_preserves_fields_and_is_searchable(
+    fake_d1_http, fake_vectorize_http
+):
+    db = _db(fake_d1_http, fake_vectorize_http)
+    line = (
+        '{"id": "s1", "content": "polars beats pandas", "category": "preference", '
+        '"tags": ["python"], "created_at": "2026-02-12T00:00:00", "importance": 0.9}'
+    )
+    res = db.import_jsonl(line)
+    assert res["imported"] == 1
+    got = db.get("s1")
+    assert got["category"] == "preference"
+    assert got["created_at"] == "2026-02-12T00:00:00"
+    assert got["importance"] == 0.9
+    # Trigger-maintained FTS makes the imported row immediately keyword-searchable.
+    assert any(m["id"] == "s1" for m in db.search("polars", limit=5))
+
+
+def test_export_then_import_roundtrips_into_fresh_sub(
+    fake_d1_http, fake_vectorize_http
+):
+    src = _db(fake_d1_http, fake_vectorize_http, sub="src")
+    src.add("portable memory one", category="fact", tags=["t1"])
+    src.add("portable memory two", category="plan")
+    jsonl, count = src.export_jsonl()
+
+    dst = _db(fake_d1_http, fake_vectorize_http, sub="dst")
+    res = dst.import_jsonl(jsonl)
+    assert res["imported"] == count == 2
+    assert dst.stats()["total_memories"] == 2
+    assert any(
+        m["content"] == "portable memory one" for m in dst.search("portable", limit=5)
+    )
+
+
+def test_import_jsonl_single_dict_input(fake_d1_http, fake_vectorize_http):
+    """A bare dict (not wrapped in a list) imports as one row."""
+    db = _db(fake_d1_http, fake_vectorize_http)
+    res = db.import_jsonl({"id": "d1", "content": "lone dict memory"})
+    assert res["imported"] == 1
+    assert db.get("d1")["content"] == "lone dict memory"
+
+
+def test_import_jsonl_string_counts_malformed_lines_as_rejected(
+    fake_d1_http, fake_vectorize_http
+):
+    # A blank line is skipped (not counted); two malformed lines are rejected.
+    data = '{"id": "g1", "content": "good"}\n\nnot-json\n{bad json}'
+    res = _db(fake_d1_http, fake_vectorize_http).import_jsonl(data)
+    assert res["imported"] == 1
+    assert res["rejected"] == 2
+
+
+def test_import_jsonl_unsupported_type_imports_nothing(
+    fake_d1_http, fake_vectorize_http
+):
+    """A non-str/list/dict payload parses to no items (and skips the insert)."""
+    db = _db(fake_d1_http, fake_vectorize_http)
+    res = db.import_jsonl(12345)  # type: ignore[arg-type]
+    assert res == {"imported": 0, "skipped": 0, "rejected": 0}
+
+
+def test_import_jsonl_non_dict_item_is_rejected(fake_d1_http, fake_vectorize_http):
+    """A list element that is not a mapping is rejected, not fatal."""
+    db = _db(fake_d1_http, fake_vectorize_http)
+    res = db.import_jsonl([{"id": "ok", "content": "fine"}, "not-a-dict", 99])
+    assert res["imported"] == 1
+    assert res["rejected"] == 2
+
+
+def test_import_jsonl_accepts_prestringified_tags(fake_d1_http, fake_vectorize_http):
+    """Tags already serialized as a JSON string pass through unchanged."""
+    db = _db(fake_d1_http, fake_vectorize_http)
+    res = db.import_jsonl([{"id": "pt", "content": "tagged", "tags": '["a", "b"]'}])
+    assert res["imported"] == 1
+    assert db.get("pt")["tags"] == '["a", "b"]'


### PR DESCRIPTION
## What

`MemoryDBD1` lacked the JSONL surface, so the `export_memories` / `import_memories` tools raised `AttributeError` on the `cf-d1` backend — leaving **no canonical route** to migrate an existing single-user memory store into per-sub D1.

## Changes

- Add `export_jsonl()` + `import_jsonl()` to `MemoryDBD1`, scoped to `self.sub`: export reads only the caller's rows; import writes every row under the caller's sub (any `sub` in the payload is ignored), so a single-user dump lands under the importing session's identity (DECISION D3).
- Field set mirrors `db.MemoryDB`. Rows import without embeddings (parity with the local import) and become keyword-searchable immediately via the trigger-maintained FTS index. Counts derive from a before/after row count since D1 `executemany` returns no rowcount. `replace` mode clears the sub first; stale Vectorize entries are harmless (search hydrates from D1 and drops vector hits with no matching row).
- Ignore `scripts/.mnemo_cf_token` (a real JWT dumped by the CF self-test).

## Tests

Adds 12 tests: sub-scoping, merge/replace, oversize/empty/malformed rejection, dict/string/list/unsupported inputs, pre-stringified tags, and an export->import round-trip into a fresh sub. Full suite 1323 passed, coverage 95.12% (>= 95% gate).