### PR TITLE
fix: migrate mnemo LLM dispatch to the per-task model chain

### DIFF
--- a/src/mnemo_mcp/compression.py
+++ b/src/mnemo_mcp/compression.py
@@ -36,7 +36,7 @@ from typing import Final
 import tiktoken
 from loguru import logger
 
-from mnemo_mcp.llm import call_llm, detect_provider, get_default_model
+from mnemo_mcp.llm import call_llm, llm_chain, provider_for_model
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -78,24 +78,21 @@ def _env_compression_enabled() -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
-def _resolve_provider(explicit: str | None) -> str | None:
-    """Pick provider: explicit arg > COMPRESSION_PROVIDER env > auto-detect."""
-    if explicit:
-        return explicit
-    env = os.environ.get("COMPRESSION_PROVIDER", "").strip()
-    if env:
-        return env
-    return detect_provider()
+def _resolve_models(explicit_model: str | None) -> list[str]:
+    """Pick the compression model chain.
 
-
-def _resolve_model(provider: str, explicit: str | None) -> str:
-    """Pick model: explicit arg > COMPRESSION_MODEL env > provider default."""
-    if explicit:
-        return explicit
+    Priority: explicit ``model`` arg (single-model chain) > ``COMPRESSION_MODEL``
+    env (single-model chain) > the resolved, key-gated LLM chain
+    (``settings.llm_chain()``). Provider is derived from each model's prefix by
+    litellm, so there is no separate provider step. Returns ``[]`` when nothing
+    is configured so the caller gracefully skips compression.
+    """
+    if explicit_model:
+        return [explicit_model]
     env = os.environ.get("COMPRESSION_MODEL", "").strip()
     if env:
-        return env
-    return get_default_model(provider)
+        return [env]
+    return llm_chain()
 
 
 def count_tokens(text: str) -> int:
@@ -147,36 +144,31 @@ async def compress(
         logger.debug("compression: COMPRESSION_ENABLED=false, skipping")
         return skip_payload
 
-    resolved_provider = _resolve_provider(provider)
-    if resolved_provider is None:
+    models = _resolve_models(model)
+    if not models:
         logger.warning(
-            "compression: no LLM provider available - storing raw text "
-            "(set GEMINI_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY / "
-            "XAI_API_KEY to enable compression)"
+            "compression: no LLM model available - storing raw text "
+            "(set LLM_MODELS, COMPRESSION_MODEL, or a <PROVIDER>_API_KEY for a "
+            "default-chain model to enable compression)"
         )
         return skip_payload
 
-    resolved_model = _resolve_model(resolved_provider, model)
+    primary = models[0]
 
     try:
         compressed_text = await call_llm(
             COMPRESSION_PROMPT.format(text=text),
-            provider=resolved_provider,
-            model=resolved_model,
+            models=models,
             temperature=0.0,
             max_tokens=max(64, tokens_in // 2),
         )
     except Exception as e:  # pragma: no cover - SDK guard
-        logger.warning(
-            f"compression: provider={resolved_provider} model={resolved_model} "
-            f"failed with {e}; storing raw text"
-        )
+        logger.warning(f"compression: chain={models} failed with {e}; storing raw text")
         return skip_payload
 
     if not compressed_text or not compressed_text.strip():
         logger.warning(
-            f"compression: provider={resolved_provider} returned empty text; "
-            "storing raw text"
+            f"compression: chain head {primary} returned empty text; storing raw text"
         )
         return skip_payload
 
@@ -185,8 +177,8 @@ async def compress(
         "text": compressed_text,
         "text_raw": text,
         "compressed": True,
-        "compression_provider": resolved_provider,
-        "compression_model": resolved_model,
+        "compression_provider": provider_for_model(primary),
+        "compression_model": primary,
         "tokens_in": tokens_in,
         "tokens_out": tokens_out,
     }

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -146,13 +146,19 @@ class Settings(BaseSettings):
     # Temporal decay
     recency_half_life_days: int = 7
 
-    # LLM for graph/importance (reuse existing SDK config)
-    llm_models: str = "gemini/gemini-3-flash-preview,openai/gpt-5.4-mini-2026-03-17"
+    # LLM chain (graph/importance/compression). Empty -> the key-gated default
+    # chain (only default models whose provider key is configured); if none ->
+    # empty -> LLM feature gracefully unavailable. Explicit LLM_MODELS is honored
+    # verbatim (not key-filtered), matching EMBEDDING_MODELS / RERANK_MODELS.
+    llm_models: str = ""
 
     # Phase 2: LLM compression
     compression_enabled: bool = True
-    compression_provider: str = ""  # "" = auto-detect via llm.detect_provider
-    compression_model: str = ""  # "" = use llm.get_default_model(provider)
+    # "" = use the resolved llm_chain(); set to pin a single model (provider
+    # derived from its prefix). compression_provider is kept for backward
+    # compat with persisted config.enc but is no longer consulted by dispatch.
+    compression_provider: str = ""
+    compression_model: str = ""
 
     # DEPRECATED (2026-05-14): backend is auto-resolved from SYNC_S3_BUCKET
     # presence via :func:`mnemo_mcp.sync.resolve_active_backend` (XOR
@@ -299,6 +305,10 @@ class Settings(BaseSettings):
         "jina_ai/jina-reranker-v3",
         "cohere/rerank-v3.5",
     )
+    _DEFAULT_LLM_CHAIN = (
+        "gemini/gemini-3-flash-preview",
+        "openai/gpt-5.4-mini-2026-03-17",
+    )
 
     def _chain(self, primary: str, legacy: str, default: tuple[str, ...]) -> list[str]:
         if primary:
@@ -354,7 +364,31 @@ class Settings(BaseSettings):
         return chain[0] if chain else None
 
     def llm_chain(self) -> list[str]:
-        return [m.strip() for m in self.llm_models.split(",") if m.strip()]
+        """Resolve the LLM model chain.
+
+        Explicit ``LLM_MODELS`` is honored verbatim. When unset, the curated
+        default chain is key-gated: only default models whose provider key is
+        configured survive (reusing the same ``_key_available`` /
+        ``key_env_for_model`` filter as the embedding/rerank defaults). If no
+        default model has a configured key, the chain is empty and the LLM
+        feature is gracefully unavailable -- no keyless cloud model is emitted.
+        """
+        # No legacy singular LLM env var; pass "" so _chain skips to the
+        # key-gated default when llm_models is empty.
+        return self._chain(self.llm_models, "", self._DEFAULT_LLM_CHAIN)
+
+    def llm_primary(self) -> str | None:
+        chain = self.llm_chain()
+        return chain[0] if chain else None
+
+    def resolve_llm_backend(self) -> str:
+        """Resolve the LLM backend: 'cloud' (non-empty chain) or 'unavailable'.
+
+        The LLM feature has no local fallback: an empty chain (no LLM_MODELS and
+        no default-model provider key) means the feature is off, reported as
+        'unavailable' so ``config(action="status")`` can show it cleanly.
+        """
+        return "cloud" if self.llm_chain() else "unavailable"
 
     def resolve_embedding_dims(self) -> int:
         """Return explicit EMBEDDING_DIMS or 0 for auto-detect."""

--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 
 from loguru import logger
 
+from mnemo_mcp.llm import acomplete
+
 
 def _has_llm_provider() -> bool:
     """Check if any LLM provider API key is available."""
@@ -17,62 +19,6 @@ def _has_llm_provider() -> bool:
         or os.getenv("ANTHROPIC_API_KEY")
         or os.getenv("XAI_API_KEY")
     )
-
-
-def _resolve_llm_model(settings_obj) -> str:
-    """Resolve the LLM model to use from settings, in litellm ``provider/model`` form.
-
-    ``LLM_MODELS`` accepts ``provider=model`` (=-form) or ``provider/model``
-    (slash form). A bare =-form first entry (no slash) is normalised to slash
-    form so ``_litellm_model`` does not double-prefix it.
-    """
-    models = [m.strip() for m in settings_obj.llm_models.split(",") if m.strip()]
-    raw = models[0] if models else "gemini/gemini-3-flash-preview"
-    return raw.replace("=", "/", 1) if ("=" in raw and "/" not in raw) else raw
-
-
-def _litellm_model(model: str) -> str:
-    """Normalise a model string to litellm ``provider/model`` form.
-
-    ``_resolve_llm_model`` may yield ``provider/model`` (slash form) or a bare
-    name. litellm infers the provider from the prefix, so a bare gemini model
-    (e.g. ``gemini-3-flash-preview``) is prefixed with ``gemini/``; any other
-    bare name is left as-is for litellm to route via env keys.
-    """
-    if "/" in model:
-        return model
-    if "gemini" in model.lower():
-        return f"gemini/{model}"
-    return model
-
-
-async def _llm_completion(
-    model: str,
-    messages: list[dict],
-    temperature: float = 0,
-    max_tokens: int = 500,
-    response_format: dict | None = None,
-) -> str:
-    """Call LLM completion via mcp_core.llm (litellm passthrough).
-
-    litellm infers the provider from the ``provider/model`` prefix and returns
-    OpenAI-shaped responses (``resp.choices[0].message.content``).
-    Returns the response text content.
-    """
-    # Lazy import: litellm costs ~1-2s on first import.
-    from mcp_core.llm import acompletion
-
-    kwargs: dict = {"temperature": temperature, "max_tokens": max_tokens}
-    if response_format:
-        kwargs["response_format"] = response_format
-
-    resp = await acompletion(
-        model=_litellm_model(model),
-        messages=messages,
-        api_base=os.environ.get("LLM_API_BASE") or None,
-        **kwargs,
-    )
-    return resp.choices[0].message.content or ""
 
 
 async def extract_entities(content: str) -> dict | None:
@@ -87,10 +33,7 @@ async def extract_entities(content: str) -> dict | None:
         return None
 
     try:
-        model = _resolve_llm_model(settings)
-
-        text = await _llm_completion(
-            model=model,
+        text = await acomplete(
             messages=[
                 {
                     "role": "user",
@@ -110,6 +53,8 @@ async def extract_entities(content: str) -> dict | None:
             temperature=0,
             max_tokens=500,
         )
+        if not text:
+            return None
 
         data = json.loads(text)
         if "entities" not in data:
@@ -160,10 +105,7 @@ async def score_importance(content: str) -> float:
         return 0.5
 
     try:
-        model = _resolve_llm_model(settings)
-
-        text = await _llm_completion(
-            model=model,
+        text = await acomplete(
             messages=[
                 {
                     "role": "user",
@@ -180,6 +122,8 @@ async def score_importance(content: str) -> float:
             temperature=0,
             max_tokens=10,
         )
+        if not text:
+            return 0.5
 
         score = float(text.strip())
         return max(0.0, min(1.0, score))

--- a/src/mnemo_mcp/llm.py
+++ b/src/mnemo_mcp/llm.py
@@ -1,150 +1,140 @@
-"""Multi-provider LLM dispatch layer (Phase 1 foundation).
+"""Chain-based LLM dispatch layer.
 
-Provides a single ``call_llm`` entry point that auto-detects the active
-provider from environment variables and dispatches via ``mcp_core.llm``
-(litellm passthrough). The priority order matches the spec
-(`2026-04-19-mnemo-v2-design.md` §4.2):
+Provides a single entry point that dispatches a chat completion over the
+configured LLM model chain (``settings.llm_chain()``) via ``mcp_core.llm``
+(litellm passthrough). The chain is an ordered list of ``provider/model``
+strings; the provider is derived from each model's prefix
+(``mcp_core.llm.providers``) and litellm routes accordingly. Models are tried
+in order so a transient failure on the primary falls back to the next entry.
 
-    1. Gemini (``GEMINI_API_KEY`` or ``GOOGLE_API_KEY``)
-    2. OpenAI (``OPENAI_API_KEY``)
-    3. Anthropic (``ANTHROPIC_API_KEY``)
-    4. xAI / Grok (``XAI_API_KEY``)
+If the chain is empty (``LLM_MODELS`` unset and no provider key configured for
+any default model), dispatch logs a warning and returns ``None`` so callers
+(compression, graph extraction, temporal extraction) can gracefully skip
+LLM-dependent enrichment.
 
-litellm calls each provider's API directly, so ``ANTHROPIC_API_KEY`` now
-works WITHOUT the ``anthropic`` package installed (no native SDK import).
-
-If no provider key is available, ``call_llm`` logs a warning and returns
-``None`` so callers (e.g. the upcoming ``capture`` action's optional fact
-extraction) can gracefully skip LLM-dependent enrichment.
-
-This module is intentionally a *dispatch layer only*. The actual
-fact-extraction prompting / parsing logic is deferred to Phase 2
-(compression). Existing graph-extraction logic continues to live in
-``graph.py`` and is not migrated here in this slice.
+litellm calls each provider's API directly, so ``ANTHROPIC_API_KEY`` works
+WITHOUT the ``anthropic`` package installed (no native SDK import).
 """
 
 from __future__ import annotations
 
 import os
-from typing import Final
 
 from loguru import logger
-
-# Provider priority is encoded once and consumed by both detection and
-# default-model lookup so they cannot drift apart.
-_PROVIDER_ENV_VARS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
-    ("gemini", ("GEMINI_API_KEY", "GOOGLE_API_KEY")),
-    ("openai", ("OPENAI_API_KEY",)),
-    ("anthropic", ("ANTHROPIC_API_KEY",)),
-    ("xai", ("XAI_API_KEY",)),
-)
-
-# Sane per-provider defaults if ``LLM_MODELS`` env var is not set or does not
-# specify the active provider. Names follow the user's prior choices in the
-# repo (see CLAUDE.md "Default AI models" section); keep these exact unless
-# explicitly directed — see ~/.claude memory feedback_dont_change_model_names.
-_DEFAULT_MODELS: Final[dict[str, str]] = {
-    "gemini": "gemini-3-flash-preview",
-    "openai": "gpt-5.4-mini-2026-03-17",
-    "anthropic": "claude-haiku-4-5",
-    "xai": "grok-4-fast",
-}
+from mcp_core.llm.providers import provider_of_model
 
 
-def detect_provider() -> str | None:
-    """Return the highest-priority provider with a configured API key.
+def llm_chain() -> list[str]:
+    """Return the resolved, key-gated LLM model chain from settings.
 
-    Returns ``None`` when no provider key is found in the environment so
-    callers can short-circuit to a graceful skip path.
+    A thin accessor so callers depend on this module (not ``config``) for the
+    LLM chain, mirroring how ``settings.embedding_chain()`` /
+    ``settings.rerank_chain()`` are consumed by the embed / rerank backends.
     """
-    for provider, env_vars in _PROVIDER_ENV_VARS:
-        for env_var in env_vars:
-            if os.environ.get(env_var):
-                return provider
+    from mnemo_mcp.config import settings
+
+    return settings.llm_chain()
+
+
+def _normalize_model(model: str) -> str:
+    """Normalise a model string to litellm ``provider/model`` form.
+
+    A ``provider/model`` string passes through unchanged. A bare gemini model
+    name (e.g. ``gemini-3-flash-preview``) is prefixed with ``gemini/`` so
+    litellm routes it via ``GEMINI_API_KEY``; any other bare name is left as-is
+    (litellm treats a bare name as an OpenAI model per its convention).
+    """
+    model = model.strip()
+    if "/" in model:
+        return model
+    if "gemini" in model.lower():
+        return f"gemini/{model}"
+    return model
+
+
+def provider_for_model(model: str) -> str:
+    """Provider prefix for a chain model (via the mcp-core primitive)."""
+    return provider_of_model(_normalize_model(model))
+
+
+async def acomplete(
+    messages: list[dict],
+    *,
+    models: list[str] | None = None,
+    temperature: float = 0.0,
+    max_tokens: int = 500,
+    response_format: dict | None = None,
+) -> str | None:
+    """Dispatch a chat completion over the LLM chain with ordered fallback.
+
+    Args:
+        messages: OpenAI-shaped chat messages.
+        models: Explicit chain override. When ``None`` the resolved
+            ``settings.llm_chain()`` is used. The provider for each entry is
+            derived from its prefix; litellm routes via ``<PROVIDER>_API_KEY``.
+        temperature: Sampling temperature passed through to litellm.
+        max_tokens: Maximum response tokens to request.
+        response_format: Optional litellm ``response_format`` (e.g.
+            ``{"type": "json_object"}``); only forwarded when provided.
+
+    Returns:
+        The text content of the first model that responds, or ``None`` when the
+        chain is empty (no provider configured) or every model in the chain
+        fails.
+    """
+    chain = models if models is not None else llm_chain()
+    if not chain:
+        logger.warning(
+            "acomplete: no LLM model configured (LLM_MODELS empty and no "
+            "default-model provider key set); returning None for graceful skip"
+        )
+        return None
+
+    # Lazy import: litellm costs ~1-2s on first import.
+    from mcp_core.llm import acompletion
+
+    api_base = os.environ.get("LLM_API_BASE") or None
+    extra: dict = {"response_format": response_format} if response_format else {}
+
+    last_exc: Exception | None = None
+    for model in chain:
+        try:
+            resp = await acompletion(
+                model=_normalize_model(model),
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                api_base=api_base,
+                **extra,
+            )
+            return resp.choices[0].message.content or ""
+        except Exception as e:  # per-model runtime guard; fall through to next
+            last_exc = e
+            logger.warning(f"acomplete: model={model} failed: {e}; trying next")
+            continue
+
+    logger.warning(
+        f"acomplete: all {len(chain)} chain model(s) failed; last error: {last_exc}"
+    )
     return None
-
-
-def get_default_model(provider: str) -> str:
-    """Return the model name for ``provider``, honouring the ``LLM_MODELS`` env var.
-
-    ``LLM_MODELS`` accepts comma-separated ``provider=model`` or
-    ``provider/model`` pairs (matching the existing settings format), e.g.::
-
-        LLM_MODELS="gemini=gemini-3-flash,openai=gpt-5-mini"
-        LLM_MODELS="gemini/gemini-3-flash,openai/gpt-5-mini"
-
-    The first matching entry wins. If the env var is unset or contains no
-    entry for ``provider``, the per-provider sane default from
-    ``_DEFAULT_MODELS`` is returned.
-    """
-    raw = os.environ.get("LLM_MODELS", "").strip()
-    if raw:
-        for pair in raw.split(","):
-            pair = pair.strip()
-            if not pair:
-                continue
-            for sep in ("=", "/"):
-                if sep in pair:
-                    key, _, model = pair.partition(sep)
-                    if key.strip().lower() == provider:
-                        model = model.strip()
-                        if model:
-                            return model
-                    break
-
-    return _DEFAULT_MODELS.get(provider, "")
 
 
 async def call_llm(
     prompt: str,
-    provider: str | None = None,
-    model: str | None = None,
     *,
+    models: list[str] | None = None,
     temperature: float = 0.0,
     max_tokens: int = 500,
 ) -> str | None:
-    """Dispatch ``prompt`` to the configured LLM provider.
+    """Dispatch a single-turn ``prompt`` over the LLM chain.
 
-    Args:
-        prompt: User prompt text. Treated as a single-turn user message.
-        provider: Optional explicit provider override
-            (``"gemini"`` / ``"openai"`` / ``"anthropic"`` / ``"xai"``).
-            When ``None`` (the default), auto-detection runs.
-        model: Optional explicit model override. When ``None``, the result of
-            :func:`get_default_model` for the resolved provider is used.
-        temperature: Sampling temperature passed through to litellm.
-        max_tokens: Maximum response tokens to request from the provider.
-
-    Returns:
-        The text content of the LLM response, or ``None`` when no provider
-        could be resolved (caller is expected to gracefully skip the
-        LLM-dependent enrichment in that case).
+    Thin wrapper around :func:`acomplete` that wraps ``prompt`` in a single
+    user message. Returns ``None`` when no provider could be resolved (caller
+    is expected to gracefully skip the LLM-dependent enrichment).
     """
-    resolved_provider = provider or detect_provider()
-    if resolved_provider is None:
-        logger.warning(
-            "call_llm: no LLM provider API key found in environment "
-            "(GEMINI_API_KEY / GOOGLE_API_KEY / OPENAI_API_KEY / "
-            "ANTHROPIC_API_KEY / XAI_API_KEY); returning None for graceful skip"
-        )
-        return None
-
-    resolved_model = model or get_default_model(resolved_provider)
-
-    try:
-        # Lazy import: litellm costs ~1-2s on first import.
-        from mcp_core.llm import acompletion
-
-        response = await acompletion(
-            model=f"{resolved_provider}/{resolved_model}",
-            messages=[{"role": "user", "content": prompt}],
-            temperature=temperature,
-            max_tokens=max_tokens,
-            api_base=os.environ.get("LLM_API_BASE") or None,
-        )
-        return response.choices[0].message.content or ""
-    except Exception as e:  # pragma: no cover - per-provider runtime guard
-        logger.warning(
-            f"call_llm: provider={resolved_provider} model={resolved_model} failed: {e}"
-        )
-        return None
+    return await acomplete(
+        [{"role": "user", "content": prompt}],
+        models=models,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1221,16 +1221,13 @@ async def _handle_consolidate(
         )
 
     try:
-        from mnemo_mcp.graph import _llm_completion, _resolve_llm_model
-
-        model = _resolve_llm_model(settings)
+        from mnemo_mcp.llm import acomplete
 
         content_list = "\n---\n".join(
             f"[{m['id'][:8]}] {m['content']}" for m in memories[:20]
         )
 
-        summary = await _llm_completion(
-            model=model,
+        summary = await acomplete(
             messages=[
                 {
                     "role": "user",
@@ -1244,6 +1241,13 @@ async def _handle_consolidate(
             temperature=0,
             max_tokens=1000,
         )
+        if not summary:
+            return _json(
+                {
+                    "error": "Consolidation failed: no LLM model configured",
+                    "suggestion": "Set LLM_MODELS or a <PROVIDER>_API_KEY to enable consolidation.",
+                }
+            )
 
         return _json(
             {

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,8 +1,8 @@
 """Tests for the Phase 2 LLM-driven compression pipeline.
 
 Covers:
-- ``compress`` returns compressed text when a provider is available.
-- Graceful skip when no provider env vars are set.
+- ``compress`` returns compressed text when an LLM chain is available.
+- Graceful skip when no provider env vars are set (empty chain).
 - ``COMPRESSION_ENABLED=false`` env override skips even with a provider.
 - Empty / whitespace-only LLM response degrades to graceful skip.
 - Token counting via tiktoken cl100k_base is reflected in ``tokens_in/out``.
@@ -42,8 +42,8 @@ def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
         "XAI_API_KEY",
+        "LLM_MODELS",
         "COMPRESSION_ENABLED",
-        "COMPRESSION_PROVIDER",
         "COMPRESSION_MODEL",
         "DEDUP_THRESHOLD",
     ):
@@ -64,7 +64,7 @@ SAMPLE_TURN = (
 
 
 async def test_compress_graceful_skip_when_no_provider() -> None:
-    """No provider env -> returns original text + compressed=False."""
+    """No provider env -> empty chain -> original text + compressed=False."""
     result = await compress("any text")
     assert result["compressed"] is False
     assert result["text"] == "any text"
@@ -77,7 +77,7 @@ async def test_compress_graceful_skip_when_no_provider() -> None:
 async def test_compress_returns_compressed_text_when_provider_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With Gemini key + mocked call_llm, compress rewrites text."""
+    """With a Gemini key + mocked call_llm, the default chain compresses text."""
     monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
 
     short_compressed = (
@@ -86,8 +86,10 @@ async def test_compress_returns_compressed_text_when_provider_available(
         "GEMINI_API_KEY in env. Budget $1500. Email user@example.com."
     )
 
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
-        assert provider == "gemini"
+    async def _fake_call(prompt, *, models, temperature, max_tokens):
+        # Default key-gated chain resolves to a gemini model when only the
+        # Gemini key is configured.
+        assert models and models[0].startswith("gemini/")
         assert "<turn>" in prompt
         assert temperature == 0.0
         return short_compressed
@@ -119,55 +121,37 @@ async def test_compress_disabled_via_env(monkeypatch: pytest.MonkeyPatch) -> Non
     assert result["text_raw"] is None
 
 
-async def test_compress_provider_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Explicit provider arg wins over env auto-detection."""
+async def test_compress_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit ``model`` arg becomes the single-model chain."""
     monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
 
-    captured_provider: dict = {"value": None}
+    captured: dict = {"models": None}
 
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
-        captured_provider["value"] = provider
+    async def _fake_call(prompt, *, models, temperature, max_tokens):
+        captured["models"] = models
         return "compressed"
 
     with patch("mnemo_mcp.compression.call_llm", side_effect=_fake_call):
-        await compress("text", provider="openai")
+        await compress("text", model="openai/gpt-4o-mini")
 
-    assert captured_provider["value"] == "openai"
-
-
-async def test_compress_env_provider_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """COMPRESSION_PROVIDER env wins when no explicit arg passed."""
-    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "fake-key-2")
-    monkeypatch.setenv("COMPRESSION_PROVIDER", "openai")
-
-    captured: dict = {"value": None}
-
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
-        captured["value"] = provider
-        return "compressed"
-
-    with patch("mnemo_mcp.compression.call_llm", side_effect=_fake_call):
-        await compress("text")
-
-    assert captured["value"] == "openai"
+    assert captured["models"] == ["openai/gpt-4o-mini"]
 
 
 async def test_compress_env_model_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """COMPRESSION_MODEL env passes through to call_llm."""
+    """COMPRESSION_MODEL env becomes the single-model chain for compression."""
     monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
-    monkeypatch.setenv("COMPRESSION_MODEL", "gemini-2.5-flash")
+    monkeypatch.setenv("COMPRESSION_MODEL", "gemini/gemini-2.5-flash")
 
-    captured: dict = {"value": None}
+    captured: dict = {"models": None}
 
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
-        captured["value"] = model
+    async def _fake_call(prompt, *, models, temperature, max_tokens):
+        captured["models"] = models
         return "compressed"
 
     with patch("mnemo_mcp.compression.call_llm", side_effect=_fake_call):
         await compress("text")
 
-    assert captured["value"] == "gemini-2.5-flash"
+    assert captured["models"] == ["gemini/gemini-2.5-flash"]
 
 
 async def test_compress_empty_response_degrades_to_skip(
@@ -176,7 +160,7 @@ async def test_compress_empty_response_degrades_to_skip(
     """Empty / whitespace LLM response -> graceful skip path."""
     monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
 
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
+    async def _fake_call(prompt, *, models, temperature, max_tokens):
         return "   "
 
     with patch("mnemo_mcp.compression.call_llm", side_effect=_fake_call):
@@ -192,7 +176,7 @@ async def test_compress_sdk_exception_degrades_to_skip(
     """SDK raising mid-call must not bubble into the caller."""
     monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
 
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
+    async def _fake_call(prompt, *, models, temperature, max_tokens):
         raise RuntimeError("simulated SDK failure")
 
     with patch("mnemo_mcp.compression.call_llm", side_effect=_fake_call):
@@ -220,7 +204,7 @@ async def test_capture_writes_compression_columns_when_provider_active(
 ) -> None:
     monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
 
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
+    async def _fake_call(prompt, *, models, temperature, max_tokens):
         return "tight summary keeping facts"
 
     with patch("mnemo_mcp.compression.call_llm", side_effect=_fake_call):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -673,7 +673,58 @@ def test_rerank_models_chain(monkeypatch):
     assert s.rerank_primary() == "jina_ai/jina-reranker-v3"
 
 
-def test_llm_models_chain_default_preserved(monkeypatch):
-    monkeypatch.delenv("LLM_MODELS", raising=False)
-    s = Settings()
-    assert s.llm_chain()[0] == "gemini/gemini-3-flash-preview"
+class TestLlmChain:
+    """LLM chain resolution + key-gated default (F4) + backend status."""
+
+    def test_explicit_models_honored_verbatim(self, monkeypatch):
+        """Explicit LLM_MODELS is honored as-is (not key-filtered)."""
+        monkeypatch.setenv("LLM_MODELS", "openai/gpt-test,gemini/gem-test")
+        s = Settings()
+        assert s.llm_chain() == ["openai/gpt-test", "gemini/gem-test"]
+        assert s.llm_primary() == "openai/gpt-test"
+
+    def test_default_key_gated_to_gemini(self, monkeypatch):
+        """Unset LLM_MODELS + a GEMINI key -> only the gemini default survives."""
+        monkeypatch.delenv("LLM_MODELS", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        s = Settings()
+        assert s.llm_chain() == ["gemini/gemini-3-flash-preview"]
+        assert s.resolve_llm_backend() == "cloud"
+
+    def test_default_key_gated_to_openai(self, monkeypatch):
+        """An OpenAI key -> only the openai default survives (gemini dropped)."""
+        monkeypatch.delenv("LLM_MODELS", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "o-key")
+        s = Settings()
+        assert s.llm_chain() == ["openai/gpt-5.4-mini-2026-03-17"]
+
+    def test_default_both_keys_keeps_chain_order(self, monkeypatch):
+        """Both keys -> both default models survive, in default order."""
+        monkeypatch.delenv("LLM_MODELS", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        monkeypatch.setenv("OPENAI_API_KEY", "o-key")
+        s = Settings()
+        assert s.llm_chain() == [
+            "gemini/gemini-3-flash-preview",
+            "openai/gpt-5.4-mini-2026-03-17",
+        ]
+
+    def test_default_no_key_is_empty_and_unavailable(self, monkeypatch):
+        """No LLM_MODELS + no provider key -> empty chain -> 'unavailable'.
+
+        No keyless cloud model is emitted (F4).
+        """
+        for v in ("LLM_MODELS", "GEMINI_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.delenv(v, raising=False)
+        s = Settings()
+        assert s.llm_chain() == []
+        assert s.llm_primary() is None
+        assert s.resolve_llm_backend() == "unavailable"
+
+    def test_default_google_alias_satisfies_gemini(self, monkeypatch):
+        """GOOGLE_API_KEY (alias) keeps the gemini default model."""
+        monkeypatch.delenv("LLM_MODELS", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "g-key")
+        s = Settings()
+        assert s.llm_chain() == ["gemini/gemini-3-flash-preview"]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -63,7 +63,7 @@ class TestExtractEntities:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value='{"entities": [{"name": "Python", "type": "tool"}], "relations": []}',
             ),
@@ -80,7 +80,7 @@ class TestExtractEntities:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 side_effect=Exception("API error"),
             ),
@@ -95,7 +95,7 @@ class TestExtractEntities:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value="not json",
             ),
@@ -110,7 +110,7 @@ class TestExtractEntities:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value='{"relations": []}',
             ),
@@ -125,7 +125,7 @@ class TestExtractEntities:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value='{"entities": [{"name": "Test", "type": "concept"}], "relations": []}',
             ) as mock_llm,
@@ -136,124 +136,6 @@ class TestExtractEntities:
             result = await extract_entities("test content")
             assert result is not None
             mock_llm.assert_called_once()
-
-    async def test_llm_completion_gemini_bare_name_gets_prefixed(self):
-        """Bare gemini model is prefixed to litellm 'gemini/...' form."""
-        from types import SimpleNamespace
-
-        mock = AsyncMock(
-            return_value=SimpleNamespace(
-                choices=[
-                    SimpleNamespace(message=SimpleNamespace(content="gemini response"))
-                ]
-            )
-        )
-        with patch("mcp_core.llm.acompletion", mock):
-            from mnemo_mcp.graph import _llm_completion
-
-            res = await _llm_completion(
-                "gemini-pro", [{"role": "user", "content": "hi"}]
-            )
-            assert res == "gemini response"
-            assert mock.call_args.kwargs["model"] == "gemini/gemini-pro"
-
-    async def test_llm_completion_slash_form_passes_through(self):
-        """A 'provider/model' string is passed to litellm unchanged."""
-        from types import SimpleNamespace
-
-        mock = AsyncMock(
-            return_value=SimpleNamespace(
-                choices=[
-                    SimpleNamespace(message=SimpleNamespace(content="openai response"))
-                ]
-            )
-        )
-        with patch("mcp_core.llm.acompletion", mock):
-            from mnemo_mcp.graph import _llm_completion
-
-            res = await _llm_completion(
-                "openai/gpt-4", [{"role": "user", "content": "hi"}]
-            )
-            assert res == "openai response"
-            assert mock.call_args.kwargs["model"] == "openai/gpt-4"
-
-    async def test_llm_completion_response_format_forwarded(self):
-        """response_format is forwarded to litellm only when provided."""
-        from types import SimpleNamespace
-
-        mock = AsyncMock(
-            return_value=SimpleNamespace(
-                choices=[SimpleNamespace(message=SimpleNamespace(content="{}"))]
-            )
-        )
-        with patch("mcp_core.llm.acompletion", mock):
-            from mnemo_mcp.graph import _llm_completion
-
-            await _llm_completion(
-                "gemini/gemini-3-flash-preview",
-                [{"role": "user", "content": "hi"}],
-                response_format={"type": "json_object"},
-            )
-            assert mock.call_args.kwargs["response_format"] == {"type": "json_object"}
-
-    async def test_resolve_llm_model_custom(self):
-        from mnemo_mcp.graph import _resolve_llm_model
-
-        class MockSettings:
-            llm_models = " custom/model , other/model "
-
-        assert _resolve_llm_model(MockSettings()) == "custom/model"
-
-    async def test_resolve_llm_model_empty(self):
-        from mnemo_mcp.graph import _resolve_llm_model
-
-        class MockSettings:
-            llm_models = ""
-
-        assert _resolve_llm_model(MockSettings()) == "gemini/gemini-3-flash-preview"
-
-    async def test_resolve_llm_model_equals_form_normalised(self):
-        """=-form first entry is normalised to slash form for litellm."""
-        from mnemo_mcp.graph import _resolve_llm_model
-
-        class MockSettings:
-            llm_models = "gemini=gemini-2.0-flash,openai=gpt-5-mini"
-
-        assert _resolve_llm_model(MockSettings()) == "gemini/gemini-2.0-flash"
-
-    async def test_resolve_llm_model_slash_form_unchanged(self):
-        """Slash-form first entry is passed through unchanged."""
-        from mnemo_mcp.graph import _resolve_llm_model
-
-        class MockSettings:
-            llm_models = "openai/gpt-5.4-mini,gemini/gemini-3-flash-preview"
-
-        assert _resolve_llm_model(MockSettings()) == "openai/gpt-5.4-mini"
-
-    async def test_equals_form_reaches_litellm_as_slash(self):
-        """End-to-end: =-form resolved model reaches acompletion as provider/model."""
-        from types import SimpleNamespace
-
-        from mnemo_mcp.graph import _litellm_model, _resolve_llm_model
-
-        class MockSettings:
-            llm_models = "openai=gpt-5-mini"
-
-        resolved = _resolve_llm_model(MockSettings())
-        assert resolved == "openai/gpt-5-mini"
-        # _litellm_model must NOT double-prefix an already-slash model.
-        assert _litellm_model(resolved) == "openai/gpt-5-mini"
-
-        mock = AsyncMock(
-            return_value=SimpleNamespace(
-                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
-            )
-        )
-        with patch("mcp_core.llm.acompletion", mock):
-            from mnemo_mcp.graph import _llm_completion
-
-            await _llm_completion(resolved, [{"role": "user", "content": "hi"}])
-        assert mock.call_args.kwargs["model"] == "openai/gpt-5-mini"
 
 
 class TestScoreImportance:
@@ -270,7 +152,7 @@ class TestScoreImportance:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value="0.8",
             ),
@@ -285,7 +167,7 @@ class TestScoreImportance:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value="1.5",
             ),
@@ -300,7 +182,7 @@ class TestScoreImportance:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value="-0.3",
             ),
@@ -315,7 +197,7 @@ class TestScoreImportance:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 side_effect=Exception("API error"),
             ),

--- a/tests/test_graph_coverage.py
+++ b/tests/test_graph_coverage.py
@@ -1,10 +1,10 @@
-"""Tests for graph.py -- LLM completion routing and edge cases.
+"""Tests for graph.py -- entity extraction + graph SQL edge cases.
 
-Targets: _llm_completion (Gemini path with json_object, OpenAI path with
-response_format, xAI path), _resolve_llm_model, extract_entities entity
-validation (invalid types, long names), upsert_entities with empty list,
-link_memory_entities empty, link_memory_entities exception,
-find_related_memory_ids no_new_ids early break.
+LLM chain dispatch + model normalization moved to ``mnemo_mcp.llm`` (covered by
+test_llm_provider.py); graph.py now calls ``acomplete`` directly. This module
+covers: extract_entities entity validation (invalid types, long names, non-dict,
+non-string names), _has_llm_provider key detection, upsert_entities edge cases,
+link_memory_entities empty/exception, find_related_memory_ids traversal.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,119 +12,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.graph import (
     _has_llm_provider,
-    _llm_completion,
-    _resolve_llm_model,
     extract_entities,
     find_related_memory_ids,
     link_memory_entities,
     upsert_entities,
 )
-
-# ---------------------------------------------------------------------------
-# _resolve_llm_model
-# ---------------------------------------------------------------------------
-
-
-class TestResolveLlmModel:
-    def test_first_model_from_csv(self):
-        mock_settings = MagicMock()
-        mock_settings.llm_models = "gemini/gemini-3-flash-preview,openai/gpt-5.4-mini"
-        assert _resolve_llm_model(mock_settings) == "gemini/gemini-3-flash-preview"
-
-    def test_single_model(self):
-        mock_settings = MagicMock()
-        mock_settings.llm_models = "openai/gpt-5.4-mini"
-        assert _resolve_llm_model(mock_settings) == "openai/gpt-5.4-mini"
-
-    def test_empty_models_fallback(self):
-        mock_settings = MagicMock()
-        mock_settings.llm_models = ""
-        assert _resolve_llm_model(mock_settings) == "gemini/gemini-3-flash-preview"
-
-
-# ---------------------------------------------------------------------------
-# _llm_completion
-# ---------------------------------------------------------------------------
-
-
-def _completion(content):
-    """Build a litellm-shaped completion response."""
-    from types import SimpleNamespace
-
-    return SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
-    )
-
-
-class TestLlmCompletion:
-    async def test_slash_form_passthrough(self):
-        """A 'provider/model' string is passed to litellm unchanged."""
-        mock = AsyncMock(return_value=_completion('{"result": "test"}'))
-        with patch("mcp_core.llm.acompletion", mock):
-            result = await _llm_completion(
-                "gemini/gemini-3-flash-preview",
-                [{"role": "user", "content": "test prompt"}],
-                response_format={"type": "json_object"},
-            )
-        assert result == '{"result": "test"}'
-        kwargs = mock.call_args.kwargs
-        assert kwargs["model"] == "gemini/gemini-3-flash-preview"
-        assert kwargs["response_format"] == {"type": "json_object"}
-
-    async def test_gemini_bare_name_prefixed(self):
-        """A bare gemini model gets the 'gemini/' prefix for litellm."""
-        mock = AsyncMock(return_value=_completion("0.7"))
-        with patch("mcp_core.llm.acompletion", mock):
-            result = await _llm_completion(
-                "gemini-3-flash-preview",
-                [{"role": "user", "content": "score"}],
-            )
-        assert result == "0.7"
-        assert mock.call_args.kwargs["model"] == "gemini/gemini-3-flash-preview"
-
-    async def test_empty_content(self):
-        """Returns empty string when message.content is None."""
-        mock = AsyncMock(return_value=_completion(None))
-        with patch("mcp_core.llm.acompletion", mock):
-            result = await _llm_completion(
-                "gemini/gemini-3-flash-preview",
-                [{"role": "user", "content": "test"}],
-            )
-        assert result == ""
-
-    async def test_response_format_omitted_when_none(self):
-        """response_format is not forwarded when not provided."""
-        mock = AsyncMock(return_value=_completion('{"entities": []}'))
-        with patch("mcp_core.llm.acompletion", mock):
-            result = await _llm_completion(
-                "openai/gpt-5.4-mini",
-                [{"role": "user", "content": "test"}],
-            )
-        assert result == '{"entities": []}'
-        assert "response_format" not in mock.call_args.kwargs
-
-    async def test_non_gemini_bare_name_passthrough(self):
-        """A non-gemini bare model name is passed to litellm as-is."""
-        mock = AsyncMock(return_value=_completion("0.8"))
-        with patch("mcp_core.llm.acompletion", mock):
-            result = await _llm_completion(
-                "gpt-5.4-mini",
-                [{"role": "user", "content": "test"}],
-            )
-        assert result == "0.8"
-        assert mock.call_args.kwargs["model"] == "gpt-5.4-mini"
-
-    async def test_api_base_from_env(self, monkeypatch):
-        """LLM_API_BASE flows through to acompletion as api_base."""
-        monkeypatch.setenv("LLM_API_BASE", "https://proxy.example/v1")
-        mock = AsyncMock(return_value=_completion("ok"))
-        with patch("mcp_core.llm.acompletion", mock):
-            await _llm_completion(
-                "gemini/gemini-3-flash-preview",
-                [{"role": "user", "content": "test"}],
-            )
-        assert mock.call_args.kwargs["api_base"] == "https://proxy.example/v1"
-
 
 # ---------------------------------------------------------------------------
 # _has_llm_provider
@@ -158,7 +50,7 @@ class TestExtractEntitiesValidation:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value=(
                     '{"entities": ['
@@ -173,7 +65,6 @@ class TestExtractEntitiesValidation:
             ),
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            mock_settings.llm_models = "gemini/gemini-3-flash-preview"
 
             result = await extract_entities("test content")
             assert result is not None
@@ -193,7 +84,7 @@ class TestExtractEntitiesValidation:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value=(
                     f'{{"entities": [{{"name": "{long_name}", "type": "concept"}}, '
@@ -202,7 +93,6 @@ class TestExtractEntitiesValidation:
             ),
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            mock_settings.llm_models = "gemini/gemini-3-flash-preview"
 
             result = await extract_entities("test content")
             assert result is not None
@@ -215,7 +105,7 @@ class TestExtractEntitiesValidation:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value=(
                     '{"entities": ["not_a_dict", {"name": "Valid", "type": "concept"}], "relations": []}'
@@ -223,7 +113,6 @@ class TestExtractEntitiesValidation:
             ),
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            mock_settings.llm_models = "gemini/gemini-3-flash-preview"
 
             result = await extract_entities("test content")
             assert result is not None
@@ -235,7 +124,7 @@ class TestExtractEntitiesValidation:
         with (
             patch("mnemo_mcp.config.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.graph.acomplete",
                 new_callable=AsyncMock,
                 return_value=(
                     '{"entities": [{"name": 123, "type": "concept"}, '
@@ -244,7 +133,6 @@ class TestExtractEntitiesValidation:
             ),
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            mock_settings.llm_models = "gemini/gemini-3-flash-preview"
 
             result = await extract_entities("test content")
             assert result is not None

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,11 +1,12 @@
-"""Tests for the multi-provider LLM dispatch layer (``mnemo_mcp.llm``).
+"""Tests for the chain-based LLM dispatch layer (``mnemo_mcp.llm``).
 
 Focus is on:
-- Auto-detection priority order across the 4 supported providers.
-- Graceful skip path when no provider key is present.
-- Explicit ``provider`` / ``model`` overrides bypass detection.
-- ``LLM_MODELS`` env override resolves model names per provider.
-- Per-provider dispatch routes to the correct SDK call site.
+- ``acomplete`` dispatches over the resolved ``settings.llm_chain()``.
+- Ordered fallback: a failing primary falls through to the next chain entry.
+- Empty chain (no provider key, no LLM_MODELS) -> graceful ``None``.
+- Provider is derived from each model's prefix (bare gemini gets prefixed).
+- ``call_llm`` is a single-user-message wrapper over ``acomplete``.
+- ``LLM_MODELS`` env override flows through the chain.
 """
 
 from __future__ import annotations
@@ -32,219 +33,203 @@ _ALL_KEYS = (
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
+    "JINA_AI_API_KEY",
+    "COHERE_API_KEY",
     "LLM_MODELS",
+    "LLM_API_BASE",
 )
 
 
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Strip all provider env vars before each test for deterministic dispatch."""
+    """Strip provider env vars before each test for deterministic dispatch."""
     for key in _ALL_KEYS:
         monkeypatch.delenv(key, raising=False)
 
 
 # ---------------------------------------------------------------------------
-# detect_provider
+# _normalize_model
 # ---------------------------------------------------------------------------
 
 
-def test_detect_provider_gemini_first(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
-    assert llm.detect_provider() == "gemini"
+def test_normalize_model_slash_form_passthrough() -> None:
+    assert llm._normalize_model("openai/gpt-test") == "openai/gpt-test"
 
 
-def test_detect_provider_google_alias_resolves_to_gemini(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("GOOGLE_API_KEY", "g-key")
-    assert llm.detect_provider() == "gemini"
-
-
-def test_detect_provider_priority_order(monkeypatch: pytest.MonkeyPatch) -> None:
-    # OpenAI beats Anthropic and xAI when Gemini is absent.
-    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
-    monkeypatch.setenv("XAI_API_KEY", "x-key")
-    assert llm.detect_provider() == "openai"
-
-    # Removing OpenAI promotes Anthropic.
-    monkeypatch.delenv("OPENAI_API_KEY")
-    assert llm.detect_provider() == "anthropic"
-
-    # Removing Anthropic promotes xAI as last resort.
-    monkeypatch.delenv("ANTHROPIC_API_KEY")
-    assert llm.detect_provider() == "xai"
-
-
-def test_detect_provider_none_when_no_keys() -> None:
-    assert llm.detect_provider() is None
-
-
-# ---------------------------------------------------------------------------
-# get_default_model
-# ---------------------------------------------------------------------------
-
-
-def test_get_default_model_falls_back_to_builtin() -> None:
-    assert llm.get_default_model("gemini") == llm._DEFAULT_MODELS["gemini"]
-    assert llm.get_default_model("openai") == llm._DEFAULT_MODELS["openai"]
-    assert llm.get_default_model("anthropic") == llm._DEFAULT_MODELS["anthropic"]
-    assert llm.get_default_model("xai") == llm._DEFAULT_MODELS["xai"]
-
-
-def test_get_default_model_from_env_equals_form(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("LLM_MODELS", "gemini=gemini-3-flash-test,openai=gpt-test")
-    assert llm.get_default_model("gemini") == "gemini-3-flash-test"
-    assert llm.get_default_model("openai") == "gpt-test"
-
-
-def test_get_default_model_from_env_slash_form(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv(
-        "LLM_MODELS", "gemini/gemini-3-flash,openai/gpt-5.4-mini-2026-03-17"
+def test_normalize_model_bare_gemini_prefixed() -> None:
+    assert (
+        llm._normalize_model("gemini-3-flash-preview")
+        == "gemini/gemini-3-flash-preview"
     )
-    assert llm.get_default_model("gemini") == "gemini-3-flash"
-    assert llm.get_default_model("openai") == "gpt-5.4-mini-2026-03-17"
 
 
-def test_get_default_model_unknown_provider_returns_empty() -> None:
-    assert llm.get_default_model("unknown-provider") == ""
+def test_normalize_model_bare_other_passthrough() -> None:
+    assert llm._normalize_model("gpt-5.4-mini") == "gpt-5.4-mini"
+
+
+def test_provider_for_model_derives_from_prefix() -> None:
+    assert llm.provider_for_model("gemini/gemini-3-flash-preview") == "gemini"
+    assert llm.provider_for_model("openai/gpt-test") == "openai"
+    # bare gemini normalises then resolves to gemini
+    assert llm.provider_for_model("gemini-3-flash-preview") == "gemini"
+    # bare non-gemini is an OpenAI model by litellm convention
+    assert llm.provider_for_model("gpt-5.4-mini") == "openai"
 
 
 # ---------------------------------------------------------------------------
-# call_llm — graceful skip
+# acomplete — chain dispatch
 # ---------------------------------------------------------------------------
 
 
-def test_call_llm_graceful_skip_no_provider() -> None:
-    """When no provider is configured, call_llm returns None and warns."""
+def test_acomplete_dispatches_primary_of_explicit_chain() -> None:
+    mock = AsyncMock(return_value=_fake_completion("ok"))
+    with patch("mcp_core.llm.acompletion", mock):
+        result = asyncio.run(
+            llm.acomplete(
+                [{"role": "user", "content": "hi"}],
+                models=["gemini/gemini-3-flash-preview"],
+            )
+        )
+    assert result == "ok"
+    assert mock.call_args.kwargs["model"] == "gemini/gemini-3-flash-preview"
+    assert mock.call_args.kwargs["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_acomplete_empty_chain_returns_none() -> None:
     with patch.object(llm.logger, "warning") as warn:
-        result = asyncio.run(llm.call_llm("hello"))
-    assert result is None
-    assert warn.called, "expected a warning log on graceful skip"
-    msg = warn.call_args.args[0] if warn.call_args.args else ""
-    assert "no LLM provider" in msg
-
-
-def test_call_llm_unknown_explicit_provider_returns_none() -> None:
-    """Explicit but unsupported provider returns None when litellm raises."""
-    mock = AsyncMock(side_effect=Exception("bogus provider"))
-    with (
-        patch("mcp_core.llm.acompletion", mock),
-        patch.object(llm.logger, "warning") as warn,
-    ):
-        result = asyncio.run(llm.call_llm("hello", provider="bogus"))
+        result = asyncio.run(
+            llm.acomplete([{"role": "user", "content": "hi"}], models=[])
+        )
     assert result is None
     assert warn.called
 
 
-# ---------------------------------------------------------------------------
-# call_llm — litellm passthrough dispatch
-# ---------------------------------------------------------------------------
-
-
-def test_call_llm_dispatches_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
-
-    mock = AsyncMock(return_value=_fake_completion("from gemini"))
-    with patch("mcp_core.llm.acompletion", mock):
-        result = asyncio.run(llm.call_llm("hi"))
-
-    assert result == "from gemini"
-    call_kwargs = mock.call_args.kwargs
-    assert call_kwargs["model"] == f"gemini/{llm._DEFAULT_MODELS['gemini']}"
-    assert call_kwargs["messages"] == [{"role": "user", "content": "hi"}]
-
-
-def test_call_llm_dispatches_openai(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
-
-    mock = AsyncMock(return_value=_fake_completion("from openai"))
+def test_acomplete_falls_back_to_next_model_on_failure() -> None:
+    mock = AsyncMock(
+        side_effect=[Exception("primary down"), _fake_completion("from fallback")]
+    )
     with patch("mcp_core.llm.acompletion", mock):
         result = asyncio.run(
-            llm.call_llm("hi", model="gpt-test", temperature=0.2, max_tokens=42)
+            llm.acomplete(
+                [{"role": "user", "content": "hi"}],
+                models=["gemini/gemini-3-flash-preview", "openai/gpt-test"],
+            )
         )
-
-    assert result == "from openai"
-    call_kwargs = mock.call_args.kwargs
-    assert call_kwargs["model"] == "openai/gpt-test"
-    assert call_kwargs["messages"] == [{"role": "user", "content": "hi"}]
-    assert call_kwargs["temperature"] == 0.2
-    assert call_kwargs["max_tokens"] == 42
+    assert result == "from fallback"
+    assert mock.await_count == 2
+    # Second call used the fallback model.
+    assert mock.call_args.kwargs["model"] == "openai/gpt-test"
 
 
-def test_call_llm_dispatches_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
-    """ANTHROPIC_API_KEY now works WITHOUT the anthropic package (litellm)."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
+def test_acomplete_all_fail_returns_none() -> None:
+    mock = AsyncMock(side_effect=Exception("boom"))
+    with (
+        patch("mcp_core.llm.acompletion", mock),
+        patch.object(llm.logger, "warning") as warn,
+    ):
+        result = asyncio.run(
+            llm.acomplete(
+                [{"role": "user", "content": "hi"}],
+                models=["gemini/a", "openai/b"],
+            )
+        )
+    assert result is None
+    assert mock.await_count == 2
+    assert warn.called
 
-    mock = AsyncMock(return_value=_fake_completion("from anthropic"))
-    # No `anthropic` package: ensure import is never attempted.
-    with patch.dict("sys.modules", {"anthropic": None}):
-        with patch("mcp_core.llm.acompletion", mock):
-            result = asyncio.run(llm.call_llm("hi"))
 
-    assert result == "from anthropic"
-    call_kwargs = mock.call_args.kwargs
-    assert call_kwargs["model"] == f"anthropic/{llm._DEFAULT_MODELS['anthropic']}"
-    assert call_kwargs["messages"] == [{"role": "user", "content": "hi"}]
-
-
-def test_call_llm_dispatches_xai(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("XAI_API_KEY", "x-key")
-
-    mock = AsyncMock(return_value=_fake_completion("from xai"))
+def test_acomplete_response_format_forwarded_only_when_set() -> None:
+    mock = AsyncMock(return_value=_fake_completion("{}"))
     with patch("mcp_core.llm.acompletion", mock):
-        result = asyncio.run(llm.call_llm("hi"))
+        asyncio.run(
+            llm.acomplete(
+                [{"role": "user", "content": "hi"}],
+                models=["openai/gpt-test"],
+                response_format={"type": "json_object"},
+            )
+        )
+    assert mock.call_args.kwargs["response_format"] == {"type": "json_object"}
 
-    assert result == "from xai"
-    call_kwargs = mock.call_args.kwargs
-    assert call_kwargs["model"] == f"xai/{llm._DEFAULT_MODELS['xai']}"
+    mock2 = AsyncMock(return_value=_fake_completion("{}"))
+    with patch("mcp_core.llm.acompletion", mock2):
+        asyncio.run(
+            llm.acomplete(
+                [{"role": "user", "content": "hi"}], models=["openai/gpt-test"]
+            )
+        )
+    assert "response_format" not in mock2.call_args.kwargs
 
 
-def test_call_llm_passes_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
-    """LLM_API_BASE flows through to acompletion as api_base."""
-    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
-    monkeypatch.setenv("LLM_API_BASE", "https://proxy.example/v1")
-
+def test_acomplete_bare_gemini_model_prefixed() -> None:
     mock = AsyncMock(return_value=_fake_completion("ok"))
     with patch("mcp_core.llm.acompletion", mock):
-        asyncio.run(llm.call_llm("hi"))
+        asyncio.run(
+            llm.acomplete(
+                [{"role": "user", "content": "hi"}],
+                models=["gemini-3-flash-preview"],
+            )
+        )
+    assert mock.call_args.kwargs["model"] == "gemini/gemini-3-flash-preview"
 
+
+def test_acomplete_passes_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_API_BASE", "https://proxy.example/v1")
+    mock = AsyncMock(return_value=_fake_completion("ok"))
+    with patch("mcp_core.llm.acompletion", mock):
+        asyncio.run(
+            llm.acomplete(
+                [{"role": "user", "content": "hi"}], models=["openai/gpt-test"]
+            )
+        )
     assert mock.call_args.kwargs["api_base"] == "https://proxy.example/v1"
 
 
-# ---------------------------------------------------------------------------
-# Overrides
-# ---------------------------------------------------------------------------
-
-
-def test_call_llm_explicit_provider_override_skips_detection(
+def test_acomplete_uses_settings_chain_when_models_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``provider="openai"`` must dispatch to OpenAI even when Gemini is detected."""
-    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
-    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
-
-    mock = AsyncMock(return_value=_fake_completion("from openai"))
+    """acomplete(models=None) consumes the resolved settings.llm_chain()."""
+    monkeypatch.setattr(
+        "mnemo_mcp.config.settings.llm_models", "openai/gpt-from-settings"
+    )
+    mock = AsyncMock(return_value=_fake_completion("ok"))
     with patch("mcp_core.llm.acompletion", mock):
-        result = asyncio.run(llm.call_llm("hi", provider="openai"))
-
-    assert result == "from openai"
-    call_kwargs = mock.call_args.kwargs
-    assert call_kwargs["model"].startswith("openai/")
+        result = asyncio.run(llm.acomplete([{"role": "user", "content": "hi"}]))
+    assert result == "ok"
+    assert mock.call_args.kwargs["model"] == "openai/gpt-from-settings"
 
 
-def test_call_llm_uses_env_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
-    monkeypatch.setenv("LLM_MODELS", "gemini=gemini-3-flash-from-env")
+# ---------------------------------------------------------------------------
+# call_llm — single-prompt wrapper
+# ---------------------------------------------------------------------------
 
+
+def test_call_llm_graceful_skip_no_provider() -> None:
+    """No LLM_MODELS + no provider key -> empty chain -> None."""
+    with patch.object(llm.logger, "warning") as warn:
+        result = asyncio.run(llm.call_llm("hello"))
+    assert result is None
+    assert warn.called
+
+
+def test_call_llm_wraps_prompt_in_user_message() -> None:
+    mock = AsyncMock(return_value=_fake_completion("answer"))
+    with patch("mcp_core.llm.acompletion", mock):
+        result = asyncio.run(
+            llm.call_llm(
+                "hi", models=["openai/gpt-test"], temperature=0.2, max_tokens=42
+            )
+        )
+    assert result == "answer"
+    assert mock.call_args.kwargs["messages"] == [{"role": "user", "content": "hi"}]
+    assert mock.call_args.kwargs["temperature"] == 0.2
+    assert mock.call_args.kwargs["max_tokens"] == 42
+
+
+def test_call_llm_uses_settings_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mnemo_mcp.config.settings.llm_models", "gemini/gemini-3-flash-from-settings"
+    )
     mock = AsyncMock(return_value=_fake_completion("ok"))
     with patch("mcp_core.llm.acompletion", mock):
         asyncio.run(llm.call_llm("hi"))
-
-    call_kwargs = mock.call_args.kwargs
-    assert call_kwargs["model"] == "gemini/gemini-3-flash-from-env"
+    assert mock.call_args.kwargs["model"] == "gemini/gemini-3-flash-from-settings"

--- a/tests/test_passport_actions.py
+++ b/tests/test_passport_actions.py
@@ -276,7 +276,7 @@ async def test_memory_compress_rewrites_existing_row(
     )
     isolated_db._conn.commit()
 
-    async def _fake_call(prompt, provider, model, *, temperature, max_tokens):
+    async def _fake_call(prompt, *, models, temperature, max_tokens):
         return "tight summary"
 
     ctx = _make_ctx(isolated_db)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -649,7 +649,7 @@ class TestConsolidate:
         with (
             patch("mnemo_mcp.server.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.llm.acomplete",
                 new_callable=AsyncMock,
                 return_value="Python is excellent",
             ),
@@ -671,7 +671,7 @@ class TestConsolidate:
         with (
             patch("mnemo_mcp.server.settings") as mock_settings,
             patch(
-                "mnemo_mcp.graph._llm_completion",
+                "mnemo_mcp.llm.acomplete",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("LLM error"),
             ),


### PR DESCRIPTION
## Problem
The LLM path (graph extraction, importance scoring, compression, consolidation) still used a legacy provider-priority + hardcoded per-provider default model (`detect_provider` / `_DEFAULT_MODELS`) that ignored `LLM_MODELS` -- while embed/rerank already used `settings.<task>_chain()`. This was the still-valid part of the 'still uses hardcoded provider/model' complaint.

## Fix
- `llm.py` exposes `acomplete()`/`call_llm()` dispatching over `settings.llm_chain()` with ordered fallback; provider derived from each model's prefix (`mcp_core.llm.providers`); key-gated default chain; graceful `None` on empty chain.
- `graph.py`, `compression.py`, and `server._handle_consolidate` consume the chain API.
- Legacy `detect_provider` / `_resolve_llm_model` / `_llm_completion` / `_DEFAULT_MODELS` removed.

## Tests
Full suite green: 1333 passed, 78 deselected. Graph/compression/consolidation tests migrated to the chain API; llm-chain key-gating covered in test_llm_provider/test_config.