### PR TITLE
fix: add vertex ai (express) support to the relay credential form

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -42,6 +42,7 @@ CLOUD_KEYS = [
     "COHERE_API_KEY",
     "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
+    "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
 # All config keys that indicate a valid saved config (includes GDrive)

--- a/src/mnemo_mcp/relay_schema.py
+++ b/src/mnemo_mcp/relay_schema.py
@@ -111,6 +111,12 @@ RELAY_SCHEMA: dict[str, Any] = {
             "https://console.anthropic.com/settings/keys",
         ),
         _key_field("XAI_API_KEY", "xAI API Key", "xai-...", "https://console.x.ai/"),
+        _key_field(
+            "GOOGLE_VERTEX_EXPRESS_API_KEY",
+            "Vertex AI (Express) API Key",
+            "AQ...",
+            "https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview",
+        ),
     ],
     "capabilityInfo": [
         {

--- a/src/mnemo_mcp/relay_setup.py
+++ b/src/mnemo_mcp/relay_setup.py
@@ -21,6 +21,7 @@ CLOUD_KEYS = [
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
     "COHERE_API_KEY",
+    "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 # All config keys that indicate a valid saved config
 _ALL_CONFIG_KEYS = [*CLOUD_KEYS, "GOOGLE_DRIVE_CLIENT_ID"]

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -25,3 +25,13 @@ def test_suggested_models_carry_provider_prefix():
         if f.get("type") == "model-chain":
             for m in f["suggestedModels"]:
                 assert "/" in m, f"suggested model {m!r} lacks a provider prefix"
+
+
+def test_vertex_express_key_field_present_and_derived():
+    # Selecting a vertex_express/gemini model must surface a credential box, so
+    # the schema declares GOOGLE_VERTEX_EXPRESS_API_KEY as a derived field. The
+    # credential-state layer also recognizes it (see test_credential_state).
+    by_key = {f["key"]: f for f in RELAY_SCHEMA["fields"]}
+    assert "GOOGLE_VERTEX_EXPRESS_API_KEY" in by_key
+    assert by_key["GOOGLE_VERTEX_EXPRESS_API_KEY"].get("derived") is True
+    assert "VERTEX_AI_API_KEY" not in by_key  # no dead-end field


### PR DESCRIPTION
## Problem

In the relay credential form, choosing a Vertex Gemini model in a model chain showed no credential box. Root cause (verified in code, not guessed):

- The dropdown offered the whole litellm registry, including providers no server declares a credential field for (`vertex_ai/*`, `bedrock/*`, `azure/*`, ...). Picking one derived an unbacked `<PROVIDER>_API_KEY`, so the derive-keys widget had nothing to reveal — a silent trap.
- litellm's `vertex_ai/` still requires a Service Account / ADC (BerriAI/litellm#21036, open). This stack authenticates Vertex only via the `vertex_express` httpx adapter (Gemini chat/vision, `GOOGLE_VERTEX_EXPRESS_API_KEY`).
- Even the correct `vertex_express/` prefix had no schema field, and the hardcoded `CLOUD_KEYS` omitted the key, so a vertex-only config was neither detected as configured nor forwarded to the LLM dispatch.

## Fix

- **mcp-core**: the dropdown offers only catalog models whose provider has a credential field on the page; it remaps `vertex_ai/gemini-*` to the working `vertex_express/*` and drops other unsupported `vertex_ai/*`.
- **server**: declares the derived `GOOGLE_VERTEX_EXPRESS_API_KEY` field and adds it to `CLOUD_KEYS` / credential-state so the key actually reaches the model dispatch.

Free-text entry still accepts any model (open passthrough). Part of a coordinated 5-repo set: mcp-core + wet-mcp + mnemo-mcp + better-code-review-graph + imagine-mcp.
