### PR TITLE
fix: chunk MemoryDBD1 bulk import under D1's 100-bound-parameter ceiling

### DIFF
--- a/src/mnemo_mcp/db_cf.py
+++ b/src/mnemo_mcp/db_cf.py
@@ -26,6 +26,16 @@ from mnemo_mcp._d1_conn import D1Connection
 MAX_CONTENT_LENGTH = 5000
 MAX_TAGS_FILTER = 50
 
+# D1's HTTP query API caps bound parameters at 100 per statement -- the SQLite
+# 999-variable ceiling does NOT apply over D1's wire protocol. The bulk-import
+# INSERT binds _IMPORT_COLS columns per row, so a multi-row batch must stay under
+# the param ceiling or D1 drops the request (the container disconnects mid-call).
+# D1Backend.executemany chunks by ROW count (default 100), which is param-unsafe
+# for a wide row, so import_jsonl pre-chunks by the param-derived row budget.
+_D1_MAX_BOUND_PARAMS = 100
+_IMPORT_COLS = 11
+_D1_SAFE_IMPORT_ROWS = max(1, _D1_MAX_BOUND_PARAMS // _IMPORT_COLS)
+
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
@@ -722,13 +732,18 @@ class MemoryDBD1:
         before = self._count_rows()
         if to_insert:
             op = "REPLACE" if mode == "replace" else "IGNORE"
-            self._d1.executemany(
+            sql = (
                 f"INSERT OR {op} INTO memories "
                 "(id, sub, content, category, tags, source, "
                 "created_at, updated_at, access_count, last_accessed, importance) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                to_insert,
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
             )
+            # Pre-chunk to the D1 param-safe row budget: each executemany call then
+            # expands into a single multi-row INSERT that stays under the 100 bound
+            # parameter ceiling (a 264-row import that previously crashed D1 now
+            # lands as ~30 safe statements).
+            for j in range(0, len(to_insert), _D1_SAFE_IMPORT_ROWS):
+                self._d1.executemany(sql, to_insert[j : j + _D1_SAFE_IMPORT_ROWS])
         after = self._count_rows()
         imported = after - before
         skipped = len(to_insert) - imported

--- a/tests/test_db_cf_coverage.py
+++ b/tests/test_db_cf_coverage.py
@@ -302,3 +302,33 @@ def test_import_jsonl_accepts_prestringified_tags(fake_d1_http, fake_vectorize_h
     res = db.import_jsonl([{"id": "pt", "content": "tagged", "tags": '["a", "b"]'}])
     assert res["imported"] == 1
     assert db.get("pt")["tags"] == '["a", "b"]'
+
+
+def test_import_jsonl_bulk_stays_under_d1_param_limit(
+    fake_d1_http, fake_vectorize_http
+):
+    """A bulk import must never bind more than D1's 100-parameter-per-query
+    ceiling. Regression: D1Backend.executemany chunks by ROW (default 100), so a
+    wide-row batch (11 cols) overflowed D1's wire limit and disconnected the
+    container live -- the in-memory FakeD1Http does not enforce it, so this spies
+    on the wire params directly. import_jsonl must pre-chunk to stay safe.
+    """
+    import json as _json
+
+    max_params = {"n": 0}
+    original = fake_d1_http.request
+
+    def spy(method, url, data=None, headers=None):
+        if data and url.endswith("/query"):
+            params = _json.loads(data.decode()).get("params", [])
+            max_params["n"] = max(max_params["n"], len(params))
+        return original(method, url, data=data, headers=headers)
+
+    fake_d1_http.request = spy
+    db = _db(fake_d1_http, fake_vectorize_http)
+    rows = [{"id": f"m{i}", "content": f"bulk memory number {i}"} for i in range(25)]
+    res = db.import_jsonl(rows)
+    assert res["imported"] == 25
+    assert max_params["n"] <= 100, (
+        f"a single D1 query bound {max_params['n']} params (> 100 ceiling)"
+    )


### PR DESCRIPTION
## Bug

`import_jsonl` handed the whole row set to `D1Backend.executemany`, which chunks by **row** count (default 100). The import INSERT binds 11 columns per row, so any batch of >=10 rows produced a multi-row statement exceeding **D1's 100-bound-parameter wire limit** -- D1 dropped the request and the container disconnected mid-call. A 264-row live migration crashed this way. The in-memory `FakeD1Http` double does not enforce the limit, so the suite stayed green while production failed.

## Fix

Pre-chunk `to_insert` to a param-derived row budget (`100 // 11 = 9` rows) so each `executemany` expands into a single INSERT under the ceiling; a 264-row import now lands as ~30 safe statements.

## Test

Adds a regression test that spies on the D1 wire and asserts no single query binds more than 100 parameters (fails on the old code: a 25-row import bound 275). Full suite 1324 passed, coverage 95.12%.

## Note (out of scope)

The deeper cause is `mcp_core.storage.D1Backend.executemany` chunking by row, not by parameter count -- latent for any wide-row bulk insert (affects other consumers e.g. wet). Flagging for a follow-up mcp-core fix; this PR makes mnemo's import path safe now.