### PR TITLE
fix: pin CF container max_instances to 3

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,7 +18,7 @@
       // && wrangler containers push mnemo-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:beta",
       "instance_type": "basic",
-      "max_instances": 10
+      "max_instances": 3
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
The live CF Containers app `mnemo-mcp-worker` was PATCHed to `max_instances=3`, but committed `wrangler.jsonc` still declared `max_instances: 10`. A future `wrangler deploy` would regress the live value back to 10. This pins the committed config to 3 to match live.

Single-line change: `containers[0].max_instances` 10 -> 3. `instance_type`, `image`, and all other fields untouched.