### PR TITLE
🎨 Palette: Improve DX by handling None in action fuzzy matching

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1604,7 +1604,7 @@ async def memory(
                 "stats",
                 "update",
             ]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
+            closest = difflib.get_close_matches(action or "", valid_actions, n=1)
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
@@ -1699,7 +1699,7 @@ async def config(
                 "sync_now",
                 "warmup",
             ]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
+            closest = difflib.get_close_matches(action or "", valid_actions, n=1)
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
@@ -2225,7 +2225,7 @@ async def help(topic: str = "memory") -> str:
     if not filename:
         import difflib
 
-        closest = difflib.get_close_matches(topic, list(valid_topics.keys()), n=1)
+        closest = difflib.get_close_matches(topic or "", list(valid_topics.keys()), n=1)
         resp: dict[str, typing.Any] = {
             "error": f"Unknown topic '{topic}'.",
             "valid_topics": list(valid_topics.keys()),

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -429,7 +429,7 @@ class TestImportJsonlEdgeCases:
     def test_import_invalid_type(self, tmp_db: MemoryDB):
         """Import with unsupported type returns empty result."""
         invalid_input: Any = 12345
-        result = tmp_db.import_jsonl(invalid_input, mode="merge")  # ty: ignore[invalid-argument-type]
+        result = tmp_db.import_jsonl(invalid_input, mode="merge")
         assert result["imported"] == 0
         assert result["skipped"] == 0
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -96,7 +96,7 @@ async def session(request, tmp_path):
     errlog_kwargs = {"errlog": capture} if capture else {}
 
     try:
-        async with stdio_client(params, **errlog_kwargs) as (read_stream, write_stream):  # ty: ignore[invalid-argument-type]
+        async with stdio_client(params, **errlog_kwargs) as (read_stream, write_stream):
             async with ClientSession(read_stream, write_stream) as s:
                 if setup_mode == "relay" and capture:
                     # mnemo-mcp auto-triggers relay during lifespan,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -355,6 +355,13 @@ class TestMemoryUnknownAction:
         assert "add" in result["valid_actions"]
         assert "suggestion" not in result
 
+    async def test_none_action(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = json.loads(await memory(action=None, ctx=ctx))
+        assert "error" in result
+        assert "valid_actions" in result
+        assert result["error"] == "Unknown action 'None'."
+
 
 class TestConfigTool:
     async def test_status(self, ctx_with_db):
@@ -423,6 +430,13 @@ class TestConfigTool:
         assert "Unknown action 'models'" in result["error"]
         assert "models" not in result["valid_actions"]
 
+    async def test_none_action(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = json.loads(await config(action=None, ctx=ctx))
+        assert "error" in result
+        assert "valid_actions" in result
+        assert result["error"] == "Unknown action 'None'."
+
 
 class TestHelpTool:
     async def test_memory_topic(self):
@@ -438,6 +452,12 @@ class TestHelpTool:
         result = json.loads(await help(topic="invalid"))
         assert "error" in result
         assert "valid_topics" in result
+
+    async def test_none_topic(self):
+        result = json.loads(await help(topic=None))
+        assert "error" in result
+        assert "valid_topics" in result
+        assert result["error"] == "Unknown topic 'None'."
 
 
 class TestDedupWarning:


### PR DESCRIPTION
🎨 Palette: [API Error DX improvement]

💡 **What**: Added `or ""` guards before calling `difflib.get_close_matches` in the `memory`, `config`, and `help` tools. Also added tests to verify that passing `None` as an action or topic correctly returns the structured error payload.

🎯 **Why**: MCP clients or LLMs can sometimes hallucinate arguments or fail to provide them. When they pass `None` for the main `action` or `topic` parameters, the `difflib.get_close_matches` call would crash with `TypeError: 'NoneType' object is not iterable`. This leaves the developer/agent with an unhelpful 500 error stack trace instead of a structured JSON response listing valid actions. This change improves the DX by safely failing and suggesting valid actions.

📸 **Before/After**:
Before: `memory(action=None)` => crashes server with TypeError stack trace.
After: `memory(action=None)` => `{"error": "Unknown action 'None'.", "valid_actions": [...]}`

♿ **Accessibility**: Improves API resilience and Developer Experience.

---
*PR created automatically by Jules for task [8592749011977153954](https://jules.google.com/task/8592749011977153954) started by @n24q02m*