### PR TITLE
[FIX] N+1 Query Issue in Edge Update

### DIFF
--- a/src/mnemo_mcp/temporal/store.py
+++ b/src/mnemo_mcp/temporal/store.py
@@ -80,6 +80,7 @@ def store_kg_with_memory_id(
     # have NULL memory_id / NULL valid_from -- so an edge already attached
     # to an earlier capture is left alone.
     edge_count = 0
+    params = []
     if relations:
         now_iso = time.strftime("%Y-%m-%dT%H:%M:%S")
         for rel in relations:
@@ -90,14 +91,19 @@ def store_kg_with_memory_id(
             tgt_id = name_to_id.get(tgt_name)
             if not (src_id and tgt_id and rtype):
                 continue
-            cursor = conn.execute(
-                "UPDATE memory_edges SET "
-                "  memory_id = COALESCE(memory_id, ?), "
-                "  valid_from = COALESCE(valid_from, ?) "
-                "WHERE source_id = ? AND target_id = ? AND relation_type = ?",
-                (memory_id, now_iso, src_id, tgt_id, rtype),
-            )
-            edge_count += cursor.rowcount or 0
+            params.append((memory_id, now_iso, src_id, tgt_id, rtype))
+
+    if params:
+        cursor = conn.executemany(
+            "UPDATE memory_edges SET "
+            "  memory_id = COALESCE(memory_id, ?), "
+            "  valid_from = COALESCE(valid_from, ?) "
+            "WHERE source_id = ? AND target_id = ? AND relation_type = ?",
+            params,
+        )
+        # For UPDATE, executemany's rowcount is the sum of all affected rows.
+        # Bolt Performance Note: Using executemany eliminates N+1 updates.
+        edge_count = cursor.rowcount if cursor.rowcount != -1 else len(params)
         conn.commit()
 
     logger.debug(


### PR DESCRIPTION
Refactored `store_kg_with_memory_id` in `src/mnemo_mcp/temporal/store.py` to use `conn.executemany` for batch updates of `memory_edges`. This optimization eliminates N+1 database roundtrips during the Phase 3 KG-store backfill. Handled `cursor.rowcount` with a fallback to parameter length and verified with tests.

---
*PR created automatically by Jules for task [11804602229699143326](https://jules.google.com/task/11804602229699143326) started by @n24q02m*