### PR TITLE
feat: DISABLE_LOCAL_EMBED / DISABLE_LOCAL_RERANK disable-local toggles (WS-5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.0b3",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.0b12,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b13,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from mcp_core.chains import resolve_backend
 from mcp_core.llm.providers import key_env_for_model
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
@@ -95,6 +96,13 @@ class Settings(BaseSettings):
     embedding_backend: str = (
         ""  # "cloud" | "local" | "" (auto: API_KEYS->cloud, else local)
     )
+
+    # Per-capability disable-local toggles (cross-cutting; see mcp_core.chains).
+    # Turn OFF the heavy local qwen3 ONNX fallback (~570MB) WITHOUT pinning a
+    # cloud model. Toggle on + no cloud chain => feature gracefully UNAVAILABLE
+    # (clear status), never silently forced to a provider. Independent per task.
+    disable_local_embed: bool = False  # env DISABLE_LOCAL_EMBED
+    disable_local_rerank: bool = False  # env DISABLE_LOCAL_RERANK
 
     # BYO (bring-your-own) LOCAL model override. When set, the local
     # embed/rerank backend loads this model id instead of the bundled
@@ -362,15 +370,17 @@ class Settings(BaseSettings):
         )
 
     def resolve_embedding_backend(self) -> str:
-        """Resolve embedding backend: 'local' or 'cloud'.
+        """Resolve embedding backend: 'cloud', 'local', or 'unavailable'.
 
-        Always returns a valid backend (never empty). Backend is inferred
-        from EMBEDDING_MODELS (non-empty chain -> cloud, empty -> local);
-        the deprecated EMBEDDING_BACKEND env var is honored for one release.
+        3-way resolution via the shared mcp-core primitive: 'cloud' (non-empty
+        EMBEDDING_MODELS chain), 'local' (empty chain + local leg enabled), or
+        'unavailable' (empty chain + DISABLE_LOCAL_EMBED set -> no local download
+        and no cloud, so embedding is gracefully unavailable, NOT forced). The
+        deprecated EMBEDDING_BACKEND env var is honored for one release.
 
-        Cloudflare serverless mode sets EMBEDDING_MODELS (Jina) via wrangler
-        vars so this returns 'cloud' and the 570MB qwen3-embed ONNX model is
-        never instantiated in the container.
+        Cloudflare serverless sets a cloud EMBEDDING_MODELS chain (or
+        DISABLE_LOCAL_EMBED) via wrangler vars so the 570MB qwen3-embed ONNX
+        model is never instantiated in the container.
         """
         if self.embedding_backend:
             logger.warning(
@@ -382,14 +392,17 @@ class Settings(BaseSettings):
                 if self.embedding_backend in ("cloud", "litellm")
                 else self.embedding_backend
             )
-        return "cloud" if self.embedding_chain() else "local"
+        return resolve_backend(
+            has_cloud_chain=bool(self.embedding_chain()),
+            local_enabled=not self.disable_local_embed,
+        ).value
 
     def resolve_rerank_backend(self) -> str:
-        """Resolve reranker backend: 'cloud', 'local', or '' (disabled).
+        """Resolve reranker backend: 'cloud', 'local', 'unavailable', or '' (disabled).
 
-        Disabled when rerank_enabled is False. Otherwise inferred from
-        RERANK_MODELS (non-empty chain -> cloud, empty -> local); the
-        deprecated RERANK_BACKEND env var is honored for one release.
+        '' when rerank_enabled is False. Otherwise 3-way via the shared mcp-core
+        primitive (keyed on RERANK_MODELS + DISABLE_LOCAL_RERANK); the deprecated
+        RERANK_BACKEND env var is honored for one release.
         """
         if not self.rerank_enabled:
             return ""
@@ -403,7 +416,10 @@ class Settings(BaseSettings):
                 if self.rerank_backend in ("cloud", "litellm")
                 else self.rerank_backend
             )
-        return "cloud" if self.rerank_chain() else "local"
+        return resolve_backend(
+            has_cloud_chain=bool(self.rerank_chain()),
+            local_enabled=not self.disable_local_rerank,
+        ).value
 
     def resolve_local_rerank_model(self) -> str:
         """Resolve local reranker model: GGUF if GPU + llama-cpp, else ONNX.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -123,6 +123,12 @@ async def _init_embedding_backend(
     embedding_dims = settings.resolve_embedding_dims()
     embedding_backend_type = settings.resolve_embedding_backend()
 
+    if embedding_backend_type == "unavailable":
+        logger.info(
+            "Embedding: unavailable (DISABLE_LOCAL_EMBED set + no cloud model configured, FTS5 mode)"
+        )
+        return
+
     if cred_state == CredentialState.LOCAL or embedding_backend_type == "local":
         # Local-only path
         local_model = settings.resolve_local_embedding_model()
@@ -182,6 +188,12 @@ async def _init_reranker_backend(mode: str) -> None:
     backend_type = settings.resolve_rerank_backend()
     if not backend_type:
         logger.debug("Reranking disabled")
+        return
+
+    if backend_type == "unavailable":
+        logger.info(
+            "Reranker: unavailable (DISABLE_LOCAL_RERANK set + no cloud model configured)"
+        )
         return
 
     cred_state = get_state()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -272,6 +272,29 @@ class TestEmbeddingBackend:
         s = Settings(embedding_backend="litellm")
         assert s.resolve_embedding_backend() == "cloud"
 
+    def test_unavailable_when_local_disabled_and_no_chain(self, monkeypatch):
+        """DISABLE_LOCAL_EMBED + empty chain -> 'unavailable' (NOT forced)."""
+        for v in (
+            "EMBEDDING_MODELS",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        s = Settings(
+            embedding_backend="", embedding_models="", disable_local_embed=True
+        )
+        assert s.resolve_embedding_backend() == "unavailable"
+
+    def test_cloud_wins_even_when_local_disabled(self):
+        """A configured cloud chain still resolves to 'cloud' with local disabled."""
+        s = Settings(
+            embedding_models="gemini/gemini-embedding-001", disable_local_embed=True
+        )
+        assert s.resolve_embedding_backend() == "cloud"
+
 
 class TestRerankSettings:
     def test_rerank_enabled_default(self):
@@ -323,6 +346,22 @@ class TestRerankSettings:
     def test_resolve_rerank_backend_local_fallback(self):
         s = Settings()
         assert s.resolve_rerank_backend() == "local"
+
+    def test_resolve_rerank_unavailable_when_local_disabled(self, monkeypatch):
+        """DISABLE_LOCAL_RERANK + empty chain (rerank enabled) -> 'unavailable'."""
+        for v in ("RERANK_MODELS", "JINA_AI_API_KEY", "COHERE_API_KEY"):
+            monkeypatch.delenv(v, raising=False)
+        s = Settings(
+            rerank_enabled=True,
+            rerank_backend="",
+            rerank_models="",
+            disable_local_rerank=True,
+        )
+        assert s.resolve_rerank_backend() == "unavailable"
+
+    def test_resolve_rerank_disabled_overrides_toggle(self):
+        s = Settings(rerank_enabled=False, disable_local_rerank=True)
+        assert s.resolve_rerank_backend() == ""
 
     def test_rerank_chain_explicit(self):
         s = Settings(rerank_models="custom/reranker")

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -1,5 +1,6 @@
 """Guard: mnemo must depend on a mcp-core release that ships the CF storage
-backends (D1Backend + VectorizeBackend), promoted in 1.18.0b12."""
+backends (D1Backend + VectorizeBackend, promoted in 1.18.0b12) AND the
+capability provider-chain primitive (mcp_core.chains, added in 1.18.0b13)."""
 
 import tomllib
 from pathlib import Path
@@ -9,10 +10,9 @@ def test_mcp_core_pin_includes_cf_backends():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
-    # D1Backend + VectorizeBackend promoted into mcp-core storage at 1.18.0b12;
-    # the per-sub credential regex fix (#501) in the deployed CF image lands at
-    # 1.18.0b12, and this floor pins it.
-    assert "1.18.0b12" in core, f"expected >=1.18.0b12 floor, got: {core}"
+    # 1.18.0b12 promoted the CF storage backends; 1.18.0b13 added mcp_core.chains
+    # (resolve_backend) used by the DISABLE_LOCAL_EMBED/_RERANK toggles. Pin the latter.
+    assert "1.18.0b13" in core, f"expected >=1.18.0b13 floor, got: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b12,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b13,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b12"
+version = "1.18.0b13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1232,9 +1232,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/93/7bacfbaeaf6805fad2f4883ffb2f9aba4c2f147eb0d2d4d3d2d423733836/n24q02m_mcp_core-1.18.0b12.tar.gz", hash = "sha256:b8dffee8d18468a0ded29d7aa0eccb6af5daed62fd1ef96f8833787cbca2eb03", size = 287572, upload-time = "2026-06-18T12:36:36.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/de/63e21abb61c6463bf9ef5700b96f97c41755272154eac550cbf9eb0283f3/n24q02m_mcp_core-1.18.0b13.tar.gz", hash = "sha256:d8d56e7bbc89305e86ba3d5a61f3ae269063ec7f533a3b76e761dc36b7dc196b", size = 292494, upload-time = "2026-06-19T07:03:07.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/98/cdf75f3d9cf5eec197384d0b5c8e0e237ac2bc03d2685f64c4e881414006/n24q02m_mcp_core-1.18.0b12-py3-none-any.whl", hash = "sha256:f87d26b576836d406fbdd43d3f6c5a398a6cd721d7db5dd51eeabe6cbe8917fc", size = 158657, upload-time = "2026-06-18T12:36:37.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ac/97a7befbeb87e04a10c673468fff7cd02909914209cd2dee5571f000da25/n24q02m_mcp_core-1.18.0b13-py3-none-any.whl", hash = "sha256:7ca71aa27a01eb6e44e3144346c6fddaae980f092a106e440aa30cf22e5a8439", size = 161881, upload-time = "2026-06-19T07:03:06.06Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
3-way embed/rerank resolution (cloud/local/unavailable) via mcp_core.chains.resolve_backend so the local qwen3 ONNX leg can be disabled without pinning a cloud model. Bumps mcp-core 1.18.0b13.