### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in gdrive sync state

### DIFF
--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -219,6 +219,23 @@ async def _load_folder_id(folder_name: str) -> str | None:
 async def _save_folder_id(folder_name: str, folder_id: str) -> None:
     """Persist folder ID to disk."""
     path = settings.get_data_dir() / "sync_folder_ids.json"
+
+    def _write_secure(file_path: Path, content: str) -> None:
+        import os
+        import stat
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR
+        fd = os.open(file_path, flags, mode)
+        try:
+            if os.name != "nt":
+                os.fchmod(fd, mode)
+        except OSError:
+            pass
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+
     async with _folder_id_disk_lock:
         data: dict[str, str] = {}
         try:
@@ -228,8 +245,7 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
         except (json.JSONDecodeError, OSError):
             pass
         data[folder_name] = folder_id
-        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
-        await asyncio.to_thread(path.write_text, json.dumps(data), encoding="utf-8")
+        await asyncio.to_thread(_write_secure, path, json.dumps(data))
 
 
 async def _verify_folder_exists(token: dict, folder_id: str) -> bool:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `_save_folder_id` function in `src/mnemo_mcp/sync/gdrive.py` was saving the sensitive `sync_folder_ids.json` state using a basic `path.write_text()`. This creates the file with default OS permissions, potentially exposing Google Drive folder mapping details to other unauthorized users on the same host system (a Time-of-Check-to-Time-of-Use / insecure default permissions vulnerability).
🎯 **Impact:** Unauthorized local users could read or manipulate the Google Drive sync target IDs, potentially redirecting sync data or reading metadata.
🔧 **Fix:** Replaced `path.write_text()` with a `_write_secure` helper using `os.open` with `os.O_CREAT | os.O_WRONLY | os.O_TRUNC` flags, and explicitly enforced `0o600` (owner read/write only) permissions via `os.fchmod`. The blocking OS operations were correctly wrapped in `asyncio.to_thread` to prevent event loop blocking.
✅ **Verification:** Ran `uv run ruff check` and `uv run pytest` successfully. No regressions found.

---
*PR created automatically by Jules for task [9734672800209553102](https://jules.google.com/task/9734672800209553102) started by @n24q02m*