### PR TITLE
fix: mnemo max_instances 20 -> 1 (restore solo-dev cost cap)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,7 +18,7 @@
       // && wrangler containers push mnemo-mcp:beta`, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/mnemo-mcp:beta",
       "instance_type": "basic",
-      "max_instances": 20
+      "max_instances": 1
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
#901 accidentally shipped max_instances=20 (sed matched '1' in '10'). Restore the locked max_instances=1 (P0 2026-06-23 cost rule). Setup contention handled by /token DO-routing fix + steady-state 1 sub container.