### PR TITLE
feat: enable username-stable-sub workspace bucket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.0b3",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.0b10,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b12,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2439,6 +2439,7 @@ async def run_http(port: int = 0) -> None:
         # "Waiting for authorization..." forever. Accepts legacy 1-arg core.
         setup_complete_hook=wire_gdrive_callbacks,
         auth_scope=_per_request_sub_scope if public_url else None,
+        stable_sub_enabled=True,
     )
 
 

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -1,5 +1,5 @@
 """Guard: mnemo must depend on a mcp-core release that ships the CF storage
-backends (D1Backend + VectorizeBackend), promoted in 1.18.0b9."""
+backends (D1Backend + VectorizeBackend), promoted in 1.18.0b12."""
 
 import tomllib
 from pathlib import Path
@@ -9,10 +9,10 @@ def test_mcp_core_pin_includes_cf_backends():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
-    # D1Backend + VectorizeBackend promoted into mcp-core storage at 1.18.0b9;
+    # D1Backend + VectorizeBackend promoted into mcp-core storage at 1.18.0b12;
     # the per-sub credential regex fix (#501) in the deployed CF image lands at
-    # 1.18.0b10, and this floor pins it.
-    assert "1.18.0b10" in core, f"expected >=1.18.0b10 floor, got: {core}"
+    # 1.18.0b12, and this floor pins it.
+    assert "1.18.0b12" in core, f"expected >=1.18.0b12 floor, got: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/tests/test_stable_sub_optin.py
+++ b/tests/test_stable_sub_optin.py
@@ -1,0 +1,9 @@
+"""Guard: this server opts into username-stable-sub."""
+
+import inspect
+
+from mnemo_mcp import server
+
+
+def test_enables_stable_sub():
+    assert "stable_sub_enabled=True" in inspect.getsource(server)

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b14"
+version = "2.3.0b15"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1111,7 +1111,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b10,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b12,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b10"
+version = "1.18.0b12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1232,9 +1232,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/70/043942c59667fce1b53f269f5df16cf9fb12bde1a4bbb81f52c51baac10e/n24q02m_mcp_core-1.18.0b10.tar.gz", hash = "sha256:62a7f759ddade906eb9603a67e6155b87dee79163bb7c732db0698b395214f88", size = 282027, upload-time = "2026-06-17T08:19:56.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/93/7bacfbaeaf6805fad2f4883ffb2f9aba4c2f147eb0d2d4d3d2d423733836/n24q02m_mcp_core-1.18.0b12.tar.gz", hash = "sha256:b8dffee8d18468a0ded29d7aa0eccb6af5daed62fd1ef96f8833787cbca2eb03", size = 287572, upload-time = "2026-06-18T12:36:36.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/c4/fd1626e9ab0afe60ae9880b8f5a855ad14ef1785a2598d8010b55cbee62c/n24q02m_mcp_core-1.18.0b10-py3-none-any.whl", hash = "sha256:44ea32698b985384181676ee4c3e2f2d58abae8dfc94b47eaaeee371d978b1f0", size = 156789, upload-time = "2026-06-17T08:19:54.678Z" },
+    { url = "https://files.pythonhosted.org/packages/19/98/cdf75f3d9cf5eec197384d0b5c8e0e237ac2bc03d2685f64c4e881414006/n24q02m_mcp_core-1.18.0b12-py3-none-any.whl", hash = "sha256:f87d26b576836d406fbdd43d3f6c5a398a6cd721d7db5dd51eeabe6cbe8917fc", size = 158657, upload-time = "2026-06-18T12:36:37.321Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Opts this data-bearing server into the username-stable-sub feature (mcp-core 1.18.0b12, PRs #502+#503): passes stable_sub_enabled=True to run_http_server so the credential form shows the optional workspace-username field; a returning user typing the same username lands on the SAME per-sub bucket (docs/memories persist across re-auth + devices). Blank username = unchanged random behaviour. Bumps mcp-core pin floor + lockfile to 1.18.0b12 and the pin-guard test.