### PR TITLE
fix: bump mcp-core to 1.18.0b20 for relay catalog + drop hardcoded suggestions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.0b3",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.0b19,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b20,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.4",

--- a/src/mnemo_mcp/relay_schema.py
+++ b/src/mnemo_mcp/relay_schema.py
@@ -20,19 +20,9 @@ from __future__ import annotations
 
 from typing import Any
 
-_EMBEDDING_SUGGESTED = [
-    "jina_ai/jina-embeddings-v5-text-small",
-    "gemini/gemini-embedding-001",
-    "openai/text-embedding-3-large",
-    "cohere/embed-multilingual-v3.0",
-]
-_RERANK_SUGGESTED = ["jina_ai/jina-reranker-v3", "cohere/rerank-v3.5"]
-_LLM_SUGGESTED = [
-    "gemini/gemini-3-flash-preview",
-    "openai/gpt-5.4-mini-2026-03-17",
-    "anthropic/claude-haiku-4-5",
-    "xai/grok-4-fast",
-]
+# model-chain tasks (embedding/rerank/chat) carry NO hardcoded suggestions: the
+# relay widget's dropdown is fully catalog-driven (live Jina + normalized litellm
+# from mcp-core), so the user searches the real provider/model space.
 
 
 def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
@@ -61,7 +51,6 @@ RELAY_SCHEMA: dict[str, Any] = {
             "label": "Embedding models",
             "type": "model-chain",
             "task": "embedding",
-            "suggestedModels": _EMBEDDING_SUGGESTED,
             "hasLocal": True,
             "placeholder": "add embedding model…",
         },
@@ -70,7 +59,6 @@ RELAY_SCHEMA: dict[str, Any] = {
             "label": "Rerank models",
             "type": "model-chain",
             "task": "rerank",
-            "suggestedModels": _RERANK_SUGGESTED,
             "hasLocal": True,
             "placeholder": "add rerank model…",
         },
@@ -79,7 +67,6 @@ RELAY_SCHEMA: dict[str, Any] = {
             "label": "LLM models",
             "type": "model-chain",
             "task": "chat",
-            "suggestedModels": _LLM_SUGGESTED,
             "hasLocal": False,
             "placeholder": "add LLM model…",
         },

--- a/tests/test_mcp_core_pin.py
+++ b/tests/test_mcp_core_pin.py
@@ -13,8 +13,10 @@ def test_mcp_core_pin_includes_cf_backends():
     # 1.18.0b12 promoted the CF storage backends; 1.18.0b13 added mcp_core.chains
     # (resolve_backend); 1.18.0b14 added mcp_core.llm.key_rotation, so the embed/
     # rerank dispatch rotates provider API keys on rate-limit. 1.18.0b19 added the
-    # F2 relay model-search catalog + OAuth refresh-TTL fix. Pin the latter.
-    assert "1.18.0b19" in core, f"expected >=1.18.0b19 floor, got: {core}"
+    # F2 relay model-search catalog + OAuth refresh-TTL fix. 1.18.0b20 added the
+    # relay catalog Jina live providers + bare-name normalization + keyword search.
+    # Pin the latter.
+    assert "1.18.0b20" in core, f"expected >=1.18.0b20 floor, got: {core}"
 
 
 def test_no_uv_path_source_for_mcp_core():

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -18,10 +18,11 @@ def test_no_hardcoded_priority_strings():
         assert ">" not in cap.get("priority", "")
 
 
-def test_suggested_models_carry_provider_prefix():
-    # Every suggested model except bare-openai must carry a "<provider>/" prefix
-    # so the widget derive-keys maps it to the correct key field.
-    for f in RELAY_SCHEMA["fields"]:
-        if f.get("type") == "model-chain":
-            for m in f["suggestedModels"]:
-                assert "/" in m, f"suggested model {m!r} lacks a provider prefix"
+def test_model_chain_fields_have_no_hardcoded_suggestions():
+    # model-chain dropdowns are fully catalog-driven (live Jina + normalized
+    # litellm from mcp-core); they must carry no hand-curated suggestion list.
+    by_key = {f["key"]: f for f in RELAY_SCHEMA["fields"]}
+    for key in ("EMBEDDING_MODELS", "RERANK_MODELS", "LLM_MODELS"):
+        assert not by_key[key].get("suggestedModels"), (
+            f"{key} must be catalog-driven, no hardcode"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.3.0b20"
+version = "2.3.0b21"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1096,7 +1096,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b19,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b20,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1202,7 +1202,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b19"
+version = "1.18.0b20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1217,9 +1217,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/0b/3d4ed59ce33bf6a8991ce47713d7fedb22bd3040079529851c7a670508e2/n24q02m_mcp_core-1.18.0b19.tar.gz", hash = "sha256:6105cc86a79dd5c6778991ee378561eea9dbd1677f8fb5af6acc7331c40f5b0d", size = 297999, upload-time = "2026-06-22T12:46:55.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/10/ec1bdeff0df00bb00382107f79ca575c784c28067fda4229083ab3a97dc7/n24q02m_mcp_core-1.18.0b20.tar.gz", hash = "sha256:6814f5e0c9887dff3afdf2c7049ff4b598fa1c2cbca0656d95f48fb1f2226d8b", size = 301569, upload-time = "2026-06-23T02:28:51.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/15/d39c509cfde412e94db5b5c6921b931f7833c1cc4479e668b589f7742198/n24q02m_mcp_core-1.18.0b19-py3-none-any.whl", hash = "sha256:8a31c96a80e029455e07ce7a9c08795495a166d7edce250457e2708879587a37", size = 166014, upload-time = "2026-06-22T12:46:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/db/a555b269c368c2238a82186e90f65a41a07a93b11d0c4b8516703a19a90b/n24q02m_mcp_core-1.18.0b20-py3-none-any.whl", hash = "sha256:66fae2c80c3287b1a7c5d3aa3eec0948ccd819efb1ddc9549a9ecfb003be3d84", size = 168546, upload-time = "2026-06-23T02:28:49.873Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bump n24q02m-mcp-core[llm] floor to >=1.18.0b20 (relay model-search catalog: Jina live providers + bare-name normalization + keyword search). Also drops hardcoded model-chain suggestions; the relay model dropdown is now catalog-driven. Lock regenerated; mcp-core resolves to 1.18.0b20.