### PR TITLE
🎨 Palette: Add default suggestion for unknown help topics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2025-05-18 - Added context-aware `suggestion` to JSON error responses
-**Learning:** In a backend/CLI-focused MCP server, traditional frontend UX paradigms translate to Developer/Agent Experience (DX). When the server returns raw errors without guidance, consumers (like LLMs or developers debugging tools) struggle to recover. Standardizing on a top-level `suggestion` key in JSON error responses makes the API significantly more actionable and "intuitive".
-**Action:** When adding or refactoring error paths in server tool handlers (like `_handle_add`, `_handle_capture`, etc.), always ensure `_json({"error": ...})` includes a corresponding `"suggestion": "..."` field with concrete next steps.
+## 2026-06-20 - [UX Improvement for Unknown Help Topics]
+**Learning:** In backend CLI/MCP APIs where user interfaces are limited, explicitly providing default suggestions for missing inputs acts as a crucial fallback when fuzzy-matching algorithms (like `difflib`) fail to find close matches. Without an explicit UI, textual errors must bridge the interaction gap.
+**Action:** Always provide a default `suggestion` alongside API-driven error responses for missing or severely misspelled inputs, ensuring the user (or consuming agent) has actionable next steps rather than a dead end.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2303,6 +2303,10 @@ async def help(topic: str = "memory") -> str:
         }
         if closest:
             resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+        else:
+            resp["suggestion"] = (
+                "Available topics: 'memory' for memory management, 'config' for configuration."
+            )
         return _json(resp)
 
     doc_file = docs_package / filename

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -234,11 +234,12 @@ class TestHelpTool:
         assert "Did you mean 'memory'?" in result["suggestion"]
 
     async def test_help_no_match(self):
-        """Completely invalid topic returns error without suggestion."""
+        """Completely invalid topic returns error with suggestion."""
         result = json.loads(await help(topic="xyzxyz"))
         assert "error" in result
         assert "valid_topics" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Available topics:" in result["suggestion"]
 
     async def test_help_setup_redirects_to_config(self):
         """'setup' topic is redirected to 'config'."""

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b16"
+version = "2.3.0b17"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 What: The UX enhancement added a fallback `suggestion` message for the `help` command when an unknown topic is requested and `difflib.get_close_matches` yields no similar options.
🎯 Why: Previously, requesting a completely invalid topic returned an error with no actionable suggestion. Adding a default suggestion listing available core topics ensures the user (or consuming agent) is always guided toward correct inputs.
♿ Accessibility: N/A (Backend MCP server DX improvement)

---
*PR created automatically by Jules for task [14752938711629211877](https://jules.google.com/task/14752938711629211877) started by @n24q02m*