### PR TITLE
fix: wire per-sub credentials into live embed/rerank/llm dispatch

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -96,6 +96,37 @@ def credentials_for_current_request() -> dict[str, str]:
     return PerPluginStore("mnemo", safe_sub, backend=_cred_backend()).load() or {}
 
 
+def api_key_for_model(model: str) -> str | None:
+    """Resolve the per-request API key for a litellm ``model`` at dispatch time.
+
+    The credential for one user MUST NOT be applied to the process-global
+    ``os.environ`` (it would leak to concurrent requests of a different JWT
+    ``sub``). Instead, the live embed / rerank / LLM dispatch paths call this
+    helper and pass the returned key explicitly down to the litellm call.
+
+    Behaviour:
+
+    - **Single-user** (``_current_sub`` unset -- stdio or single-user HTTP):
+      returns ``None`` so litellm keeps reading the key from ``os.environ``
+      (the existing singleton / ``apply_config`` -> env path is unchanged).
+    - **Multi-user remote** (``_current_sub`` set): resolves the canonical key
+      env var for ``model`` (via the mcp-core ``key_env_for_model`` primitive,
+      e.g. ``jina_ai/...`` -> ``JINA_AI_API_KEY``) and returns the matching
+      value from the per-``sub`` config, or ``None`` when that user has not
+      configured the provider.
+
+    Returning ``None`` is always safe: the cloud backends treat a falsy
+    ``api_key`` as "let litellm resolve from env", and in multi-user mode the
+    process env carries no per-sub secrets.
+    """
+    if _current_sub.get() is None:
+        return None
+    from mcp_core.llm.providers import key_env_for_model
+
+    env_var = key_env_for_model(model)
+    return credentials_for_current_request().get(env_var) or None
+
+
 class CredentialState(Enum):
     AWAITING_SETUP = "awaiting_setup"
     SETUP_IN_PROGRESS = "setup_in_progress"

--- a/src/mnemo_mcp/llm.py
+++ b/src/mnemo_mcp/llm.py
@@ -93,18 +93,27 @@ async def acomplete(
     # Lazy import: litellm costs ~1-2s on first import.
     from mcp_core.llm import acompletion
 
+    from mnemo_mcp.credential_state import api_key_for_model
+
     api_base = os.environ.get("LLM_API_BASE") or None
     extra: dict = {"response_format": response_format} if response_format else {}
 
     last_exc: Exception | None = None
     for model in chain:
+        normalized = _normalize_model(model)
         try:
+            # Multi-user remote: resolve THIS request's per-``sub`` key for the
+            # model and pass it explicitly so one tenant's key never reaches
+            # another's request (the key is never applied to process env).
+            # Single-user: ``api_key_for_model`` returns ``None`` -> litellm
+            # reads the key from env (existing behaviour preserved).
             resp = await acompletion(
-                model=_normalize_model(model),
+                model=normalized,
                 messages=messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 api_base=api_base,
+                api_key=api_key_for_model(normalized),
                 **extra,
             )
             return resp.choices[0].message.content or ""

--- a/src/mnemo_mcp/relay_setup.py
+++ b/src/mnemo_mcp/relay_setup.py
@@ -51,9 +51,19 @@ def load_relay_config() -> dict[str, str] | None:
 
 
 def apply_config(config: dict[str, str]) -> None:
-    """Apply config dict to environment variables."""
+    """Apply config dict to environment variables (single-user mode only).
+
+    Overwrites an existing env var when the new value differs so a single-user
+    reconfigure (e.g. rotating a key via the relay form) actually takes effect.
+    The previous ``key not in os.environ`` guard silently dropped the new value
+    whenever the var was already set, leaving stale credentials in the process.
+
+    This MUST stay single-user only: callers route multi-user per-``sub``
+    credentials through ``store_for_sub`` + request-scoped dispatch, never to
+    the process-global ``os.environ`` (which would leak across tenants).
+    """
     for key, value in config.items():
-        if value and key not in os.environ:
+        if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -452,6 +452,57 @@ def _format_memory(mem: dict) -> dict:
     return mem
 
 
+def _resolve_request_embed_backend(model: str):
+    """Pick the embedding backend for the current request.
+
+    Single-user (``_current_sub`` unset): return the startup singleton -- the
+    cloud singleton already carries the env-resolved key, the local Qwen3
+    singleton needs none. Behaviour is unchanged.
+
+    Multi-user remote (``_current_sub`` set): the startup singleton must NOT be
+    used for cloud models, because it was created once with no per-``sub`` key
+    (litellm would read the process env, which carries no per-``sub`` secret --
+    or worse, one tenant's leaked key). Instead build a *request-scoped*
+    ``CloudEmbeddingBackend`` with this ``sub``'s key resolved at dispatch time
+    via :func:`credentials_for_current_request`. The local ``__local__`` model
+    needs no key, so the singleton is reused for it.
+    """
+    from mnemo_mcp.credential_state import api_key_for_model, get_current_sub
+    from mnemo_mcp.embedder import CloudEmbeddingBackend, get_backend
+
+    singleton = get_backend()
+    if get_current_sub() is None or model == "__local__":
+        return singleton
+
+    # Multi-user cloud dispatch: per-request backend keyed by this sub's key.
+    return CloudEmbeddingBackend(model, api_key=api_key_for_model(model))
+
+
+def _resolve_request_reranker(singleton):
+    """Pick the reranker for the current request.
+
+    Single-user (``_current_sub`` unset): return the startup singleton
+    unchanged (cloud singleton carries the env key; local needs none).
+
+    Multi-user remote (``_current_sub`` set) with a configured cloud rerank
+    chain: build a *request-scoped* :class:`CloudReranker` keyed by this
+    ``sub``'s key, resolved at dispatch time -- never the shared singleton
+    (which carries no per-``sub`` key). When the deployment has no cloud rerank
+    chain (local ONNX cross-encoder), reuse the singleton since it needs no key.
+    """
+    from mnemo_mcp.credential_state import api_key_for_model, get_current_sub
+    from mnemo_mcp.reranker import CloudReranker
+
+    if get_current_sub() is None:
+        return singleton
+
+    model = settings.rerank_primary()
+    if not model:
+        # No cloud rerank chain configured -> local ONNX path, no key needed.
+        return singleton
+    return CloudReranker(model, api_key=api_key_for_model(model))
+
+
 async def _embed(
     text: str, model: str | None, dims: int, is_query: bool = False
 ) -> list[float] | None:
@@ -467,9 +518,9 @@ async def _embed(
     if not model:
         return None
 
-    from mnemo_mcp.embedder import Qwen3EmbedBackend, get_backend
+    from mnemo_mcp.embedder import Qwen3EmbedBackend
 
-    backend = get_backend()
+    backend = _resolve_request_embed_backend(model)
     if backend is None:
         # Should not happen if model is set (implies init succeeded), but safe guard.
         logger.warning(f"Embedding backend not initialized despite model={model}")
@@ -652,7 +703,7 @@ async def _handle_search(
     # when a reranker is active and otherwise stay at the LLM-requested limit.
     from mnemo_mcp.reranker import get_reranker
 
-    reranker = get_reranker()
+    reranker = _resolve_request_reranker(get_reranker())
     rerank_pool = max(50, limit * 5) if reranker else None
 
     results = await asyncio.to_thread(

--- a/tests/test_multi_user_dispatch.py
+++ b/tests/test_multi_user_dispatch.py
@@ -1,0 +1,316 @@
+"""Dispatch-level multi-user credential isolation tests.
+
+The accessor-level tests in ``test_multi_user.py`` prove that
+``credentials_for_current_request()`` returns the right per-``sub`` dict. They
+do NOT prove that the per-``sub`` key actually reaches the live litellm call
+during embed / rerank / LLM dispatch -- which is the crg-class bug this module
+guards: the embed / rerank backends were module-level singletons created at
+startup with ``api_key=None`` (litellm read the process env), and ``acomplete``
+called ``acompletion`` with no ``api_key``, so a relay-submitted per-``sub`` key
+(``store_for_sub``) never reached embed / rerank / LLM in multi-user mode.
+
+These tests mock the lowest litellm passthrough (``mcp_core.llm.aembedding`` /
+``acompletion`` / ``rerank``) and assert the ``api_key=`` kwarg equals the per-
+``sub`` value -- and that a second ``sub`` driving the SAME process does not see
+the first ``sub``'s key.
+
+Spec: ``~/.claude/skills/mcp-dev/references/multi-user-pattern.md`` +
+``2026-05-01-stdio-pure-http-multiuser.md`` §4.2.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _credential_secret(monkeypatch):
+    """Per-sub config routes through PerPluginStore, whose multi-user key
+    derivation requires CREDENTIAL_SECRET. Real deployments always set it."""
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret")
+
+
+@pytest.fixture(autouse=True)
+def _reset_current_sub():
+    """Guarantee ``_current_sub`` is ``None`` before/after every test so a sub
+    cannot leak across tests and mask an isolation bug."""
+    from mnemo_mcp.credential_state import _current_sub
+
+    token = _current_sub.set(None)
+    try:
+        yield
+    finally:
+        _current_sub.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cloud_env(monkeypatch):
+    """Clear all cloud keys from the process env so a leaked env value cannot
+    accidentally satisfy an assertion (the whole point is that multi-user
+    dispatch must NOT read process env)."""
+    from mnemo_mcp.credential_state import CLOUD_KEYS
+
+    for key in CLOUD_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _embed_resp(*vectors):
+    return SimpleNamespace(
+        data=[
+            SimpleNamespace(index=i, embedding=list(v)) for i, v in enumerate(vectors)
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# api_key_for_model helper
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_for_model_single_user_returns_none(monkeypatch):
+    """Single-user (no ``_current_sub``): helper returns ``None`` so litellm
+    keeps reading the key from env (singleton behaviour unchanged)."""
+    monkeypatch.setenv("JINA_AI_API_KEY", "env-key")
+    from mnemo_mcp.credential_state import api_key_for_model
+
+    assert api_key_for_model("jina_ai/jina-embeddings-v5-text-small") is None
+
+
+def test_api_key_for_model_resolves_per_sub(tmp_path, monkeypatch):
+    """Multi-user: helper maps model -> key env var -> per-sub value."""
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import (
+        _current_sub,
+        api_key_for_model,
+        store_for_sub,
+    )
+
+    store_for_sub("alice", {"JINA_AI_API_KEY": "alice-jina"})
+    token = _current_sub.set("alice")
+    try:
+        assert (
+            api_key_for_model("jina_ai/jina-embeddings-v5-text-small") == "alice-jina"
+        )
+        # A provider Alice did not configure resolves to None, not a crash.
+        assert api_key_for_model("cohere/rerank-v3.5") is None
+    finally:
+        _current_sub.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# embed dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_embed_passes_per_sub_key_to_litellm(tmp_path, monkeypatch):
+    """``_embed`` under an active sub must pass that sub's key to ``aembedding``,
+    NOT ``None`` (which would let litellm fall back to the process env)."""
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import _current_sub, store_for_sub
+    from mnemo_mcp.server import _embed
+
+    store_for_sub("alice", {"JINA_AI_API_KEY": "alice-embed-key"})
+
+    mock = AsyncMock(return_value=_embed_resp([0.1, 0.2, 0.3]))
+    token = _current_sub.set("alice")
+    try:
+        with patch("mcp_core.llm.aembedding", mock):
+            result = await _embed("hello", "jina_ai/jina-embeddings-v5-text-small", 3)
+    finally:
+        _current_sub.reset(token)
+
+    assert result == [0.1, 0.2, 0.3]
+    mock.assert_awaited_once()
+    assert mock.call_args.kwargs.get("api_key") == "alice-embed-key"
+
+
+async def test_embed_second_sub_does_not_see_first_sub_key(tmp_path, monkeypatch):
+    """Two subs drive ``_embed`` in the same process; each litellm call must
+    carry only its own sub's key (no bleed via a cached singleton)."""
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import _current_sub, store_for_sub
+    from mnemo_mcp.server import _embed
+
+    store_for_sub("alice", {"JINA_AI_API_KEY": "alice-embed-key"})
+    store_for_sub("bob", {"JINA_AI_API_KEY": "bob-embed-key"})
+
+    mock = AsyncMock(return_value=_embed_resp([0.1]))
+
+    # Alice's request first.
+    token = _current_sub.set("alice")
+    try:
+        with patch("mcp_core.llm.aembedding", mock):
+            await _embed("q", "jina_ai/jina-embeddings-v5-text-small", 1)
+    finally:
+        _current_sub.reset(token)
+    assert mock.call_args.kwargs.get("api_key") == "alice-embed-key"
+
+    # Bob's request second -- must NOT inherit Alice's key.
+    token = _current_sub.set("bob")
+    try:
+        with patch("mcp_core.llm.aembedding", mock):
+            await _embed("q", "jina_ai/jina-embeddings-v5-text-small", 1)
+    finally:
+        _current_sub.reset(token)
+    assert mock.call_args.kwargs.get("api_key") == "bob-embed-key"
+
+
+# ---------------------------------------------------------------------------
+# rerank dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_rerank_passes_per_sub_key_to_litellm(tmp_path, monkeypatch):
+    """The reranker invoked from ``_handle_search`` under an active sub must
+    pass that sub's key to ``mcp_core.llm.rerank``."""
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    # A cloud rerank chain is forced so the request-scoped CloudReranker path
+    # is exercised regardless of which provider keys exist in the process env.
+    monkeypatch.setattr("mnemo_mcp.config.settings.rerank_models", "cohere/rerank-v3.5")
+    from mnemo_mcp.credential_state import _current_sub, store_for_sub
+    from mnemo_mcp.server import _resolve_request_reranker
+
+    store_for_sub("alice", {"COHERE_API_KEY": "alice-rerank-key"})
+
+    rerank_resp = SimpleNamespace(
+        results=[SimpleNamespace(index=0, relevance_score=0.9)]
+    )
+    mock = MagicMock(return_value=rerank_resp)
+
+    token = _current_sub.set("alice")
+    try:
+        reranker = _resolve_request_reranker(MagicMock(name="startup_singleton"))
+        with patch("mcp_core.llm.rerank", mock):
+            ranked = reranker.rerank("q", ["doc one", "doc two"], top_n=1)
+    finally:
+        _current_sub.reset(token)
+
+    assert ranked == [(0, 0.9)]
+    mock.assert_called_once()
+    assert mock.call_args.kwargs.get("api_key") == "alice-rerank-key"
+
+
+async def test_rerank_second_sub_does_not_see_first_sub_key(tmp_path, monkeypatch):
+    """Two subs rerank in the same process; no key bleed via singleton."""
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr("mnemo_mcp.config.settings.rerank_models", "cohere/rerank-v3.5")
+    from mnemo_mcp.credential_state import _current_sub, store_for_sub
+    from mnemo_mcp.server import _resolve_request_reranker
+
+    store_for_sub("alice", {"COHERE_API_KEY": "alice-rerank-key"})
+    store_for_sub("bob", {"COHERE_API_KEY": "bob-rerank-key"})
+
+    rerank_resp = SimpleNamespace(
+        results=[SimpleNamespace(index=0, relevance_score=0.9)]
+    )
+    mock = MagicMock(return_value=rerank_resp)
+    startup_singleton = MagicMock(name="startup_singleton")
+
+    token = _current_sub.set("alice")
+    try:
+        with patch("mcp_core.llm.rerank", mock):
+            _resolve_request_reranker(startup_singleton).rerank("q", ["a", "b"], 1)
+    finally:
+        _current_sub.reset(token)
+    assert mock.call_args.kwargs.get("api_key") == "alice-rerank-key"
+
+    token = _current_sub.set("bob")
+    try:
+        with patch("mcp_core.llm.rerank", mock):
+            _resolve_request_reranker(startup_singleton).rerank("q", ["a", "b"], 1)
+    finally:
+        _current_sub.reset(token)
+    assert mock.call_args.kwargs.get("api_key") == "bob-rerank-key"
+
+
+# ---------------------------------------------------------------------------
+# LLM dispatch (acomplete)
+# ---------------------------------------------------------------------------
+
+
+async def test_acomplete_passes_per_sub_key_to_litellm(tmp_path, monkeypatch):
+    """``acomplete`` under an active sub must pass that sub's key for the
+    resolved chain model to ``acompletion``."""
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import _current_sub, store_for_sub
+    from mnemo_mcp.llm import acomplete
+
+    store_for_sub("alice", {"GEMINI_API_KEY": "alice-gemini-key"})
+
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))]
+    )
+    mock = AsyncMock(return_value=resp)
+
+    token = _current_sub.set("alice")
+    try:
+        with patch("mcp_core.llm.acompletion", mock):
+            out = await acomplete(
+                [{"role": "user", "content": "ping"}],
+                models=["gemini/gemini-3-flash-preview"],
+            )
+    finally:
+        _current_sub.reset(token)
+
+    assert out == "hi"
+    mock.assert_awaited_once()
+    assert mock.call_args.kwargs.get("api_key") == "alice-gemini-key"
+
+
+async def test_acomplete_second_sub_does_not_see_first_sub_key(tmp_path, monkeypatch):
+    """Two subs drive ``acomplete`` in the same process; no key bleed."""
+    monkeypatch.setenv("MNEMO_DATA_DIR", str(tmp_path))
+    from mnemo_mcp.credential_state import _current_sub, store_for_sub
+    from mnemo_mcp.llm import acomplete
+
+    store_for_sub("alice", {"GEMINI_API_KEY": "alice-gemini-key"})
+    store_for_sub("bob", {"GEMINI_API_KEY": "bob-gemini-key"})
+
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+    )
+    mock = AsyncMock(return_value=resp)
+
+    token = _current_sub.set("alice")
+    try:
+        with patch("mcp_core.llm.acompletion", mock):
+            await acomplete(
+                [{"role": "user", "content": "x"}],
+                models=["gemini/gemini-3-flash-preview"],
+            )
+    finally:
+        _current_sub.reset(token)
+    assert mock.call_args.kwargs.get("api_key") == "alice-gemini-key"
+
+    token = _current_sub.set("bob")
+    try:
+        with patch("mcp_core.llm.acompletion", mock):
+            await acomplete(
+                [{"role": "user", "content": "x"}],
+                models=["gemini/gemini-3-flash-preview"],
+            )
+    finally:
+        _current_sub.reset(token)
+    assert mock.call_args.kwargs.get("api_key") == "bob-gemini-key"
+
+
+async def test_acomplete_single_user_omits_api_key(monkeypatch):
+    """Single-user (no sub): ``acomplete`` must NOT inject api_key so litellm
+    keeps reading from env (existing behaviour preserved)."""
+    monkeypatch.setenv("GEMINI_API_KEY", "env-gemini")
+    from mnemo_mcp.llm import acomplete
+
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+    )
+    mock = AsyncMock(return_value=resp)
+    with patch("mcp_core.llm.acompletion", mock):
+        await acomplete(
+            [{"role": "user", "content": "x"}],
+            models=["gemini/gemini-3-flash-preview"],
+        )
+    # api_key omitted (None) -> litellm resolves from env.
+    assert mock.call_args.kwargs.get("api_key") is None

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -40,14 +40,25 @@ class TestApplyConfig:
         assert os.environ.get("JINA_AI_API_KEY") == "jina_test_key"
         assert os.environ.get("GEMINI_API_KEY") == "AIza_test_key"
 
-    def test_skips_existing_env_vars(self, monkeypatch):
-        """Does not overwrite existing env vars."""
+    def test_overwrites_existing_env_var_on_differing_value(self, monkeypatch):
+        """Single-user reconfigure: a differing value overwrites the stale env
+        var so a rotated key actually takes effect (the old ``key not in
+        os.environ`` guard silently dropped the new value)."""
         monkeypatch.setenv("JINA_AI_API_KEY", "existing_key")
 
         config = {"JINA_AI_API_KEY": "new_key"}
         apply_config(config)
 
-        assert os.environ.get("JINA_AI_API_KEY") == "existing_key"
+        assert os.environ.get("JINA_AI_API_KEY") == "new_key"
+
+    def test_noop_when_value_unchanged(self, monkeypatch):
+        """An identical value is a no-op (no needless rewrite)."""
+        monkeypatch.setenv("JINA_AI_API_KEY", "same_key")
+
+        config = {"JINA_AI_API_KEY": "same_key"}
+        apply_config(config)
+
+        assert os.environ.get("JINA_AI_API_KEY") == "same_key"
 
     def test_skips_empty_values(self, monkeypatch):
         """Does not set empty string values."""
@@ -61,19 +72,21 @@ class TestApplyConfig:
         assert os.environ.get("OPENAI_API_KEY") == "sk_test"
 
     def test_multiple_keys_with_mixed_states(self, monkeypatch):
-        """Handles a mix of new, existing, and empty values."""
+        """Handles a mix of new, changed, and empty values: a changed value
+        overwrites the stale env var, a new value is set, an empty value is
+        skipped."""
         monkeypatch.setenv("COHERE_API_KEY", "existing")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("JINA_AI_API_KEY", raising=False)
 
         config = {
-            "COHERE_API_KEY": "should_not_overwrite",
+            "COHERE_API_KEY": "rotated",
             "OPENAI_API_KEY": "new_openai",
             "JINA_AI_API_KEY": "",
         }
         apply_config(config)
 
-        assert os.environ.get("COHERE_API_KEY") == "existing"
+        assert os.environ.get("COHERE_API_KEY") == "rotated"
         assert os.environ.get("OPENAI_API_KEY") == "new_openai"
         assert os.environ.get("JINA_AI_API_KEY") is None
 


### PR DESCRIPTION
## Problem (crg-class multi-user credential bug)

In multi-user remote mode (`PUBLIC_URL` set), a relay-submitted per-`sub` key (`store_for_sub`) **never reached the live model dispatch**:

- The embedding (`embedder._backend`) and reranker (`reranker._backend`) backends are module-level singletons created once at startup with `api_key=None` (litellm then reads the process env).
- `llm.acomplete` called `mcp_core.llm.acompletion` with no `api_key`.
- `credentials_for_current_request()` (the per-`sub` accessor) was only consulted by config-status (`server.py`), never by embed / rerank / LLM dispatch.

Net effect in multi-user: embed/rerank/graph/compression ran against the shared host process env, so a per-`sub` key submitted via the relay was ignored — and a key present in the process env could serve a different `sub`'s request.

## Fix (request-scoped key, never process-global env)

Per the multi-user security invariant, per-`sub` credentials must never be applied to `os.environ`; they flow request-scoped and are passed `api_key` explicitly down each call:

- **`credential_state.api_key_for_model(model)`** — resolves the per-`sub` key for a litellm model via the mcp-core `key_env_for_model` primitive when `_current_sub` is set; returns `None` for single-user so litellm keeps reading env (existing behavior preserved).
- **`server._resolve_request_embed_backend` / `_resolve_request_reranker`** — when a `sub` is active, build a **request-scoped** `CloudEmbeddingBackend` / `CloudReranker` keyed by that `sub`'s key instead of reusing the shared startup singleton (no global singleton keyed across subs). Single-user and the local ONNX path keep the singleton.
- **`llm.acomplete`** — passes `api_key=api_key_for_model(model)` per chain model, so graph extraction, compression and temporal LLM calls all isolate per `sub` (every LLM path funnels through `acomplete`).
- **`relay_setup.apply_config`** — single-user staleness fix: it skipped writing a key already present in `os.environ`, so a single-user reconfigure (rotated key) silently kept the stale value. Now overwrites when the value differs (single-user only; still never used for multi-user).

## Tests

New `tests/test_multi_user_dispatch.py` asserts the per-`sub` key actually reaches the mocked `aembedding` / `acompletion` / `rerank` call (not just that the accessor returns it), and that a **second `sub` in the same process does not see the first `sub`'s key** — for embed, rerank and LLM. Also asserts single-user omits `api_key` (env path unchanged). `test_relay_setup.py` updated to assert the corrected `apply_config` overwrite-on-change behavior.

- Full suite: 1345 passed (default `-m 'not integration and not live and not full and not e2e'`).
- `ruff check .`, `ruff format --check .`, `ty check`: all green.
- Multi-user isolation test: included and passing.

> NOTE: please review the multi-user isolation diff before merge — DO NOT auto-merge.