### PR TITLE
feat: deploy CF Worker+Container on release from cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -293,3 +293,47 @@ jobs:
             -f event_type=plugin-sync \
             -f 'client_payload[repo]=mnemo-mcp' \
             -f 'client_payload[tag]=${{ needs.release.outputs.tag }}'
+  deploy-cf:
+    name: Deploy Cloudflare Worker+Container
+    # Builds the http-slim image on a GitHub Linux runner and deploys it to
+    # Cloudflare so any release == CF live on that version — a beta dispatch redeploys
+    # the beta, a stable dispatch is maintainer-gated (replaces the
+    # manual local deploy_cf.py step + its Windows Docker OOM). Only needs the
+    # `release` job (deploy_cf.py builds its OWN image, so merge-docker is not a
+    # dependency). Dispatch-only workflow (no fork PRs) => secrets are safe.
+    # NOTE: in CI the template renders the image at the NEW tag, so deploy_cf.py's
+    # auto-rollback (prev_ref != new) is inert here; a failed canary still fails
+    # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
+    # rollback is a tracked follow-up.
+    needs: [release]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout the released tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+      - name: Setup Bun (bunx wrangler)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install worker deps (wrangler bundles worker.ts, needs @cloudflare/containers)
+        run: bun install --frozen-lockfile
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - name: Deploy to Cloudflare (build http-slim + push + deploy + canary)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_DEPLOY_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_KV_ID: ${{ secrets.CF_KV_ID }}
+          CF_D1_ID: ${{ secrets.CF_D1_ID }}
+          CF_VECTORIZE_ID: ${{ secrets.CF_VECTORIZE_ID }}
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+          IMAGE_TAG: ${{ needs.release.outputs.version }}
+        run: python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}"

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -8,17 +8,20 @@ managed registry, deploys, waits for the container rollout to finish
 (STATE=ready) so you never verify against a half-rolled old image, then runs a
 **credential-free canary gate** and **auto-rolls-back** if it fails.
 
-Run from the repo root, with the CF dev token injected by skret:
+Set CLOUDFLARE_API_TOKEN in the environment (any secret manager works), then run
+from the repo root:
 
-    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- \\
-        python scripts/deploy_cf.py            # tag defaults to b-<short-sha>
-    ... python scripts/deploy_cf.py --tag b10-abc1234   # explicit tag
-    ... python scripts/deploy_cf.py --skip-build         # reuse a built image
-    ... python scripts/deploy_cf.py --dry-run            # print the plan only
-    ... python scripts/deploy_cf.py --no-canary          # skip the post-deploy gate
+    export CLOUDFLARE_API_TOKEN=...                       # however you store secrets
+    python scripts/deploy_cf.py                           # tag defaults to b-<short-sha>
+    ... python scripts/deploy_cf.py --tag b10-abc1234     # explicit tag
+    ... python scripts/deploy_cf.py --skip-build          # reuse a built image
+    ... python scripts/deploy_cf.py --dry-run             # print the plan only
+    ... python scripts/deploy_cf.py --no-canary           # skip the post-deploy gate
 
-Requires: CLOUDFLARE_API_TOKEN in env (skret /n24q02m/dev CF_DEV_TOKEN ->
-export CLOUDFLARE_API_TOKEN), docker, and ``bunx wrangler``. The CF container
+The maintainer injects the token via ``skret`` (one option), e.g.:
+    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- python scripts/deploy_cf.py
+
+Requires: CLOUDFLARE_API_TOKEN in env, docker, and ``bunx wrangler``. The CF container
 registry only pulls from registry.cloudflare.com/<account>/... (not ghcr), so the
 local image is tagged to that path before ``wrangler containers push``.
 
@@ -45,6 +48,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -61,6 +65,28 @@ for _stream in (sys.stdout, sys.stderr):
         _stream.reconfigure(encoding="utf-8", errors="replace")
 
 DEPLOY_CONFIG = "wrangler.deploy.jsonc"
+TEMPLATE_CONFIG = "wrangler.deploy.template.jsonc"
+
+
+def render_template(path: str) -> str:
+    """Substitute ``${VAR}`` tokens in the committed deploy template from the
+    environment.
+
+    CI runs ``deploy_cf.py --from-template`` to reconstruct the gitignored
+    ``wrangler.deploy.jsonc`` from the committed placeholder template plus the
+    real IDs, which arrive as env vars (GitHub Actions secrets synced from
+    skret). Fails loudly if a referenced var is missing so a half-substituted
+    config never reaches ``wrangler deploy``.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+
+    def _sub(m: re.Match[str]) -> str:
+        val = os.environ.get(m.group(1))
+        if val is None:
+            raise SystemExit(f"template var ${{{m.group(1)}}} not set in environment")
+        return val
+
+    return re.sub(r"\$\{([A-Z0-9_]+)\}", _sub, text)
 
 
 def _strip_jsonc(text: str) -> str:
@@ -312,6 +338,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("--dry-run", action="store_true", help="print the plan, run nothing")
     p.add_argument(
+        "--from-template",
+        action="store_true",
+        help="reconstruct wrangler.deploy.jsonc from the committed template + env (CI)",
+    )
+    p.add_argument(
         "--no-canary",
         action="store_true",
         help="skip the post-deploy canary gate (and its auto-rollback)",
@@ -319,6 +350,11 @@ def main(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
 
     repo = Path(__file__).resolve().parent.parent
+    if args.from_template:
+        (repo / DEPLOY_CONFIG).write_text(
+            render_template(str(repo / TEMPLATE_CONFIG)), encoding="utf-8"
+        )
+        print(f"Rendered {DEPLOY_CONFIG} from {TEMPLATE_CONFIG} (CI mode).")
     cfg = _load_deploy_config(repo)
     worker = cfg["name"]
     base, _account, name = _image_parts(cfg)
@@ -331,7 +367,17 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_build:
         print("[1/4] docker build --target http")
         _run(
-            ["docker", "build", "--target", "http", "-t", local, "."],
+            [
+                "docker",
+                "build",
+                "--target",
+                "http",
+                "--build-arg",
+                "SLIM=1",
+                "-t",
+                local,
+                ".",
+            ],
             dry=args.dry_run,
             cwd=repo,
         )

--- a/tests/test_deploy_cf_template.py
+++ b/tests/test_deploy_cf_template.py
@@ -1,0 +1,72 @@
+"""Tests for the CI CF-deploy template rendering in ``scripts/deploy_cf.py``.
+
+``deploy_cf.py --from-template`` reconstructs the gitignored
+``wrangler.deploy.jsonc`` from the committed placeholder template + env (CI
+provides the real IDs as GitHub Actions secrets). These tests exercise the pure
+``render_template`` substitution without touching docker/wrangler.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "deploy_cf.py"
+_spec = importlib.util.spec_from_file_location("deploy_cf", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+deploy_cf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deploy_cf)
+
+
+def test_render_template_substitutes_env(tmp_path, monkeypatch):
+    tpl = tmp_path / "wrangler.deploy.template.jsonc"
+    tpl.write_text(
+        '{"image":"registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/mnemo-mcp:${IMAGE_TAG}",'
+        '"vars":{"PUBLIC_URL":"${PUBLIC_URL}"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct123")
+    monkeypatch.setenv("IMAGE_TAG", "v9.9.9")
+    # A non-URL sentinel: this unit test exercises substitution mechanics, and a
+    # real URL literal would trip CodeQL's url-substring-sanitization heuristic.
+    # Parse + equality-assert the rendered JSON (not substring) so the test is
+    # precise and CodeQL sees no url-in-string validation pattern.
+    monkeypatch.setenv("PUBLIC_URL", "PUBLIC-URL-SENTINEL")
+    cfg = json.loads(deploy_cf.render_template(str(tpl)))
+    assert cfg["image"] == "registry.cloudflare.com/acct123/mnemo-mcp:v9.9.9"
+    assert cfg["vars"]["PUBLIC_URL"] == "PUBLIC-URL-SENTINEL"
+
+
+def test_render_template_missing_var_fails_loudly(tmp_path, monkeypatch):
+    tpl = tmp_path / "t.jsonc"
+    tpl.write_text('{"x":"${DEFINITELY_MISSING_VAR}"}', encoding="utf-8")
+    monkeypatch.delenv("DEFINITELY_MISSING_VAR", raising=False)
+    with pytest.raises(SystemExit):
+        deploy_cf.render_template(str(tpl))
+
+
+def test_committed_template_renders_to_valid_json(monkeypatch):
+    """The real committed template must render cleanly when all documented CI
+    env vars are set, and parse as valid JSON (catches a ${VAR} typo or a stray
+    placeholder the tiny unit example would miss)."""
+    for k, v in {
+        "CLOUDFLARE_ACCOUNT_ID": "acct",
+        "IMAGE_TAG": "v1",
+        "CF_KV_ID": "kvid",
+        "CF_D1_ID": "d1id",
+        "CF_VECTORIZE_ID": "vecidx",
+        "PUBLIC_URL": "https://wet.n24q02m.com",
+    }.items():
+        monkeypatch.setenv(k, v)
+    tpl = _SCRIPT.parent.parent / "wrangler.deploy.template.jsonc"
+    out = deploy_cf.render_template(str(tpl))
+    assert "${" not in out  # no leftover placeholder
+    cfg = json.loads(deploy_cf._strip_jsonc(out))
+    assert cfg["name"] == "mnemo-mcp-worker"
+    assert cfg["containers"][0]["image"] == "registry.cloudflare.com/acct/mnemo-mcp:v1"
+    assert cfg["kv_namespaces"][0]["id"] == "kvid"
+    assert cfg["d1_databases"][0]["database_id"] == "d1id"
+    assert cfg["vars"]["PUBLIC_URL"] == "https://wet.n24q02m.com"

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -1,0 +1,43 @@
+// wrangler.deploy.template.jsonc - COMMITTED placeholder template for CI CF deploy.
+// scripts/deploy_cf.py --from-template renders this into the gitignored
+// wrangler.deploy.jsonc by substituting the placeholder tokens below from the
+// environment (CI provides them from GitHub Actions secrets synced from skret).
+// Real account/KV/D1/Vectorize IDs never live in git; they are placeholders here.
+{
+  "name": "mnemo-mcp-worker",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-14",
+  "workers_dev": false,
+  "containers": [
+    {
+      "name": "mnemo-mcp-worker",
+      "class_name": "MnemoContainer",
+      "image": "registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/mnemo-mcp:${IMAGE_TAG}",
+      "instance_type": "standard-1",
+      "max_instances": 1
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "MNEMO", "class_name": "MnemoContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MnemoContainer"] }],
+  "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
+  "d1_databases": [
+    { "binding": "D1", "database_name": "mnemo-memories", "database_id": "${CF_D1_ID}", "migrations_dir": "migrations" }
+  ],
+  "vectorize": [{ "binding": "VECTORIZE", "index_name": "${CF_VECTORIZE_ID}" }],
+  "vars": {
+    "PUBLIC_URL": "${PUBLIC_URL}",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal",
+    "DOCS_DB_BACKEND": "cf-d1",
+    "MCP_D1_BASE_URL": "http://d1.internal",
+    "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
+    "MCP_VECTORIZE_IDX": "${CF_VECTORIZE_ID}",
+    "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
+    "RERANK_MODELS": "jina_ai/jina-reranker-v3",
+    "LLM_MODELS": "vertex_express/gemini-3.5-flash",
+    "EMBEDDING_DIMS": "768"
+  },
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
Mirrors the wet-mcp deploy-cf-in-cd pilot (#1474): dispatch-only deploy-cf job builds the http-slim image on a GitHub Linux runner and deploys to Cloudflare on any release; deploy_cf.py --from-template rebuilds wrangler.deploy.jsonc from a committed placeholder + env; bun install so wrangler bundles worker.ts.