### PR TITLE
fix: bump mcp-core to 1.18.0b10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.0b3",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.0b9,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b10,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -9,8 +9,10 @@ def test_mcp_core_pin_includes_cf_backends():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
-    # D1Backend + VectorizeBackend promoted into mcp-core storage at 1.18.0b9.
-    assert "1.18.0b9" in core, f"expected >=1.18.0b9 floor (CF backends), got: {core}"
+    # D1Backend + VectorizeBackend promoted into mcp-core storage at 1.18.0b9;
+    # the per-sub credential regex fix (#501) in the deployed CF image lands at
+    # 1.18.0b10, and this floor pins it.
+    assert "1.18.0b10" in core, f"expected >=1.18.0b10 floor, got: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b13"
+version = "2.3.0b14"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1111,7 +1111,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b9,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b10,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b9"
+version = "1.18.0b10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1232,9 +1232,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/d0/13cdea1f6ccf7adf6a2bf921b380c1d9b6d06eb8e4b844bf51ed9d958dac/n24q02m_mcp_core-1.18.0b9.tar.gz", hash = "sha256:7b42fd9a72d28055b3f4b32b6dd93b01cea22ad6c4d5b372fe959d7333568a04", size = 281264, upload-time = "2026-06-16T10:16:31.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/70/043942c59667fce1b53f269f5df16cf9fb12bde1a4bbb81f52c51baac10e/n24q02m_mcp_core-1.18.0b10.tar.gz", hash = "sha256:62a7f759ddade906eb9603a67e6155b87dee79163bb7c732db0698b395214f88", size = 282027, upload-time = "2026-06-17T08:19:56.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/64/36d9231ce0353cf27fd74ef5df0b70328bbd1d804d42787a4b0c02651f47/n24q02m_mcp_core-1.18.0b9-py3-none-any.whl", hash = "sha256:3e9b802f7f5855a3ed93359de4c1a4d75a07e5624209f498bfa41a8bc0532d9f", size = 156425, upload-time = "2026-06-16T10:16:29.942Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c4/fd1626e9ab0afe60ae9880b8f5a855ad14ef1785a2598d8010b55cbee62c/n24q02m_mcp_core-1.18.0b10-py3-none-any.whl", hash = "sha256:44ea32698b985384181676ee4c3e2f2d58abae8dfc94b47eaaeee371d978b1f0", size = 156789, upload-time = "2026-06-17T08:19:54.678Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
main's committed uv.lock pinned mcp-core 1.18.0b9; the deployed CF container runs b10 (per-sub credential regex fix #501). Bump the pin floor + lockfile to b10 so a rebuild-from-main with `uv sync --frozen` matches the deployed image.