### PR TITLE
🎨 Palette: Add graceful error handling for None inputs in MCP tools

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-05-18 - Added context-aware `suggestion` to JSON error responses
 **Learning:** In a backend/CLI-focused MCP server, traditional frontend UX paradigms translate to Developer/Agent Experience (DX). When the server returns raw errors without guidance, consumers (like LLMs or developers debugging tools) struggle to recover. Standardizing on a top-level `suggestion` key in JSON error responses makes the API significantly more actionable and "intuitive".
 **Action:** When adding or refactoring error paths in server tool handlers (like `_handle_add`, `_handle_capture`, etc.), always ensure `_json({"error": ...})` includes a corresponding `"suggestion": "..."` field with concrete next steps.
+## 2024-06-25 - Backend Developer Experience (DX) requires graceful error handling
+**Learning:** In purely backend projects like MCP servers, missing inputs (e.g., None) passed to utility functions like `difflib.get_close_matches` can crash the tool and provide a poor Developer Experience (DX) with unhandled `TypeError`s.
+**Action:** Always guard against `NoneType` inputs for fuzzy matching and provide a fallback `suggestion` with concrete next steps when no matches are found, ensuring the API always guides the consumer.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1604,7 +1604,9 @@ async def memory(
                 "stats",
                 "update",
             ]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
+            closest = (
+                difflib.get_close_matches(action, valid_actions, n=1) if action else []
+            )
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
@@ -1612,6 +1614,10 @@ async def memory(
             }
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            else:
+                resp["suggestion"] = (
+                    f"Available actions are: {', '.join(valid_actions)}."
+                )
             return _json(resp)
 
 
@@ -1699,7 +1705,9 @@ async def config(
                 "sync_now",
                 "warmup",
             ]
-            closest = difflib.get_close_matches(action, valid_actions, n=1)
+            closest = (
+                difflib.get_close_matches(action, valid_actions, n=1) if action else []
+            )
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
@@ -1707,6 +1715,10 @@ async def config(
             }
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            else:
+                resp["suggestion"] = (
+                    f"Available actions are: {', '.join(valid_actions)}."
+                )
             return _json(resp)
 
 
@@ -2225,13 +2237,21 @@ async def help(topic: str = "memory") -> str:
     if not filename:
         import difflib
 
-        closest = difflib.get_close_matches(topic, list(valid_topics.keys()), n=1)
+        closest = (
+            difflib.get_close_matches(topic, list(valid_topics.keys()), n=1)
+            if topic
+            else []
+        )
         resp: dict[str, typing.Any] = {
             "error": f"Unknown topic '{topic}'.",
             "valid_topics": list(valid_topics.keys()),
         }
         if closest:
             resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+        else:
+            resp["suggestion"] = (
+                f"Available topics are: {', '.join(valid_topics.keys())}."
+            )
         return _json(resp)
 
     doc_file = docs_package / filename

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -353,7 +353,8 @@ class TestMemoryUnknownAction:
         assert "error" in result
         assert "valid_actions" in result
         assert "add" in result["valid_actions"]
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Available actions are:" in result["suggestion"]
 
 
 class TestConfigTool:
@@ -414,7 +415,8 @@ class TestConfigTool:
         result = json.loads(await config(action="invalid", ctx=ctx))
         assert "error" in result
         assert "valid_actions" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Available actions are:" in result["suggestion"]
 
     async def test_models_action_removed(self, ctx_with_db):
         """The 'models' catalog-listing action no longer exists."""
@@ -438,6 +440,29 @@ class TestHelpTool:
         result = json.loads(await help(topic="invalid"))
         assert "error" in result
         assert "valid_topics" in result
+
+    async def test_none_topic(self):
+        result = json.loads(await help(topic=None))
+        assert "error" in result
+        assert "valid_topics" in result
+        assert "suggestion" in result
+        assert "Available topics are:" in result["suggestion"]
+
+
+class TestNoneActionHandling:
+    async def test_memory_none_action(self):
+        result = json.loads(await memory(action=None))
+        assert "error" in result
+        assert "Unknown action 'None'" in result["error"]
+        assert "suggestion" in result
+        assert "Available actions are:" in result["suggestion"]
+
+    async def test_config_none_action(self):
+        result = json.loads(await config(action=None))
+        assert "error" in result
+        assert "Unknown action 'None'" in result["error"]
+        assert "suggestion" in result
+        assert "Available actions are:" in result["suggestion"]
 
 
 class TestDedupWarning:

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -209,12 +209,13 @@ class TestConfigActions:
         assert "Did you mean 'sync'?" in result["suggestion"]
 
     async def test_config_unknown_action_no_match(self, ctx_with_db):
-        """Config with completely invalid action returns error without suggestion."""
+        """Config with completely invalid action returns error with default suggestion."""
         ctx, _ = ctx_with_db
         result = json.loads(await config(action="xyzxyzxyz", ctx=ctx))
         assert "error" in result
         assert "Unknown action" in result["error"]
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Available actions are:" in result["suggestion"]
 
 
 # ---------------------------------------------------------------------------
@@ -233,11 +234,12 @@ class TestHelpTool:
         assert "Did you mean 'memory'?" in result["suggestion"]
 
     async def test_help_no_match(self):
-        """Completely invalid topic returns error without suggestion."""
+        """Completely invalid topic returns error with default suggestion."""
         result = json.loads(await help(topic="xyzxyz"))
         assert "error" in result
         assert "valid_topics" in result
-        assert "suggestion" not in result
+        assert "suggestion" in result
+        assert "Available topics are:" in result["suggestion"]
 
     async def test_help_setup_redirects_to_config(self):
         """'setup' topic is redirected to 'config'."""


### PR DESCRIPTION
This PR improves the Developer Experience (DX) for consumers of the MCP server's tools by preventing unhandled `TypeError`s when an API parameter like `action` or `topic` is inadvertently passed as `None`. 

By guarding against empty values before calling `difflib.get_close_matches`, the server now consistently returns a structured JSON error response that provides a helpful, dynamically generated fallback `suggestion` (e.g. `Available actions are: add, search, list...`).

This ensures a robust API that constantly guides the consumer, particularly LLMs acting as clients.

Tests have been added to verify this graceful degradation.

---
*PR created automatically by Jules for task [14547288324039310716](https://jules.google.com/task/14547288324039310716) started by @n24q02m*