### PR TITLE
fix: bump mcp-core to 1.18.0b19 (relay model-search catalog + OAuth refresh-TTL)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.0b3",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.0b14,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b19,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -12,8 +12,9 @@ def test_mcp_core_pin_includes_cf_backends():
     core = next(d for d in deps if d.startswith("n24q02m-mcp-core"))
     # 1.18.0b12 promoted the CF storage backends; 1.18.0b13 added mcp_core.chains
     # (resolve_backend); 1.18.0b14 added mcp_core.llm.key_rotation, so the embed/
-    # rerank dispatch rotates provider API keys on rate-limit. Pin the latter.
-    assert "1.18.0b14" in core, f"expected >=1.18.0b14 floor, got: {core}"
+    # rerank dispatch rotates provider API keys on rate-limit. 1.18.0b19 added the
+    # F2 relay model-search catalog + OAuth refresh-TTL fix. Pin the latter.
+    assert "1.18.0b19" in core, f"expected >=1.18.0b19 floor, got: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/uv.lock
+++ b/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.89.2"
+version = "1.89.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -937,9 +937,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/29/865d38325f9c424daf0bcc7ab61908cf51a87862b3a0dfebd059b60dac97/litellm-1.89.2.tar.gz", hash = "sha256:b2534d69568eed026310f4e006407db2d46494eb629bd1e71eb9603ec146540d", size = 14079449, upload-time = "2026-06-18T02:26:03.64Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/f1/f7cfead063f2ab1877c8fb465d0d7fe300b75f081bcb73525f6d550aeb1c/litellm-1.89.3.tar.gz", hash = "sha256:8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510", size = 14080611, upload-time = "2026-06-20T22:42:26.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/c8/51c93e8d017e7af02600171b5b6cc3805b07507acb2b94de7235ce764015/litellm-1.89.2-py3-none-any.whl", hash = "sha256:07e8e43b1a70fe919021376742897d18ffe7577ccfbb84632c949670f9abdc03", size = 15492797, upload-time = "2026-06-18T02:25:59.863Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f1/34d174ff1d84e459b30f971606ac9cb7078ad24cd7661e9786b25adf7def/litellm-1.89.3-py3-none-any.whl", hash = "sha256:414ef5aee504b2b3eb1b219d39f1c11902db399cbdbc06e5fb550c15d731abeb", size = 15495226, upload-time = "2026-06-20T22:42:23.156Z" },
 ]
 
 [[package]]
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b17"
+version = "2.3.0b20"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1096,7 +1096,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b14,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b19,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1202,7 +1202,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b16"
+version = "1.18.0b19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1217,9 +1217,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/56/4b7f384b3f0e1b11103c037bcf0e3c2114447e3e99fea6014b6ca201babe/n24q02m_mcp_core-1.18.0b16.tar.gz", hash = "sha256:acc9c97798aea53a2897d29bcf17ed35a730897534ec7e1d0792f156e20c68a8", size = 294322, upload-time = "2026-06-20T01:56:29.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/0b/3d4ed59ce33bf6a8991ce47713d7fedb22bd3040079529851c7a670508e2/n24q02m_mcp_core-1.18.0b19.tar.gz", hash = "sha256:6105cc86a79dd5c6778991ee378561eea9dbd1677f8fb5af6acc7331c40f5b0d", size = 297999, upload-time = "2026-06-22T12:46:55.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/5c/8f1bd872923b961c7183cc2bfde0132c9920b67f129d55a1afa8ced61f40/n24q02m_mcp_core-1.18.0b16-py3-none-any.whl", hash = "sha256:8f4c9936d1cc933c1dfe1b43da329b4155e5432f67f78345e403f2387812135a", size = 163277, upload-time = "2026-06-20T01:56:28.592Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/d39c509cfde412e94db5b5c6921b931f7833c1cc4479e668b589f7742198/n24q02m_mcp_core-1.18.0b19-py3-none-any.whl", hash = "sha256:8a31c96a80e029455e07ce7a9c08795495a166d7edce250457e2708879587a37", size = 166014, upload-time = "2026-06-22T12:46:53.867Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps the `n24q02m-mcp-core[llm]` floor from `>=1.18.0b14` to `>=1.18.0b19` and regenerates `uv.lock` so the dependency resolves to **1.18.0b19**.

## Root cause
The Dockerfile installs deps via `uv sync --frozen`, so the lockfile wins over the pyproject specifier. The lock pinned `n24q02m-mcp-core==1.18.0b16`, meaning every published mnemo image (incl `:beta` / 2.3.0-beta.20) shipped b16 instead of the intended newer core. mnemo was missed in the earlier pin-bump round.

## What b19 brings
- F2 relay model-search catalog fix
- OAuth refresh-TTL fix

## Changes
- `pyproject.toml`: floor `>=1.18.0b14,<2` -> `>=1.18.0b19,<2` (keeps `[llm]` extra + `<2` bound)
- `uv.lock`: regenerated via `uv lock` (resolves mcp-core 1.18.0b19; litellm transitive bump 1.89.2->1.89.3)
- `tests/test_mcp_core_pin.py`: floor-guard assertion moved b14 -> b19 to match the new pin

Verified locally: `uv sync --no-sources` installs mcp-core 1.18.0b19; full pytest green (1344 passed, pin-guard updated).