### PR TITLE
fix: neutral default endpoint + env-first secrets in CF self-host scripts

### DIFF
--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -56,7 +56,10 @@ import time
 import urllib.parse
 from pathlib import Path
 
-DEFAULT_ENDPOINT = "https://mnemo.n24q02m.com"
+# No hardcoded host: set CF_ENDPOINT or pass --endpoint https://<your-worker-domain>.
+# This self-tests YOUR deployed CF server; creds come from env (MCP_RELAY_PASSWORD +
+# provider keys) -- the maintainer injects them via skret, but any export works.
+DEFAULT_ENDPOINT = os.environ.get("CF_ENDPOINT", "")
 
 # A unique marker memory added then searched to exercise the D1 FTS round-trip.
 MARKER = "cf-canary-probe-mnemo"
@@ -326,6 +329,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--endpoint",
         default=DEFAULT_ENDPOINT,
+        required=not DEFAULT_ENDPOINT,
         help=f"Deployed wet endpoint (default: {DEFAULT_ENDPOINT})",
     )
     mode = p.add_mutually_exclusive_group()

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -8,17 +8,20 @@ managed registry, deploys, waits for the container rollout to finish
 (STATE=ready) so you never verify against a half-rolled old image, then runs a
 **credential-free canary gate** and **auto-rolls-back** if it fails.
 
-Run from the repo root, with the CF dev token injected by skret:
+Set CLOUDFLARE_API_TOKEN in the environment (any secret manager works), then run
+from the repo root:
 
-    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- \\
-        python scripts/deploy_cf.py            # tag defaults to b-<short-sha>
-    ... python scripts/deploy_cf.py --tag b10-abc1234   # explicit tag
-    ... python scripts/deploy_cf.py --skip-build         # reuse a built image
-    ... python scripts/deploy_cf.py --dry-run            # print the plan only
-    ... python scripts/deploy_cf.py --no-canary          # skip the post-deploy gate
+    export CLOUDFLARE_API_TOKEN=...                       # however you store secrets
+    python scripts/deploy_cf.py                           # tag defaults to b-<short-sha>
+    ... python scripts/deploy_cf.py --tag b10-abc1234     # explicit tag
+    ... python scripts/deploy_cf.py --skip-build          # reuse a built image
+    ... python scripts/deploy_cf.py --dry-run             # print the plan only
+    ... python scripts/deploy_cf.py --no-canary           # skip the post-deploy gate
 
-Requires: CLOUDFLARE_API_TOKEN in env (skret /n24q02m/dev CF_DEV_TOKEN ->
-export CLOUDFLARE_API_TOKEN), docker, and ``bunx wrangler``. The CF container
+The maintainer injects the token via ``skret`` (one option), e.g.:
+    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- python scripts/deploy_cf.py
+
+Requires: CLOUDFLARE_API_TOKEN in env, docker, and ``bunx wrangler``. The CF container
 registry only pulls from registry.cloudflare.com/<account>/... (not ghcr), so the
 local image is tagged to that path before ``wrangler containers push``.
 


### PR DESCRIPTION
Polishes the public CF self-host scripts so they are neutral for any self-hoster (per README 'Run your own ... instance on Cloudflare' + docs/cf-deploy.md placeholder runbook): (1) cf_full_flow.py no longer defaults to a maintainer-specific *.n24q02m.com host — it reads CF_ENDPOINT or requires --endpoint; (2) docstrings frame secrets env-first (CLOUDFLARE_API_TOKEN / MCP_RELAY_PASSWORD / provider keys set via any manager) with skret shown only as the maintainer's convenience. No behaviour change for the maintainer (export CF_ENDPOINT) and no functional change to the deploy/canary flow.