### PR TITLE
[FIX] Data Exposure: Token Permissions TOCTOU Vulnerability on Windows

### DIFF
--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import stat
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -229,7 +231,21 @@ async def _save_folder_id(folder_name: str, folder_id: str) -> None:
             pass
         data[folder_name] = folder_id
         await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
-        await asyncio.to_thread(path.write_text, json.dumps(data), encoding="utf-8")
+
+        def _secure_write():
+            # Prevent TOCTOU vulnerability by setting permissions on creation (0600)
+            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            mode = stat.S_IRUSR | stat.S_IWUSR
+            fd = os.open(path, flags, mode)
+            try:
+                if os.name != "nt":
+                    os.fchmod(fd, mode)
+            except OSError:
+                pass
+            with os.fdopen(fd, "w", encoding="utf-8") as f_out:
+                f_out.write(json.dumps(data))
+
+        await asyncio.to_thread(_secure_write)
 
 
 async def _verify_folder_exists(token: dict, folder_id: str) -> bool:

--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -95,28 +95,26 @@ def save_token(provider: str, token: dict) -> None:
     path = get_token_path(provider)
     token_json = json.dumps(token, indent=2)
 
-    if os.name != "nt":
+    try:
+        # Prevent TOCTOU vulnerability by setting permissions on creation (0600)
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR
+        fd = os.open(path, flags, mode)
         try:
-            # Prevent TOCTOU vulnerability by setting permissions on creation
-            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
-            mode = stat.S_IRUSR | stat.S_IWUSR  # 0600
-            fd = os.open(path, flags, mode)
-            try:
-                # Ensure existing files also get their permissions restricted
+            if os.name != "nt":
                 os.fchmod(fd, mode)
-            except OSError:
-                pass
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(token_json)
         except OSError:
-            path.write_text(token_json, encoding="utf-8")
+            pass
+        with os.fdopen(fd, "w", encoding="utf-8") as f_out:
+            f_out.write(token_json)
+    except OSError:
+        # Fallback to standard write if os.open fails
+        path.write_text(token_json, encoding="utf-8")
+        if os.name != "nt":
             try:
                 path.chmod(stat.S_IRUSR | stat.S_IWUSR)
             except OSError:
                 pass
-    else:
-        path.write_text(token_json, encoding="utf-8")
-
     logger.info(f"Token saved: {path}")
 
 
@@ -158,25 +156,26 @@ def save_token_for_sub(sub: str, provider: str, token: dict) -> None:
     path = get_token_path_for_sub(sub, provider)
     token_json = json.dumps(token, indent=2)
 
-    if os.name != "nt":
+    try:
+        # Prevent TOCTOU vulnerability by setting permissions on creation (0600)
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR
+        fd = os.open(path, flags, mode)
         try:
-            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
-            mode = stat.S_IRUSR | stat.S_IWUSR
-            fd = os.open(path, flags, mode)
-            try:
+            if os.name != "nt":
                 os.fchmod(fd, mode)
-            except OSError:
-                pass
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(token_json)
         except OSError:
-            path.write_text(token_json, encoding="utf-8")
+            pass
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(token_json)
+    except OSError:
+        # Fallback to standard write if os.open fails
+        path.write_text(token_json, encoding="utf-8")
+        if os.name != "nt":
             try:
                 path.chmod(stat.S_IRUSR | stat.S_IWUSR)
             except OSError:
                 pass
-    else:
-        path.write_text(token_json, encoding="utf-8")
 
     logger.info(f"Token saved (sub={sub}): {path}")
 


### PR DESCRIPTION
This PR addresses a Data Exposure vulnerability (TOCTOU) on Windows where sensitive OAuth tokens and configuration files were being saved with insecure default permissions.

Key changes:
- Refactored `save_token` and `save_token_for_sub` in `src/mnemo_mcp/token_store.py` to use the `os.open` pattern with `os.O_CREAT | os.O_WRONLY | os.O_TRUNC` and mode `0600`. This ensures the file is created with restricted permissions from the start on all platforms.
- Applied the same secure writing pattern to `_persist_folder_id` in `src/mnemo_mcp/sync/gdrive.py` for `sync_folder_ids.json`.
- Ensured `os.fchmod` is only called on non-Windows platforms to avoid `AttributeError`.
- Added necessary imports (`os`, `stat`) and verified with full test suite and linting.

This change aligns with best practices for sensitive data persistence and mitigates potential local privilege escalation or data exposure risks on multi-user Windows systems.

---
*PR created automatically by Jules for task [9471976180444141787](https://jules.google.com/task/9471976180444141787) started by @n24q02m*