### PR TITLE
fix: correct roadmap header to current Phase 3 / v2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ mcp-name: io.github.n24q02m/mnemo-mcp
   <img width="380" height="200" src="https://glama.ai/mcp/servers/n24q02m/mnemo-mcp/badge" alt="Mnemo MCP server" />
 </a>
 
-## Roadmap (current = Phase 1 / v1.x)
+## Roadmap (current = Phase 3 / v2.x)
 
 | Phase | Version | Status | Highlights |
 |---|---|---|---|


### PR DESCRIPTION
## Problem

The Roadmap header read `## Roadmap (current = Phase 1 / v1.x)`, but the roadmap table directly below marks **Phase 3 = v2.0.0 "Shipped (BREAKING)"**, and the latest stable release is **v2.2.1** (the current line is v2.x, with v2.3.0 betas in flight). The header was stale by two phases / a major version.

## Change

- `README.md` — header updated to `## Roadmap (current = Phase 3 / v2.x)` to match the table (all three phases Shipped) and the released version line.

## Verification

- Roadmap table (Phase 3 = v2.0.0 Shipped BREAKING) confirmed in `README.md`.
- Latest stable release confirmed as `v2.2.1` (marked Latest, `prerelease=false`) via the GitHub Releases API. Docs-only change.