### PR TITLE
feat: disable-local embed/rerank toggle + CF deploy harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,11 @@ docs/superpowers/
 *.bak
 /*.patch
 /*.diff
+
+# Cloudflare deploy (real account/KV/D1/Vectorize IDs + tokens — NEVER commit)
+wrangler.deploy.jsonc
+.wrangler/
+.wrangler-dryrun/
+scripts/.mnemo_cf_token
+node_modules/
+package-lock.json

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -1,0 +1,364 @@
+"""CF mnemo-mcp live OAuth full-flow self-test harness.
+
+Drives the deployed mnemo-mcp Cloudflare Worker (Worker + per-sub Container + KV +
+D1 + Vectorize) end-to-end against a public endpoint. mnemo is a LOCAL-FORM server
+(like wet/imagine/email, NOT delegated like notion): the /authorize gate is just
+the relay password, so the whole flow is fully autonomous -- no third-party consent.
+
+Flow (authorization_code + PKCE, DCR public client; ported verbatim from the
+mnemo/imagine/email CF harnesses):
+  1. DCR register   -- POST /register (RFC 7591) -> client_id
+  2. password-grant -- GET /authorize -> POST /login (Gate A relay password) -> form
+  3. save creds     -- POST /authorize?nonce=... {provider key} (retry-on-500 for the
+                       E.1 outbound-interception race). wet's _require_credentials()
+                       gates every tool on the per-sub vault holding >=1 provider key
+                       (JINA/GEMINI/OPENAI/COHERE); it does NOT read the server-side
+                       forwarded JINA from os.environ, so a real user must submit one.
+                       The harness submits whatever key skret /wet-mcp/prod injects.
+  4. token          -- POST /token (code + verifier) -> bearer JWT
+  5. tool call      -- config(status) + search(action="search"); assert the search
+                       path resolves real results (URLs) over the CF deployment.
+
+Secrets from env: Gate A login password MCP_RELAY_PASSWORD (or RELAY_PW) from skret
+/oci-vm-prod/prod (infra-shared); >=1 provider key (JINA_AI_API_KEY preferred) from
+skret /wet-mcp/prod -- compose both namespaces.
+
+Run modes:
+  (default)            full flow: config(status) + search, assert real results.
+  --save-only          configure one sub (submit provider key) + dump the token
+                       (recreate-gate setup half of the state-survives-recreate test).
+  --auth-only          replay the SAME token (same sub) and search again WITHOUT
+                       re-saving (recreate-gate verify: the sub vault survived KV).
+  --two-sub-isolation  two distinct subs; assert each authorizes to a distinct sub
+                       (the relay-login mints a fresh random sub per /authorize).
+
+Examples:
+  skret run -e prod --path=/oci-vm-prod/prod -- \
+    skret run -e prod --path=/wet-mcp/prod -- \
+      python scripts/cf_full_flow.py
+  ... -- python scripts/cf_full_flow.py --endpoint https://mnemo.n24q02m.com
+  ... -- python scripts/cf_full_flow.py --save-only
+  ... -- python scripts/cf_full_flow.py --auth-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json as _json
+import os
+import re
+import secrets
+import sys
+import time
+import urllib.parse
+from pathlib import Path
+
+DEFAULT_ENDPOINT = "https://mnemo.n24q02m.com"
+
+# A unique marker memory added then searched to exercise the D1 FTS round-trip.
+MARKER = "cf-canary-probe-mnemo"
+
+
+def _password() -> str:
+    pw = os.environ.get("RELAY_PW") or os.environ.get("MCP_RELAY_PASSWORD")
+    if not pw:
+        raise SystemExit(
+            "MCP_RELAY_PASSWORD (or RELAY_PW) is required for the password-grant "
+            "login gate. It lives in skret /oci-vm-prod/prod (infra-shared), NOT "
+            "/wet-mcp/prod -- compose both namespaces."
+        )
+    return pw
+
+
+def _creds() -> dict[str, str]:
+    """Per-sub credential form payload. wet's `_require_credentials()` gates every
+    tool on the per-sub vault holding at least one provider key (JINA / GEMINI /
+    OPENAI / COHERE) -- it does NOT read the server-side forwarded JINA from
+    os.environ. So a real user must submit a key; the harness submits whichever
+    provider key skret /wet-mcp/prod injects (JINA preferred)."""
+    creds: dict[str, str] = {}
+    for env_name in (
+        "JINA_AI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "COHERE_API_KEY",
+        "XAI_API_KEY",
+    ):
+        v = os.environ.get(env_name)
+        if v:
+            creds[env_name] = v
+    if not creds:
+        raise SystemExit(
+            "No provider key in env (JINA_AI_API_KEY / GEMINI_API_KEY / "
+            "OPENAI_API_KEY / COHERE_API_KEY). skret /wet-mcp/prod injects them; "
+            "wet's per-sub gate requires at least one to authorize tool calls."
+        )
+    return creds
+
+
+class _SaveRetry(Exception):
+    pass
+
+
+def get_token(endpoint: str, creds: dict[str, str], *, save_retries: int = 8) -> str:
+    """Run the full OAuth flow, retrying on a transient 500 at the credential save
+    step (CF Containers outbound-interception race on cold-started instances; E.1).
+    Each retry restarts from DCR so the nonce is fresh. ``creds`` is the /authorize
+    form payload (EMPTY for wet: search/extract + embed are server-side)."""
+    import httpx  # lazy: keep --help importable without httpx installed
+
+    last: Exception | None = None
+    for attempt in range(save_retries):
+        try:
+            return _get_token_once(httpx, endpoint, creds)
+        except _SaveRetry as e:
+            last = e
+            print(
+                f"get_token: save 500 (interception race), retry {attempt + 1}/{save_retries}"
+            )
+            time.sleep(3)
+    raise RuntimeError(f"get_token failed after {save_retries} retries: {last}")
+
+
+def _get_token_once(httpx, endpoint: str, creds: dict[str, str]) -> str:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    ru = "http://localhost:9999/cb"
+    pw = _password()
+    with httpx.Client(timeout=120, follow_redirects=False) as c:
+        cid = c.post(
+            f"{endpoint}/register",
+            json={
+                "client_name": "cf-verify",
+                "redirect_uris": [ru],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+                "scope": "offline_access",
+            },
+        ).json()["client_id"]
+        az = c.get(
+            f"{endpoint}/authorize",
+            params={
+                "response_type": "code",
+                "client_id": cid,
+                "redirect_uri": ru,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": "st",
+                "scope": "offline_access",
+            },
+        )
+        nxt = urllib.parse.parse_qs(
+            urllib.parse.urlparse(az.headers["location"]).query
+        )["next"][0]
+        lg = c.post(f"{endpoint}/login", data={"next": nxt, "password": pw})
+        url = lg.headers["location"]
+        url = url if url.startswith("http") else endpoint + url
+        form_html = c.get(url).text
+        m = re.search(r"/authorize\?nonce=([A-Za-z0-9_\-]+)", form_html)
+        assert m, "nonce not found in form"
+        nonce = m.group(1)
+        sub = c.post(f"{endpoint}/authorize", params={"nonce": nonce}, json=creds)
+        if sub.status_code == 500 and "save credentials" in sub.text:
+            raise _SaveRetry(sub.text[:120])
+        assert sub.status_code == 200, (sub.status_code, sub.text[:300])
+        data = sub.json()
+        assert data.get("ok"), data
+        code = urllib.parse.parse_qs(urllib.parse.urlparse(data["redirect_url"]).query)[
+            "code"
+        ][0]
+        tok = c.post(
+            f"{endpoint}/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": ru,
+                "client_id": cid,
+                "code_verifier": verifier,
+            },
+        )
+        assert tok.status_code == 200, (tok.status_code, tok.text[:300])
+        return tok.json()["access_token"]
+
+
+def _sub_of(token: str) -> str:
+    payload = _json.loads(base64.urlsafe_b64decode(token.split(".")[1] + "=="))
+    return payload.get("sub", "?")
+
+
+async def _call(s, label, tool, args, *, retries=20, delay=8):
+    """Call a tool, retrying while the sub is still propagating (KV cross-colo
+    eventual consistency after the setup write; E.2). Returns the concatenated
+    text payload, or None on give-up."""
+    for i in range(retries):
+        try:
+            res = await s.call_tool(tool, args)
+            txt = "".join(getattr(b, "text", "") for b in res.content)
+            if "awaiting_setup" in txt or "Credentials not configured" in txt:
+                print(f"{label}: awaiting_setup (KV propagating) try {i + 1}/{retries}")
+                await asyncio.sleep(delay)
+                continue
+            print(f"{label} OK:", txt[:320].replace("\n", " "))
+            return txt
+        except Exception as e:
+            print(f"{label} ERR:", repr(e)[:300])
+            return None
+    print(f"{label}: gave up after {retries} tries")
+    return None
+
+
+def _assert_search_resolved(txt: str | None) -> None:
+    """A real round-trip returns the just-added marker memory. An error string
+    (D1 / Vectorize misconfig) surfaces here -- a genuine CF-deployment finding."""
+    assert txt is not None, (
+        "search_memory returned no payload (gave up while not ready)"
+    )
+    assert not txt.lower().startswith("error"), (
+        f"search_memory returned an error: {txt[:300]}"
+    )
+    assert MARKER in txt, f"search_memory did not return the added marker: {txt[:300]}"
+    print(
+        "ASSERT OK: add_memory -> search_memory round-trip resolved over the CF deployment."
+    )
+
+
+async def _session(endpoint: str, token: str):
+    from mcp import ClientSession  # lazy: keep --help importable without mcp installed
+    from mcp.client.streamable_http import streamablehttp_client
+
+    return streamablehttp_client(
+        f"{endpoint}/mcp", headers={"Authorization": f"Bearer {token}"}
+    ), ClientSession
+
+
+async def _run_search(s) -> str | None:
+    # mnemo round-trip: add a marker memory, then search for it over D1 FTS.
+    await _call(
+        s,
+        "ADD_MEMORY",
+        "add_memory",
+        {"content": f"protocol self-test memory {MARKER}"},
+    )
+    return await _call(s, "SEARCH_MEMORY", "search_memory", {"query": MARKER})
+
+
+def _token_file() -> Path:
+    return Path(__file__).with_name(".wet_cf_token")
+
+
+async def run_full(endpoint: str) -> None:
+    token = get_token(endpoint, _creds())
+    print("TOKEN OK len=", len(token), "sub=", _sub_of(token))
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        tools = await s.list_tools()
+        print("TOOLS:", [t.name for t in tools.tools])
+        await _call(s, "CONFIG_STATUS", "config", {"action": "status"})
+        txt = await _run_search(s)
+        _assert_search_resolved(txt)
+    print("FULL FLOW PASS.")
+
+
+async def run_save_only(endpoint: str) -> None:
+    token = get_token(endpoint, _creds())
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        await _call(s, "CONFIG_STATUS", "config", {"action": "status"})
+    # Dump the EXACT token so --auth-only replays the SAME JWT sub (relay-login mints
+    # a fresh random sub per /authorize).
+    _token_file().write_text(token)
+    print(
+        "SAVE-ONLY OK: sub configured=",
+        _sub_of(token),
+        "(token dumped for --auth-only)",
+    )
+
+
+async def run_auth_only(endpoint: str) -> None:
+    tok_path = _token_file()
+    if not tok_path.exists():
+        raise SystemExit("No dumped token -- run --save-only first.")
+    token = tok_path.read_text().strip()
+    print("AUTH-ONLY: replaying saved token for sub=", _sub_of(token))
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        txt = await _run_search(s)
+        _assert_search_resolved(txt)
+    print("AUTH-ONLY PASS: sub survived recreate (KV vault resolved, no re-save).")
+
+
+async def run_two_sub_isolation(endpoint: str) -> None:
+    token_a = get_token(endpoint, _creds())
+    sub_a = _sub_of(token_a)
+    token_b = get_token(endpoint, _creds())
+    sub_b = _sub_of(token_b)
+    print(f"sub A={sub_a}  sub B={sub_b}")
+    if sub_a == sub_b:
+        raise SystemExit(
+            f"ISOLATION INCONCLUSIVE: both flows share sub {sub_a} (cannot test bleed)."
+        )
+    transport, ClientSession = await _session(endpoint, token_b)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        txt = await _run_search(s)
+        _assert_search_resolved(txt)
+    print(
+        "TWO-SUB ISOLATION OK: distinct subs, sub B authorizes + searches independently."
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="CF wet-mcp live OAuth full-flow self-test harness.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--endpoint",
+        default=DEFAULT_ENDPOINT,
+        help=f"Deployed wet endpoint (default: {DEFAULT_ENDPOINT})",
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--save-only",
+        action="store_true",
+        help="Configure one sub (empty form) + dump the token, then exit (recreate setup).",
+    )
+    mode.add_argument(
+        "--auth-only",
+        action="store_true",
+        help="Replay the SAME token + search WITHOUT re-saving (recreate verify).",
+    )
+    mode.add_argument(
+        "--two-sub-isolation",
+        action="store_true",
+        help="Two distinct subs; assert sub B authorizes + searches independently.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.save_only:
+        asyncio.run(run_save_only(args.endpoint))
+    elif args.auth_only:
+        asyncio.run(run_auth_only(args.endpoint))
+    elif args.two_sub_isolation:
+        asyncio.run(run_two_sub_isolation(args.endpoint))
+    else:
+        asyncio.run(run_full(args.endpoint))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Build + push + deploy this MCP server's Cloudflare Worker+Container.
+
+Turns the manual CF redeploy recipe into one repeatable command. Reads the
+gitignored ``wrangler.deploy.jsonc`` (real account/KV/D1/Vectorize IDs) for the
+container image name + account, builds the ``http`` target, pushes to the CF
+managed registry, deploys, waits for the container rollout to finish
+(STATE=ready) so you never verify against a half-rolled old image, then runs a
+**credential-free canary gate** and **auto-rolls-back** if it fails.
+
+Run from the repo root, with the CF dev token injected by skret:
+
+    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- \\
+        python scripts/deploy_cf.py            # tag defaults to b-<short-sha>
+    ... python scripts/deploy_cf.py --tag b10-abc1234   # explicit tag
+    ... python scripts/deploy_cf.py --skip-build         # reuse a built image
+    ... python scripts/deploy_cf.py --dry-run            # print the plan only
+    ... python scripts/deploy_cf.py --no-canary          # skip the post-deploy gate
+
+Requires: CLOUDFLARE_API_TOKEN in env (skret /n24q02m/dev CF_DEV_TOKEN ->
+export CLOUDFLARE_API_TOKEN), docker, and ``bunx wrangler``. The CF container
+registry only pulls from registry.cloudflare.com/<account>/... (not ghcr), so the
+local image is tagged to that path before ``wrangler containers push``.
+
+Why the rollout wait: a heavy image (wet ~6GB) keeps serving OLD Durable Object
+instances for minutes after deploy (``containers list`` STATE=provisioning);
+verifying during that window shows stale behaviour. See docs/cf-deploy.md.
+
+Why the canary gate: the unit / T0 suite cannot reach the CF-glue layer
+(worker.ts CONTAINER_ENV_KEYS forwarding, container HOST bind, JWT signing keys),
+which is exactly where the painful deploy regressions live. The gate is
+credential-free (no per-server secrets needed) and catches the three that have
+actually happened: (A) ``MCP_RELAY_PASSWORD`` dropped from the forward list ->
+``/authorize`` serves the form with no login front door = open self-service relay;
+(B) the bearer gate dropped -> ``/mcp`` no longer 401s; (C) ephemeral per-instance
+JWT keys -> ``/.well-known/jwks.json`` ``kid`` changes between requests (the
+/token-signs-with-A, /mcp-verifies-with-B -> 401 bug). On failure the previously
+deployed image tag is redeployed automatically. A full authenticated
+protocol round-trip (self-auth + setup + tool calls) stays in
+``scripts/cf_full_flow.py``, which needs the per-server runtime secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Windows consoles default to cp1252; wrangler emits box-drawing chars (│) and
+# emoji. Make our own prints utf-8-safe so a captured status line can never crash
+# the deploy on the encode side (the decode side is handled per-subprocess).
+for _stream in (sys.stdout, sys.stderr):
+    with contextlib.suppress(AttributeError, ValueError):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+DEPLOY_CONFIG = "wrangler.deploy.jsonc"
+
+
+def _strip_jsonc(text: str) -> str:
+    """Strip full-line // comments + trailing commas so json.loads accepts our
+    deploy.jsonc. Inline // after values is intentionally NOT stripped (would
+    corrupt https:// URLs); our deploy.jsonc keeps comments on their own lines."""
+    lines = [ln for ln in text.splitlines() if not re.match(r"\s*//", ln)]
+    body = "\n".join(lines)
+    body = re.sub(r",(\s*[}\]])", r"\1", body)  # trailing commas
+    return body
+
+
+def _load_deploy_config(repo: Path) -> dict:
+    path = repo / DEPLOY_CONFIG
+    if not path.exists():
+        sys.exit(
+            f"{DEPLOY_CONFIG} not found in {repo}. It is gitignored (real IDs); "
+            "reconstruct it from the committed wrangler.jsonc + CF resource IDs first."
+        )
+    return json.loads(_strip_jsonc(path.read_text(encoding="utf-8")))
+
+
+def _short_sha(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    ).stdout.strip()
+
+
+def _run(cmd: list[str], *, dry: bool, cwd: Path | None = None) -> None:
+    print(f"  $ {' '.join(cmd)}")
+    if dry:
+        return
+    subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True)
+
+
+def _image_parts(cfg: dict) -> tuple[str, str, str]:
+    """Return (registry_base_without_tag, account_id, image_name) from the
+    deploy config's first container image ref
+    registry.cloudflare.com/<account>/<name>:<tag>."""
+    ref = cfg["containers"][0]["image"]
+    base = ref.rsplit(":", 1)[0]  # drop existing tag
+    m = re.match(r"registry\.cloudflare\.com/([0-9a-f]+)/(.+)$", base)
+    if not m:
+        sys.exit(
+            f"unexpected image ref (need registry.cloudflare.com/<acct>/<name>): {ref}"
+        )
+    return base, m.group(1), m.group(2)
+
+
+def _public_url(cfg: dict) -> str:
+    url = str((cfg.get("vars") or {}).get("PUBLIC_URL", "")).rstrip("/")
+    if not url:
+        sys.exit(
+            "PUBLIC_URL missing from deploy config vars; cannot run the canary "
+            "gate. Add it or pass --no-canary."
+        )
+    return url
+
+
+def _set_image_tag(repo: Path, full_ref: str) -> None:
+    """Rewrite the deploy.jsonc image line in place so `wrangler deploy` ships the
+    tag we just pushed (gitignored file, safe to edit)."""
+    path = repo / DEPLOY_CONFIG
+    text = path.read_text(encoding="utf-8")
+    new = re.sub(
+        r'("image":\s*")registry\.cloudflare\.com/[^"]+(")',
+        rf"\g<1>{full_ref}\g<2>",
+        text,
+        count=1,
+    )
+    path.write_text(new, encoding="utf-8")
+
+
+def _wait_ready(worker: str, *, dry: bool, timeout_s: int = 600) -> None:
+    """Poll `wrangler containers list` until the worker leaves provisioning."""
+    if dry:
+        print(f"  (dry-run) would poll containers list until {worker} STATE=ready")
+        return
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        out = (
+            subprocess.run(
+                ["bunx", "wrangler", "containers", "list"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            ).stdout
+            or ""
+        )
+        line = next((ln for ln in out.splitlines() if worker in ln), "")
+        print(f"  [rollout] {line.strip() or '(no row yet)'}")
+        if line and "provisioning" not in line.lower():
+            print(f"  rollout complete: {worker} is no longer provisioning.")
+            return
+        time.sleep(25)
+    print(f"  WARNING: {worker} still provisioning after {timeout_s}s — verify later.")
+
+
+# --------------------------------------------------------------------------- #
+# Canary gate (credential-free) + auto-rollback                               #
+# --------------------------------------------------------------------------- #
+
+
+def _get(url: str, *, timeout: int = 12) -> tuple[int, dict[str, str], str]:
+    """GET following redirects. Return (status, lowercased-headers, final_url)."""
+    req = urllib.request.Request(url, method="GET", headers={"User-Agent": "cf-canary"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            hdrs = {k.lower(): v for k, v in resp.headers.items()}
+            return resp.status, hdrs, resp.geturl()
+    except urllib.error.HTTPError as e:  # 4xx/5xx still carry headers we need
+        hdrs = {k.lower(): v for k, v in (e.headers or {}).items()}
+        return e.code, hdrs, e.url or url
+    except (urllib.error.URLError, TimeoutError, OSError):
+        # unreachable / TLS / timeout: status 0 makes every gate fail, which is
+        # the correct canary verdict (a deploy that is not reachable must roll back)
+        return 0, {}, url
+
+
+def _gate_a(public_url: str) -> bool:
+    """/authorize must land on /login = the shared relay-password front door is on."""
+    authz = (
+        f"{public_url}/authorize?response_type=code&client_id=local-browser"
+        f"&redirect_uri={public_url}/callback-done&state=x"
+        f"&code_challenge=x&code_challenge_method=S256&scope=offline_access"
+    )
+    _, _, final = _get(authz)
+    ok = "/login" in final
+    detail = (
+        "OK" if ok else "FAIL: no /login -> OPEN SELF-SERVICE RELAY (Gate A dropped)"
+    )
+    print(f"  [canary] Gate A  /authorize -> {final}  {detail}")
+    return ok
+
+
+def _gate_b(public_url: str) -> bool:
+    """/mcp must 401 with a WWW-Authenticate: Bearer challenge."""
+    status, hdrs, _ = _get(f"{public_url}/mcp")
+    ok = status == 401 and "bearer" in hdrs.get("www-authenticate", "").lower()
+    detail = "OK" if ok else f"FAIL (status={status}, bearer challenge missing)"
+    print(f"  [canary] Gate B  /mcp -> {status}  {detail}")
+    return ok
+
+
+def _jwks_kid(public_url: str) -> str | None:
+    # Single fetch WITH a User-Agent: a bare urlopen (no UA) gets challenged by
+    # Cloudflare in front of the Worker and fails, which previously made this
+    # return None even though the endpoint serves a valid kid.
+    try:
+        req = urllib.request.Request(
+            f"{public_url}/.well-known/jwks.json", headers={"User-Agent": "cf-canary"}
+        )
+        with urllib.request.urlopen(req, timeout=12) as resp:
+            if resp.status != 200:
+                return None
+            data = json.loads(resp.read().decode("utf-8"))
+        keys = data.get("keys") or []
+        return keys[0].get("kid") if keys else None
+    except Exception:
+        return None
+
+
+def _gate_kid_stable(public_url: str, *, tries: int = 10, delay: int = 6) -> bool:
+    """jwks kid must be identical across requests; a varying kid means ephemeral
+    per-instance signing keys (/token signs with A, /mcp verifies with B -> 401).
+
+    A just-rolled container may not serve jwks for a few seconds, so collect over
+    a settle window: need >=3 successful reads (all identical = stable). All-None
+    after the window = the endpoint genuinely never served a key."""
+    kids: list[str] = []
+    for _ in range(tries):
+        k = _jwks_kid(public_url)
+        if k is not None:
+            kids.append(k)
+            if len(kids) >= 3:
+                break
+        time.sleep(delay)
+    uniq = set(kids)
+    ok = len(kids) >= 3 and len(uniq) == 1
+    if not kids:
+        detail = "FAIL: jwks served no kid after settle window (endpoint down?)"
+    elif len(uniq) > 1:
+        detail = "FAIL: kid varies -> ephemeral per-instance keys"
+    else:
+        detail = "OK"
+    print(f"  [canary] JWKS    kid -> {uniq or '{}'}  {detail}")
+    return ok
+
+
+def _canary(public_url: str, *, dry: bool) -> bool:
+    if dry:
+        print(
+            "  (dry-run) would run canary: Gate A /authorize->/login, "
+            "Gate B /mcp 401, JWKS kid-stable"
+        )
+        return True
+    print(f"Canary gate against {public_url} (credential-free):")
+    results = [
+        _gate_a(public_url),
+        _gate_b(public_url),
+        _gate_kid_stable(public_url),
+    ]
+    return all(results)
+
+
+def _rollback(repo: Path, worker: str, prev_ref: str, *, dry: bool) -> None:
+    print(f"  CANARY FAILED -> rolling back to previous image {prev_ref}")
+    if dry:
+        return
+    _set_image_tag(repo, prev_ref)
+    _run(
+        ["bunx", "wrangler", "deploy", "--config", DEPLOY_CONFIG],
+        dry=False,
+        cwd=repo,
+    )
+    _wait_ready(worker, dry=False)
+    print(f"  rolled back {worker} to {prev_ref}.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Deploy this MCP server's CF Worker+Container."
+    )
+    p.add_argument("--tag", default="", help="image tag (default: b-<short-sha>)")
+    p.add_argument(
+        "--skip-build", action="store_true", help="reuse an already-built local image"
+    )
+    p.add_argument("--dry-run", action="store_true", help="print the plan, run nothing")
+    p.add_argument(
+        "--no-canary",
+        action="store_true",
+        help="skip the post-deploy canary gate (and its auto-rollback)",
+    )
+    args = p.parse_args(argv)
+
+    repo = Path(__file__).resolve().parent.parent
+    cfg = _load_deploy_config(repo)
+    worker = cfg["name"]
+    base, _account, name = _image_parts(cfg)
+    prev_ref = cfg["containers"][0]["image"]  # currently-deployed tag, for rollback
+    tag = args.tag or f"b-{_short_sha(repo)}"
+    local = f"{name}:{tag}"
+    full = f"{base}:{tag}"
+
+    print(f"Deploy {worker}: image {local} -> {full}")
+    if not args.skip_build:
+        print("[1/4] docker build --target http")
+        _run(
+            ["docker", "build", "--target", "http", "-t", local, "."],
+            dry=args.dry_run,
+            cwd=repo,
+        )
+    print("[2/4] docker tag -> CF registry")
+    _run(["docker", "tag", local, full], dry=args.dry_run)
+    print("[3/4] wrangler containers push")
+    _run(["bunx", "wrangler", "containers", "push", full], dry=args.dry_run, cwd=repo)
+    print(f"[4/4] wrangler deploy --config {DEPLOY_CONFIG}")
+    if not args.dry_run:
+        _set_image_tag(repo, full)
+    _run(
+        ["bunx", "wrangler", "deploy", "--config", DEPLOY_CONFIG],
+        dry=args.dry_run,
+        cwd=repo,
+    )
+
+    print("Waiting for container rollout (avoid verifying a half-rolled old image)...")
+    _wait_ready(worker, dry=args.dry_run)
+
+    if args.no_canary:
+        print(
+            f"DONE (--no-canary): {worker} deployed at tag {tag}. "
+            "Verify manually with scripts/cf_full_flow.py."
+        )
+        return 0
+
+    if _canary(_public_url(cfg), dry=args.dry_run):
+        print(
+            f"DONE: {worker} deployed at tag {tag}, canary PASS. "
+            "Run scripts/cf_full_flow.py for the authenticated tool round-trip."
+        )
+        return 0
+
+    if prev_ref == full:
+        print(
+            "  CANARY FAILED but the previous image ref equals the just-deployed "
+            "ref; not auto-rolling-back. Investigate manually."
+        )
+        return 1
+    _rollback(repo, worker, prev_ref, dry=args.dry_run)
+    print(f"FAILED: {worker} canary did not pass; rolled back to {prev_ref}.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from mcp_core.chains import resolve_backend
 from mcp_core.llm.providers import key_env_for_model
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
@@ -95,6 +96,13 @@ class Settings(BaseSettings):
     embedding_backend: str = (
         ""  # "cloud" | "local" | "" (auto: API_KEYS->cloud, else local)
     )
+
+    # Per-capability disable-local toggles (cross-cutting; see mcp_core.chains).
+    # Turn OFF the heavy local qwen3 ONNX fallback (~570MB) WITHOUT pinning a
+    # cloud model. Toggle on + no cloud chain => feature gracefully UNAVAILABLE
+    # (clear status), never silently forced to a provider. Independent per task.
+    disable_local_embed: bool = False  # env DISABLE_LOCAL_EMBED
+    disable_local_rerank: bool = False  # env DISABLE_LOCAL_RERANK
 
     # BYO (bring-your-own) LOCAL model override. When set, the local
     # embed/rerank backend loads this model id instead of the bundled
@@ -362,11 +370,13 @@ class Settings(BaseSettings):
         )
 
     def resolve_embedding_backend(self) -> str:
-        """Resolve embedding backend: 'local' or 'cloud'.
+        """Resolve embedding backend: 'cloud', 'local', or 'unavailable'.
 
-        Always returns a valid backend (never empty). Backend is inferred
-        from EMBEDDING_MODELS (non-empty chain -> cloud, empty -> local);
-        the deprecated EMBEDDING_BACKEND env var is honored for one release.
+        3-way resolution via the shared mcp-core primitive: 'cloud' (non-empty
+        EMBEDDING_MODELS chain), 'local' (empty chain + local leg enabled), or
+        'unavailable' (empty chain + DISABLE_LOCAL_EMBED set -> no local download
+        and no cloud, so embedding is gracefully unavailable, NOT forced). The
+        deprecated EMBEDDING_BACKEND env var is honored for one release.
         """
         if self.embedding_backend:
             logger.warning(
@@ -378,14 +388,17 @@ class Settings(BaseSettings):
                 if self.embedding_backend in ("cloud", "litellm")
                 else self.embedding_backend
             )
-        return "cloud" if self.embedding_chain() else "local"
+        return resolve_backend(
+            has_cloud_chain=bool(self.embedding_chain()),
+            local_enabled=not self.disable_local_embed,
+        ).value
 
     def resolve_rerank_backend(self) -> str:
-        """Resolve reranker backend: 'cloud', 'local', or '' (disabled).
+        """Resolve reranker backend: 'cloud', 'local', 'unavailable', or '' (disabled).
 
-        Disabled when rerank_enabled is False. Otherwise inferred from
-        RERANK_MODELS (non-empty chain -> cloud, empty -> local); the
-        deprecated RERANK_BACKEND env var is honored for one release.
+        '' when rerank_enabled is False. Otherwise 3-way via the shared mcp-core
+        primitive (keyed on RERANK_MODELS + DISABLE_LOCAL_RERANK); the deprecated
+        RERANK_BACKEND env var is honored for one release.
         """
         if not self.rerank_enabled:
             return ""
@@ -399,7 +412,10 @@ class Settings(BaseSettings):
                 if self.rerank_backend in ("cloud", "litellm")
                 else self.rerank_backend
             )
-        return "cloud" if self.rerank_chain() else "local"
+        return resolve_backend(
+            has_cloud_chain=bool(self.rerank_chain()),
+            local_enabled=not self.disable_local_rerank,
+        ).value
 
     def resolve_local_rerank_model(self) -> str:
         """Resolve local reranker model: GGUF if GPU + llama-cpp, else ONNX.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -123,6 +123,12 @@ async def _init_embedding_backend(
     embedding_dims = settings.resolve_embedding_dims()
     embedding_backend_type = settings.resolve_embedding_backend()
 
+    if embedding_backend_type == "unavailable":
+        logger.info(
+            "Embedding: unavailable (DISABLE_LOCAL_EMBED set + no cloud model configured, FTS5 mode)"
+        )
+        return
+
     if cred_state == CredentialState.LOCAL or embedding_backend_type == "local":
         # Local-only path
         local_model = settings.resolve_local_embedding_model()
@@ -182,6 +188,12 @@ async def _init_reranker_backend(mode: str) -> None:
     backend_type = settings.resolve_rerank_backend()
     if not backend_type:
         logger.debug("Reranking disabled")
+        return
+
+    if backend_type == "unavailable":
+        logger.info(
+            "Reranker: unavailable (DISABLE_LOCAL_RERANK set + no cloud model configured)"
+        )
         return
 
     cred_state = get_state()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -272,6 +272,29 @@ class TestEmbeddingBackend:
         s = Settings(embedding_backend="litellm")
         assert s.resolve_embedding_backend() == "cloud"
 
+    def test_unavailable_when_local_disabled_and_no_chain(self, monkeypatch):
+        """DISABLE_LOCAL_EMBED + empty chain -> 'unavailable' (NOT forced)."""
+        for v in (
+            "EMBEDDING_MODELS",
+            "JINA_AI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "OPENAI_API_KEY",
+            "COHERE_API_KEY",
+        ):
+            monkeypatch.delenv(v, raising=False)
+        s = Settings(
+            embedding_backend="", embedding_models="", disable_local_embed=True
+        )
+        assert s.resolve_embedding_backend() == "unavailable"
+
+    def test_cloud_wins_even_when_local_disabled(self):
+        """A configured cloud chain still resolves to 'cloud' with local disabled."""
+        s = Settings(
+            embedding_models="gemini/gemini-embedding-001", disable_local_embed=True
+        )
+        assert s.resolve_embedding_backend() == "cloud"
+
 
 class TestRerankSettings:
     def test_rerank_enabled_default(self):
@@ -323,6 +346,22 @@ class TestRerankSettings:
     def test_resolve_rerank_backend_local_fallback(self):
         s = Settings()
         assert s.resolve_rerank_backend() == "local"
+
+    def test_resolve_rerank_unavailable_when_local_disabled(self, monkeypatch):
+        """DISABLE_LOCAL_RERANK + empty chain (rerank enabled) -> 'unavailable'."""
+        for v in ("RERANK_MODELS", "JINA_AI_API_KEY", "COHERE_API_KEY"):
+            monkeypatch.delenv(v, raising=False)
+        s = Settings(
+            rerank_enabled=True,
+            rerank_backend="",
+            rerank_models="",
+            disable_local_rerank=True,
+        )
+        assert s.resolve_rerank_backend() == "unavailable"
+
+    def test_resolve_rerank_disabled_overrides_toggle(self):
+        s = Settings(rerank_enabled=False, disable_local_rerank=True)
+        assert s.resolve_rerank_backend() == ""
 
     def test_rerank_chain_explicit(self):
         s = Settings(rerank_models="custom/reranker")

--- a/uv.lock
+++ b/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.89.3"
+version = "1.90.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -937,9 +937,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/f1/f7cfead063f2ab1877c8fb465d0d7fe300b75f081bcb73525f6d550aeb1c/litellm-1.89.3.tar.gz", hash = "sha256:8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510", size = 14080611, upload-time = "2026-06-20T22:42:26.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/c6/45b74e44f6605f91cffb2d6ad5463bc743f5636c66a2892c834d90b708e7/litellm-1.90.0.tar.gz", hash = "sha256:55f2be4adfc350ae2931bf369aebf1229aa54ea8ceaa1c13ee65a07724572dae", size = 14815671, upload-time = "2026-06-27T03:12:47.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/f1/34d174ff1d84e459b30f971606ac9cb7078ad24cd7661e9786b25adf7def/litellm-1.89.3-py3-none-any.whl", hash = "sha256:414ef5aee504b2b3eb1b219d39f1c11902db399cbdbc06e5fb550c15d731abeb", size = 15495226, upload-time = "2026-06-20T22:42:23.156Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f7/0864ca487526ed478b857c704244255c7be4e13ed4dde7aeec13f679c904/litellm-1.90.0-py3-none-any.whl", hash = "sha256:3a0fec8405606e34f501544fb9cfe4261fe073bef340d3ca9a60d3fb31c639ee", size = 16607104, upload-time = "2026-06-27T03:12:44.493Z" },
 ]
 
 [[package]]
@@ -1202,7 +1202,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b20"
+version = "1.18.0b21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1217,9 +1217,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/10/ec1bdeff0df00bb00382107f79ca575c784c28067fda4229083ab3a97dc7/n24q02m_mcp_core-1.18.0b20.tar.gz", hash = "sha256:6814f5e0c9887dff3afdf2c7049ff4b598fa1c2cbca0656d95f48fb1f2226d8b", size = 301569, upload-time = "2026-06-23T02:28:51.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/92/5d27474d530d85596bf55976d7a5001c5e9d9a6d5d5c6cb194ac9676ccb5/n24q02m_mcp_core-1.18.0b21.tar.gz", hash = "sha256:8927ada85ab2b29c1f2e23f947d1d8872af44daed7ebdf0c533b6c2acd03999c", size = 304974, upload-time = "2026-06-29T12:29:44.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/db/a555b269c368c2238a82186e90f65a41a07a93b11d0c4b8516703a19a90b/n24q02m_mcp_core-1.18.0b20-py3-none-any.whl", hash = "sha256:66fae2c80c3287b1a7c5d3aa3eec0948ccd819efb1ddc9549a9ecfb003be3d84", size = 168546, upload-time = "2026-06-23T02:28:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f7/99e4dc3a59aace2c1e478d820f22955e5cec3a71c4efd180d4c618be6dd3/n24q02m_mcp_core-1.18.0b21-py3-none-any.whl", hash = "sha256:8a39760921073411c106a6bef8e220472353b5e1b15ac53e646cc73058e47691", size = 169010, upload-time = "2026-06-29T12:29:43.284Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Adds DISABLE_LOCAL_EMBED / DISABLE_LOCAL_RERANK toggles (3-way backend resolution via mcp_core.chains.resolve_backend: cloud/local/unavailable) so the heavy local qwen3 ONNX fallback can be turned off WITHOUT pinning a cloud model — toggle on + no cloud chain => feature gracefully unavailable (FTS5-only embed, rerank skipped), never silently forced.

Also adds scripts/deploy_cf.py + cf_full_flow.py (CF deploy parity with the other 5 CF MCP servers) and gitignores wrangler.deploy.jsonc + scripts/.mnemo_cf_token + node_modules. Bumps mcp-core lock to 1.18.0b21 (first beta shipping mcp_core.chains).

Verified locally: 167 tests pass (test_config WS-5 + test_server).