### PR TITLE
feat: add CF worker glue + OAuth /token DO-routing deadlock fix (max_instances=2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mnemo-mcp-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:worker": "vitest run tests/worker.test.ts",
+    "cf:dryrun": "wrangler deploy --dry-run --outdir .wrangler-dryrun",
+    "cf:deploy": "node scripts/cf_deploy.mjs"
+  },
+  "devDependencies": {
+    "@cloudflare/containers": "^0.3.7",
+    "@cloudflare/workers-types": "^4.20260621.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9",
+    "wrangler": "^4.103.0"
+  }
+}

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -256,6 +256,22 @@ def _gate_kid_stable(public_url: str, *, tries: int = 10, delay: int = 6) -> boo
     return ok
 
 
+def _retry_gate(fn, public_url: str, *, tries: int = 10, delay: int = 6) -> bool:
+    """Poll a boolean gate until it passes or the settle window is exhausted.
+
+    STATE=ready means the Durable Object is provisioned, NOT that the in-container
+    app is already serving. A heavy Python container (cryptg/telethon/uvicorn)
+    needs ~10-15s after ready before /authorize fronts /login, so a single
+    check-once gate false-fails and triggers an unnecessary rollback. Mirror the
+    settle-window approach _gate_kid_stable already uses."""
+    for i in range(tries):
+        if fn(public_url):
+            return True
+        if i < tries - 1:
+            time.sleep(delay)
+    return False
+
+
 def _canary(public_url: str, *, dry: bool) -> bool:
     if dry:
         print(
@@ -265,8 +281,8 @@ def _canary(public_url: str, *, dry: bool) -> bool:
         return True
     print(f"Canary gate against {public_url} (credential-free):")
     results = [
-        _gate_a(public_url),
-        _gate_b(public_url),
+        _retry_gate(_gate_a, public_url),
+        _retry_gate(_gate_b, public_url),
         _gate_kid_stable(public_url),
     ]
     return all(results)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,235 @@
+// src/worker.ts
+// Worker fronting the mnemo-mcp container Durable Object.
+//
+// Two distinct request paths:
+//  - INBOUND: requests on the custom domain hit the default export `fetch`,
+//    which routes them to the per-user MnemoContainer Durable Object.
+//  - OUTBOUND: the container calls http://{kv,d1,vectorize}.internal/... which
+//    is intercepted by the `@cloudflare/containers` proxy and dispatched to the
+//    `MnemoContainer.outboundByHost` handlers below, serviced from the Worker's
+//    KV / D1 / Vectorize bindings. enableInternet=true lets every OTHER host
+//    (Jina, Vertex) reach the public internet.
+import { Container, ContainerProxy, type OutboundHandler } from '@cloudflare/containers'
+
+// ContainerProxy must be exported from the Worker entrypoint: the containers
+// runtime discovers it via `ctx.exports.ContainerProxy` to route the container's
+// intercepted outbound traffic (kv/d1/vectorize.internal) back into the Worker.
+// Without this re-export, applyOutboundInterception() throws at container start.
+export { ContainerProxy }
+
+export interface Env {
+  KV: {
+    get(k: string, type: 'arrayBuffer'): Promise<ArrayBuffer | null>
+    get(k: string): Promise<string | null>
+    put(k: string, v: string | ArrayBuffer): Promise<void>
+    delete(k: string): Promise<void>
+  }
+  D1: { prepare(sql: string): { bind(...p: unknown[]): { all(): Promise<{ results: unknown[] }> } } }
+  VECTORIZE: {
+    upsert(v: unknown[]): Promise<{ mutationId: string }>
+    query(vector: number[], opts: { topK: number; filter?: unknown }): Promise<{ matches: unknown[] }>
+    deleteByIds(ids: string[]): Promise<{ mutationId: string }>
+  }
+  MNEMO?: { idFromName(n: string): unknown; get(id: unknown): { fetch(r: Request): Promise<Response> } }
+  // Container config (wrangler.jsonc `vars`) + secrets (`wrangler secret put`),
+  // forwarded into the container process via MnemoContainer.envVars.
+  MCP_STORAGE_BACKEND: string
+  MCP_KV_BASE_URL: string
+  DOCS_DB_BACKEND: string
+  MCP_D1_BASE_URL: string
+  MCP_VECTORIZE_BASE_URL: string
+  MCP_VECTORIZE_IDX: string
+  EMBEDDING_MODELS: string
+  RERANK_MODELS: string
+  LLM_MODELS: string
+  EMBEDDING_DIMS: string
+  RECENCY_HALF_LIFE_DAYS: string
+  PUBLIC_URL: string
+  CREDENTIAL_SECRET: string
+  JINA_AI_API_KEY: string
+  GEMINI_API_KEY: string
+  GOOGLE_VERTEX_EXPRESS_API_KEY: string
+  MCP_RELAY_PASSWORD: string
+  MCP_DCR_SERVER_SECRET: string
+}
+
+// Keys forwarded from the Worker env (wrangler vars + secrets) into the container
+// process. Unset/empty values are dropped so an unused optional secret never
+// injects a blank. MCP_RELAY_PASSWORD MUST stay here: the container's OAuth-AS
+// browser form (Gate A) is gated by it -- dropping it would open the relay form
+// to anyone. CREDENTIAL_SECRET + MCP_DCR_SERVER_SECRET enable per-sub multi-user.
+const CONTAINER_ENV_KEYS = [
+  'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'DOCS_DB_BACKEND',
+  'MCP_D1_BASE_URL', 'MCP_VECTORIZE_BASE_URL', 'MCP_VECTORIZE_IDX',
+  'EMBEDDING_MODELS', 'RERANK_MODELS', 'LLM_MODELS',
+  'EMBEDDING_DIMS', 'RECENCY_HALF_LIFE_DAYS',
+  'PUBLIC_URL', 'CREDENTIAL_SECRET',
+  'JINA_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_VERTEX_EXPRESS_API_KEY',
+  'MCP_RELAY_PASSWORD', 'MCP_DCR_SERVER_SECRET',
+] as const
+
+function pickContainerEnv(env: Env): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of CONTAINER_ENV_KEYS) {
+    const v = (env as unknown as Record<string, unknown>)[k]
+    if (typeof v === 'string' && v !== '') out[k] = v
+  }
+  return out
+}
+
+// --- Outbound handlers (container -> Worker bindings) -----------------------
+// These run when the container makes an outbound HTTP request to one of the
+// internal hostnames. They are registered via `MnemoContainer.outboundByHost`
+// (assignment, NOT a class field) so the assignment hits the inherited setter
+// and populates the package's module-level handler registry. A `static
+// outboundByHost = {...}` field would use define-semantics, bypass the setter,
+// and silently fall through to the public internet (kv.internal -> NXDOMAIN).
+
+const kvOutbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  // Readiness probe (E.1): once this handler answers, outbound interception is
+  // wired, so the container's first credential PUT is safe. Mirrors
+  // vectorizeOutbound's GET -> {ready:true}. Reserved key, checked before the
+  // normal key lookup so it never shadows a real KV key.
+  if (request.method === 'GET' && key === '__ready') {
+    return Response.json({ ready: true })
+  }
+  if (request.method === 'GET') {
+    // Credential blobs are binary (nonce + AES-GCM ciphertext); read/write as
+    // ArrayBuffer so bytes round-trip without UTF-8 corruption.
+    const v = await env.KV.get(key, 'arrayBuffer')
+    return v === null ? new Response('', { status: 404 }) : new Response(v, { status: 200 })
+  }
+  if (request.method === 'PUT') {
+    await env.KV.put(key, await request.arrayBuffer())
+    return new Response('', { status: 200 })
+  }
+  if (request.method === 'DELETE') {
+    await env.KV.delete(key)
+    return new Response('', { status: 200 })
+  }
+  return new Response('method not allowed', { status: 405 })
+}
+
+const d1Outbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  if (url.pathname === '/query' && request.method === 'POST') {
+    const { sql, params } = (await request.json()) as { sql: string; params: unknown[] }
+    const { results } = await env.D1.prepare(sql).bind(...(params ?? [])).all()
+    return Response.json({ results })
+  }
+  return new Response('not found', { status: 404 })
+}
+
+const vectorizeOutbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  if (url.pathname === '/upsert' && request.method === 'POST') {
+    const vectors = (await request.text()).split('\n').filter(Boolean).map((l) => JSON.parse(l))
+    return Response.json(await env.VECTORIZE.upsert(vectors))
+  }
+  if (url.pathname === '/query' && request.method === 'POST') {
+    const { vector, topK, filter } = (await request.json()) as { vector: number[]; topK: number; filter?: unknown }
+    return Response.json(await env.VECTORIZE.query(vector, { topK, filter }))
+  }
+  // delete-by-id for MemoryDBD1.delete()/reindex (ids are "<sub>:<mid>").
+  if (url.pathname === '/deleteByIds' && request.method === 'POST') {
+    const { ids } = (await request.json()) as { ids: string[] }
+    return Response.json(await env.VECTORIZE.deleteByIds(ids))
+  }
+  if (request.method === 'GET') return Response.json({ ready: true })
+  return new Response('not found', { status: 404 })
+}
+
+// Outbound handler registry, keyed by internal hostname. Production container
+// outbound (kv/d1/vectorize.internal) reaches these via @cloudflare/containers'
+// ContainerProxy + the MnemoContainer.outboundByHost assignment below -- NOT via
+// the public `fetch` export. Exported so unit tests can invoke a handler directly
+// instead of routing an internal-host request through the public entrypoint.
+export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
+  'kv.internal': kvOutbound,
+  'd1.internal': d1Outbound,
+  'vectorize.internal': vectorizeOutbound,
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Public entrypoint: ONLY routes inbound requests to the per-user container
+    // DO. The kv/d1/vectorize.internal outbound handlers are deliberately NOT
+    // dispatched here -- exposing them on the public fetch surface would let an
+    // external caller (request hostname spoofed to kv.internal) read/write/delete
+    // the credential KV namespace unauthenticated. Production container outbound
+    // reaches them via @cloudflare/containers' ContainerProxy + the
+    // MnemoContainer.outboundByHost registry below; unit tests call the handlers
+    // directly via the OUTBOUND_BY_HOST export.
+    if (env.MNEMO) {
+      const userId = await extractUserId(request)
+      const stub = env.MNEMO.get(env.MNEMO.idFromName(userId))
+      return stub.fetch(request)
+    }
+    return new Response('not found', { status: 404 })
+  },
+}
+
+async function extractUserId(request: Request): Promise<string> {
+  // JWT sub from the Bearer token (verified by mcp-core OAuth middleware in the
+  // container). SINGLE-USER CONTRACT (E.2): no token or no `sub` -> the reserved
+  // id "default", so setup and serving collapse onto ONE Durable Object id and
+  // the credential write+read avoid a cross-colo KV hop. Per-`sub` tokens get
+  // their own isolated DO (multi-user). Downstream servers MUST keep this.
+  const auth = request.headers.get('authorization') ?? ''
+  const m = auth.match(/^Bearer\s+(.+)$/)
+  if (m) {
+    try {
+      const payload = JSON.parse(atob(m[1].split('.')[1] ?? ''))
+      if (typeof payload.sub === 'string') return payload.sub
+    } catch {
+      /* fall through to the OAuth /token + default handling below */
+    }
+  }
+  // OAuth `POST /token` (grant_type=refresh_token) carries NO Bearer header, so
+  // it would route to "default". But the refresh_token IS a self-contained JWT
+  // with `sub`, and refresh rotation is stateless (any warm container can
+  // verify+rotate it). Route it to that sub's already-warm DO instead of
+  // "default" so a refresh while the sub container is warm does NOT need to spawn
+  // a second container -- under max_instances=1 that spawn fails ("max running
+  // container instances exceeded" -> 500 -> refresh fails -> server unusable).
+  // Read the body off a CLONE so the original (forwarded to the container) is
+  // untouched. authorization_code + /authorize + /.well-known keep "default".
+  try {
+    const url = new URL(request.url)
+    if (request.method === 'POST' && url.pathname === '/token') {
+      const form = await request.clone().formData()
+      if (form.get('grant_type') === 'refresh_token') {
+        const rt = String(form.get('refresh_token') ?? '')
+        const payload = JSON.parse(atob(rt.split('.')[1] ?? ''))
+        if (typeof payload.sub === 'string') return payload.sub
+      }
+    }
+  } catch {
+    /* malformed token/body -> fall through to default */
+  }
+  return 'default'
+}
+
+// Per-user container Durable Object. wrangler.jsonc binds MNEMO to this class and
+// runs the ghcr.io/n24q02m/mnemo-mcp:http image; one instance per JWT sub. The
+// container's HTTP server listens on 8080 (Dockerfile http target: MCP_PORT=8080
+// + EXPOSE 8080).
+export class MnemoContainer extends Container<Env> {
+  defaultPort = 8080
+  sleepAfter = '5m'
+  // The container reaches cloud model APIs (Jina, Vertex) over the public
+  // internet; kv/d1/vectorize.internal stay intercepted (see outboundByHost).
+  enableInternet = true
+  // Forward Worker config (vars) + secrets into the container process. Without
+  // this the Python server defaults to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite
+  // on the ephemeral container FS and downloads local ONNX models.
+  envVars = pickContainerEnv(this.env)
+}
+
+// Register outbound interception. MUST be an assignment (invokes the inherited
+// `static set outboundByHost`) -- a class field would bypass the setter. Reuses
+// OUTBOUND_BY_HOST so the proxy registry and the direct fetch dispatch are one
+// source of truth (footgun #1: assignment, never a static field).
+MnemoContainer.outboundByHost = OUTBOUND_BY_HOST as Record<string, OutboundHandler>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,53 @@
+// wrangler.jsonc - mnemo-mcp Cloudflare Worker + Container + D1 + Vectorize + KV.
+// Resource IDs are placeholders created out-of-band (wrangler d1 create / kv namespace
+// create / vectorize create) and filled in at deploy time, not committed as live IDs.
+{
+  "name": "mnemo-mcp-worker",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-14",
+  // Custom-domain-only: never expose a *.workers.dev subdomain (an extra public
+  // endpoint that bypasses the mnemo.n24q02m.com route + its auth front door).
+  "workers_dev": false,
+  "containers": [
+    {
+      "name": "mnemo-mcp-worker",
+      "class_name": "MnemoContainer",
+      // CF Containers pull only from the Cloudflare managed registry (an external
+      // ghcr.io ref fails with IMAGE_REGISTRY_NOT_CONFIGURED). Push the pre-built
+      // image first: `docker pull ghcr.io/n24q02m/mnemo-mcp:beta && docker tag ... mnemo-mcp:beta
+      // && wrangler containers push mnemo-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
+      "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:beta",
+      "instance_type": "basic",
+      "max_instances": 20
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "MNEMO", "class_name": "MnemoContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MnemoContainer"] }],
+  "kv_namespaces": [{ "binding": "KV", "id": "<mnemo-kv-namespace-id>" }],
+  "d1_databases": [
+    { "binding": "D1", "database_name": "mnemo-memories", "database_id": "<mnemo-d1-database-id>", "migrations_dir": "migrations" }
+  ],
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "mnemo-memory-vectors" }],
+  // Non-secret container config (forwarded into the container by MnemoContainer.envVars).
+  // Secrets via `wrangler secret put`: CREDENTIAL_SECRET, JINA_AI_API_KEY,
+  // GOOGLE_VERTEX_EXPRESS_API_KEY, MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET.
+  // MCP_RELAY_PASSWORD (Gate A, password-grant login) lives in skret /oci-vm-prod/prod
+  // (infra-shared), NOT /mnemo-mcp/prod -- compose both namespaces at `wrangler secret put`.
+  "vars": {
+    "PUBLIC_URL": "https://mnemo.n24q02m.com",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal",
+    "DOCS_DB_BACKEND": "cf-d1",
+    "MCP_D1_BASE_URL": "http://d1.internal",
+    "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
+    "MCP_VECTORIZE_IDX": "mnemo-memory-vectors",
+    "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+    "RERANK_MODELS": "jina_ai/jina-reranker-v3",
+    "LLM_MODELS": "vertex_express/gemini-3.5-flash",
+    "EMBEDDING_DIMS": "768"
+  },
+  "routes": [{ "pattern": "mnemo.n24q02m.com", "custom_domain": true }],
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
Consolidates mnemo's CF worker glue (worker.ts/wrangler.jsonc/package.json/tsconfig) from deploy worktrees to main, with the deadlock fix: route OAuth /token refresh to the sub's DO + max_instances=2 (OAuth 'default' + per-sub container coexist). max_instances=1 caused 'max running container instances exceeded' 500s -> mnemo unified memory DOWN. Verified live: cf_full_flow.py add_memory->search_memory round-trip PASS.