### PR TITLE
[PERF] Blocking I/O in Async Function

### DIFF
--- a/src/mnemo_mcp/sync/s3.py
+++ b/src/mnemo_mcp/sync/s3.py
@@ -104,10 +104,12 @@ class S3Backend(SyncBackend):
                 return None
         key = _bundle_key(self._prefix, sequence)
         try:
-            resp = await asyncio.to_thread(
-                self._client.get_object, Bucket=self._bucket, Key=key
-            )
-            return resp["Body"].read()
+
+            def _get_and_read() -> bytes:
+                resp = self._client.get_object(Bucket=self._bucket, Key=key)
+                return resp["Body"].read()
+
+            return await asyncio.to_thread(_get_and_read)
         except ClientError as e:
             code = e.response.get("Error", {}).get("Code", "")
             if code in ("NoSuchKey", "404"):


### PR DESCRIPTION
Optimized S3Backend.pull by moving the blocking .read() call into the thread pool. Previously, only get_object was offloaded, but reading the stream body remained on the event loop. This ensures the entire pull operation is truly non-blocking for the async caller.

---
*PR created automatically by Jules for task [13874556699290014576](https://jules.google.com/task/13874556699290014576) started by @n24q02m*