### PR TITLE
fix: skip GDrive device-code on Cloudflare (D1+Vectorize is the store)

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -434,6 +434,16 @@ def _save_local_credentials(config: dict[str, str]) -> None:
         )
 
 
+def _sync_redundant_on_cf() -> bool:
+    """Whether Google Drive docs-sync is redundant on this deployment.
+
+    On Cloudflare the memory DB is D1 + Vectorize (durable across container
+    recreate), so the GDrive delta-sync is redundant. Skip the device-code flow
+    there so the relay never offers a non-functional Google Drive setup.
+    """
+    return os.environ.get("DOCS_DB_BACKEND", "").strip().lower() == "cf-d1"
+
+
 def _trigger_gdrive_flow(
     sub: str | None = None, auto_open: bool = False
 ) -> dict | None:
@@ -455,6 +465,13 @@ def _trigger_gdrive_flow(
     except Exception:
         # Resolver failure is non-fatal — fall through to legacy GDrive path.
         logger.opt(exception=True).debug("resolve_active_backend failed")
+
+    if _sync_redundant_on_cf():
+        logger.info(
+            "GDrive flow skipped: DOCS_DB_BACKEND=cf-d1 (D1+Vectorize durable, "
+            "delta-sync redundant on Cloudflare)"
+        )
+        return None
 
     try:
         from mnemo_mcp.config import settings as s

--- a/tests/test_cf_skip_gdrive.py
+++ b/tests/test_cf_skip_gdrive.py
@@ -1,0 +1,39 @@
+"""F9: skip GDrive device-code on Cloudflare.
+
+On CF the memory DB is D1 + Vectorize (durable), so the Google Drive delta-sync
+is redundant; the relay must not trigger a non-functional GDrive setup there.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mnemo_mcp.credential_state import _sync_redundant_on_cf, _trigger_gdrive_flow
+
+
+def test_sync_redundant_on_cf(monkeypatch):
+    monkeypatch.delenv("DOCS_DB_BACKEND", raising=False)
+    assert _sync_redundant_on_cf() is False
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    assert _sync_redundant_on_cf() is True
+    monkeypatch.setenv("DOCS_DB_BACKEND", "sqlite")
+    assert _sync_redundant_on_cf() is False
+
+
+def test_gdrive_flow_skipped_on_cf(monkeypatch):
+    """With GDrive creds present, the device-code flow is still skipped on CF."""
+    monkeypatch.setenv("DOCS_DB_BACKEND", "cf-d1")
+    monkeypatch.delenv("SYNC_S3_BUCKET", raising=False)
+
+    from mnemo_mcp.config import settings
+
+    monkeypatch.setattr(settings, "google_drive_client_id", "cid", raising=False)
+    monkeypatch.setattr(
+        settings, "google_drive_client_secret", "csecret", raising=False
+    )
+
+    with patch("httpx.post") as mock_post:
+        result = _trigger_gdrive_flow(auto_open=True)
+
+    assert result is None
+    assert mock_post.call_count == 0


### PR DESCRIPTION
On Cloudflare the memory DB is D1 + Vectorize (durable across container recreate), so the Google Drive delta-sync is redundant -- but the relay still triggered the GDrive device-code flow, offering a non-functional setup.

`_trigger_gdrive_flow` (the single chokepoint for both the multi-user and single-user save paths, already gated for S3 mode) now returns early when `DOCS_DB_BACKEND=cf-d1`. Mirrors the same fix in wet-mcp.

## Tests
Full suite: 1350 passed. New: `_sync_redundant_on_cf` truth table + GDrive device-code not triggered on CF even with GDrive client creds present.