### PR TITLE
fix: bump mcp-core floor to 1.18.0b14 for the key-rotation primitive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.0b3",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.0b13,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b14,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -11,8 +11,9 @@ def test_mcp_core_pin_includes_cf_backends():
     deps = pyproject["project"]["dependencies"]
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
     # 1.18.0b12 promoted the CF storage backends; 1.18.0b13 added mcp_core.chains
-    # (resolve_backend) used by the DISABLE_LOCAL_EMBED/_RERANK toggles. Pin the latter.
-    assert "1.18.0b13" in core, f"expected >=1.18.0b13 floor, got: {core}"
+    # (resolve_backend); 1.18.0b14 added mcp_core.llm.key_rotation, so the embed/
+    # rerank dispatch rotates provider API keys on rate-limit. Pin the latter.
+    assert "1.18.0b14" in core, f"expected >=1.18.0b14 floor, got: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b15"
+version = "2.3.0b16"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1111,7 +1111,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b13,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b14,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b13"
+version = "1.18.0b14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1232,9 +1232,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/de/63e21abb61c6463bf9ef5700b96f97c41755272154eac550cbf9eb0283f3/n24q02m_mcp_core-1.18.0b13.tar.gz", hash = "sha256:d8d56e7bbc89305e86ba3d5a61f3ae269063ec7f533a3b76e761dc36b7dc196b", size = 292494, upload-time = "2026-06-19T07:03:07.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/af/4ab96169a7446124cf1689bea50e1c6cc20cabbcf1889a4d6cc962b61411/n24q02m_mcp_core-1.18.0b14.tar.gz", hash = "sha256:846c194051c2cb640ecd61b787ab96e3857c5aba29d944845db5cddf9ff2b91b", size = 294342, upload-time = "2026-06-19T11:59:22.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/ac/97a7befbeb87e04a10c673468fff7cd02909914209cd2dee5571f000da25/n24q02m_mcp_core-1.18.0b13-py3-none-any.whl", hash = "sha256:7ca71aa27a01eb6e44e3144346c6fddaae980f092a106e440aa30cf22e5a8439", size = 161881, upload-time = "2026-06-19T07:03:06.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bc/7488455a8935cdc5e1de52d7b8aeebc6812f28e0f9a1f186383f78eb5a7a/n24q02m_mcp_core-1.18.0b14-py3-none-any.whl", hash = "sha256:29a283e8e820c55688404edecb3ff3fb94a5384db9b998da1c8733a00086a08c", size = 163276, upload-time = "2026-06-19T11:59:21.395Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bump n24q02m-mcp-core[llm] floor to 1.18.0b14, which ships the mcp_core.llm.key_rotation primitive. The transparent AI dispatch rotation (aembedding/arerank/aimage_generation/avideo_generation rotate provider API keys on HTTP 429/401/403) is inherited automatically through mcp_core.llm — no per-server code change. uv.lock relocked to b14; full pre-commit suite green against b14.