### PR TITLE
fix: right-size CF container to basic instance to cut GiB-second cost

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -194,7 +194,7 @@ function extractUserId(request: Request): string {
 // + EXPOSE 8080).
 export class MnemoContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '1h'
+  sleepAfter = '5m'
   // The container reaches cloud model APIs (Jina, Vertex) over the public
   // internet; kv/d1/vectorize.internal stay intercepted (see outboundByHost).
   enableInternet = true

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,8 +14,8 @@
       // image first: `docker pull ghcr.io/n24q02m/mnemo-mcp:beta && docker tag ... mnemo-mcp:beta
       // && wrangler containers push mnemo-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:beta",
-      "instance_type": "standard-1",
-      "max_instances": 100
+      "instance_type": "basic",
+      "max_instances": 10
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
## Why

Container memory (GiB-second) is ~95% of the Cloudflare bill, and this worker was running 189% over the \$10 budget. The cloud-mode container is stateless — credentials live in KV, memories in D1/Vectorize, embeddings in the Vectorize index — and it loads no local model, so it needs well under 1 GiB.

## What (config-only, no application logic changed)

**`wrangler.jsonc`** (containers[] entry):
- `instance_type`: `standard-1` (4 GiB) -> `basic` (1 GiB)
- `max_instances`: `100` -> `10`

**`src/worker.ts`** (`MnemoContainer`):
- `sleepAfter`: `1h` -> `5m` — idle per-`sub` containers scale to zero sooner, the largest GiB-second lever

## Verification

- `wrangler deploy --dry-run` — config schema valid, `basic` / `max_instances: 10` accepted (no parse error)
- `tsc --noEmit` — clean
- `vitest run tests/worker.test.ts` — 14 passed