### PR TITLE
🎨 Palette: Add actionable suggestion to import_passport error

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Improve configuration setting error reporting
 **Learning:** Returning a raw "Invalid key" or "Invalid log level" message forces users to look up documentation. A small fuzzy match with `difflib.get_close_matches` combined with a fallback list provides immediate, actionable feedback in the API response.
 **Action:** When returning validation errors for enumerated values (like settings keys or predefined constants), always try fuzzy matching to catch typos and include the full list of valid options as a fallback `suggestion`.
+## $(date +%Y-%m-%d) - Consistent Error Suggestions
+**Learning:** Returning error messages without actionable next steps leaves the developer guessing what went wrong, which degrades Developer Experience (DX). In backend MCP servers, returning structured errors with `suggestion` strings is crucial.
+**Action:** When a tool returns an error structure (e.g., in `import_passport`), ensure it includes a `suggestion` key to guide the developer/agent on how to fix the issue.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2155,6 +2155,7 @@ async def _handle_config_import_passport(
                 "error": "Passphrase mismatch or tampered bundle",
                 "detail": f"{type(e).__name__}: {e}",
                 "backend": target,
+                "suggestion": "Verify the passphrase matches the one used to export the passport bundle and that the bundle has not been modified.",
             }
         )
 


### PR DESCRIPTION
💡 What: Added an actionable `suggestion` string to the error payload returned when a passport bundle import fails in `import_passport`.
🎯 Why: In a backend MCP server, returning structured errors with actionable next steps is critical for Developer/Agent Experience (DX). This ensures the API always guides the consumer on how to resolve the issue (e.g., verifying the passphrase).
📸 Before/After: Before, it only returned `error`, `detail`, and `backend`. Now, it also returns `suggestion: "Verify the passphrase matches the one used to export the passport bundle and that the bundle has not been modified."`.
♿ Accessibility: Improves API usability and developer discoverability.

---
*PR created automatically by Jules for task [15199958531509041722](https://jules.google.com/task/15199958531509041722) started by @n24q02m*