### PR TITLE
fix: use placeholders for PUBLIC_URL and routes in wrangler.jsonc (BYO-generic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ docs/superpowers/
 
 # Cloudflare deploy (real account/KV/D1/Vectorize IDs + tokens — NEVER commit)
 wrangler.deploy.jsonc
+.wrangler.byo.jsonc
 .wrangler/
 .wrangler-dryrun/
 scripts/.mnemo_cf_token

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ uv run mnemo-mcp
 
 Run your own mnemo instance serverless on Cloudflare (Containers + D1 + Vectorize + KV).
 
-**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+**Prerequisites:** a Cloudflare account on the **Workers Paid plan** — required for Containers, D1, and Vectorize (the Cloudflare free tier does not include them) — and the `wrangler` CLI.
 
 1. `git clone https://github.com/n24q02m/mnemo-mcp && cd mnemo-mcp`
 2. `wrangler login`

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ mcp-name: io.github.n24q02m/mnemo-mcp
 - [Tools](#tools)
 - [Security](#security)
 - [Build from Source](#build-from-source)
+- [Deploy to Cloudflare](#deploy-to-cloudflare)
 - [Trust Model](#trust-model)
 - [License](#license)
 
@@ -189,6 +190,51 @@ cd mnemo-mcp
 uv sync
 uv run mnemo-mcp
 ```
+
+## Deploy to Cloudflare
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/n24q02m/mnemo-mcp)
+
+Run your own mnemo instance serverless on Cloudflare (Containers + D1 + Vectorize + KV).
+
+**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+
+1. `git clone https://github.com/n24q02m/mnemo-mcp && cd mnemo-mcp`
+2. `wrangler login`
+3. Provision the storage bindings mnemo uses -- the memories database, the embedding
+   index, and the encrypted credential store:
+   ```
+   wrangler d1 create mnemo-memories
+   wrangler vectorize create mnemo-memory-vectors --dimensions 768 --metric cosine
+   wrangler kv namespace create mnemo-kv
+   ```
+   Paste the returned D1 database ID and KV namespace ID into `wrangler.jsonc` (the
+   Vectorize index binds by name, so no ID is needed). The memories schema (tables +
+   FTS5 full-text) is created by the container on first boot -- there is no separate
+   migration step.
+4. Push the container image to your Cloudflare managed registry (CF Containers cannot
+   pull from external registries directly), then set `<YOUR_ACCOUNT_ID>` in `wrangler.jsonc`:
+   ```
+   docker pull ghcr.io/n24q02m/mnemo-mcp:beta
+   docker tag ghcr.io/n24q02m/mnemo-mcp:beta mnemo-mcp:beta
+   wrangler containers push mnemo-mcp:beta   # prints registry.cloudflare.com/<ACCOUNT_ID>/mnemo-mcp:beta
+   ```
+5. Set `<YOUR_PUBLIC_URL>` (e.g. `https://mnemo.example.com`) and `<YOUR_WORKER_DOMAIN>`
+   (e.g. `mnemo.example.com`) in `wrangler.jsonc`, then set the secrets:
+   ```
+   wrangler secret put CREDENTIAL_SECRET              # per-user vault key (encrypts the cf-kv credential store)
+   wrangler secret put MCP_RELAY_PASSWORD             # shared password gating the browser setup form
+   wrangler secret put MCP_DCR_SERVER_SECRET          # required once PUBLIC_URL is set (multi-user, per-JWT-sub)
+   wrangler secret put JINA_AI_API_KEY                # EMBEDDING_MODELS + RERANK_MODELS (cloud embed / rerank)
+   wrangler secret put GOOGLE_VERTEX_EXPRESS_API_KEY  # LLM_MODELS (graph extraction, importance, consolidation)
+   ```
+6. `wrangler deploy` and complete setup in the browser relay form at your Worker domain.
+
+Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (credentials / tokens, encrypted),
+`DOCS_DB_BACKEND=cf-d1` (the memories database + FTS5 full-text), and Vectorize (embeddings,
+cosine). Embedding and reranking are forced cloud through the `EMBEDDING_MODELS` /
+`RERANK_MODELS` chains (`jina_ai/...`) so the container never downloads the local Qwen3 ONNX
+models, and graph / LLM features run through the `LLM_MODELS` chain (`vertex_express/...`).
 
 ## Trust Model
 

--- a/scripts/cf_deploy.mjs
+++ b/scripts/cf_deploy.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// scripts/cf_deploy.mjs - Bring-your-own Cloudflare deploy for mnemo-mcp.
+//
+// The committed base wrangler.jsonc ships <PLACEHOLDER> tokens so it stays generic
+// (account / KV / D1 IDs, PUBLIC_URL, and the custom-domain route). This script
+// renders those tokens from your own environment into a runnable config, then runs
+// `wrangler deploy`. It backs the `cf:deploy` npm script.
+//
+// The maintainer CD path is separate: scripts/deploy_cf.py builds + pushes the
+// container image and deploys from the gitignored wrangler.deploy.jsonc (real IDs),
+// so it is unaffected by this script or by the base placeholders.
+//
+// Prerequisites (see README "Deploy to Cloudflare"): `wrangler login`, provision
+// the D1 / Vectorize / KV bindings, and push the container image to your Cloudflare
+// managed registry.
+//
+// Usage:
+//   CLOUDFLARE_ACCOUNT_ID=... CF_KV_ID=... CF_D1_ID=... PUBLIC_URL=https://mnemo.example.com \
+//     node scripts/cf_deploy.mjs
+//   ... node scripts/cf_deploy.mjs --dry-run   # render + validate without deploying
+//
+// Any extra CLI args (e.g. --dry-run) are forwarded to `wrangler deploy`.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BASE_CONFIG = join(repoRoot, "wrangler.jsonc");
+// Rendered config holds real resource IDs -> gitignored, and removed after deploy.
+const RENDERED_CONFIG = join(repoRoot, ".wrangler.byo.jsonc");
+
+function requireEnv(name, hint) {
+  const val = process.env[name];
+  if (!val) {
+    console.error(`${name} is not set (${hint}).`);
+    process.exit(1);
+  }
+  return val;
+}
+
+const accountId = requireEnv(
+  "CLOUDFLARE_ACCOUNT_ID",
+  "base wrangler.jsonc image uses <YOUR_ACCOUNT_ID>",
+);
+const kvId = requireEnv(
+  "CF_KV_ID",
+  "base wrangler.jsonc KV binding uses <mnemo-kv-namespace-id>",
+);
+const d1Id = requireEnv(
+  "CF_D1_ID",
+  "base wrangler.jsonc D1 binding uses <mnemo-d1-database-id>",
+);
+const publicUrl = requireEnv(
+  "PUBLIC_URL",
+  "base wrangler.jsonc vars + routes use <YOUR_PUBLIC_URL> / <YOUR_WORKER_DOMAIN>",
+);
+
+// The custom-domain route is the host of PUBLIC_URL (a BYO instance is served at
+// the same host it advertises), so no separate env var is needed for it.
+let workerDomain;
+try {
+  workerDomain = new URL(publicUrl).host;
+} catch {
+  console.error(`PUBLIC_URL is not a valid URL: ${publicUrl}`);
+  process.exit(1);
+}
+
+let substituted = readFileSync(BASE_CONFIG, "utf8");
+substituted = substituted.split("<YOUR_ACCOUNT_ID>").join(accountId);
+substituted = substituted.split("<mnemo-kv-namespace-id>").join(kvId);
+substituted = substituted.split("<mnemo-d1-database-id>").join(d1Id);
+substituted = substituted.split("<YOUR_PUBLIC_URL>").join(publicUrl);
+substituted = substituted.split("<YOUR_WORKER_DOMAIN>").join(workerDomain);
+
+// Fail loudly if any placeholder survived (e.g. a new <...> token added to the base
+// config without a matching substitution here) so a literal <...> never reaches
+// wrangler and silently deploys a broken config.
+const leftover = substituted.match(/<[A-Za-z0-9_-]+>/g);
+if (leftover) {
+  console.error(
+    `Unsubstituted placeholder(s) in rendered config: ${[...new Set(leftover)].join(", ")}`,
+  );
+  process.exit(1);
+}
+
+writeFileSync(RENDERED_CONFIG, substituted);
+try {
+  const passthrough = process.argv.slice(2);
+  // Run as a single shell string (not args + shell:true, which trips DEP0190) so the
+  // platform shell resolves npx (npx.cmd on Windows, npx on POSIX). Only the config
+  // path is quoted; the passthrough flags are the caller's own simple wrangler args.
+  const cmd = [`npx wrangler deploy --config "${RENDERED_CONFIG}"`, ...passthrough].join(" ");
+  console.log(`$ ${cmd}`);
+  const res = spawnSync(cmd, { cwd: repoRoot, stdio: "inherit", shell: true });
+  if (res.error) {
+    console.error(`Failed to run wrangler via npx: ${res.error.message}`);
+    process.exitCode = 1;
+  } else {
+    process.exitCode = res.status ?? 1;
+  }
+} finally {
+  rmSync(RENDERED_CONFIG, { force: true });
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,7 +36,7 @@
   // MCP_RELAY_PASSWORD (Gate A, password-grant login) lives in skret /oci-vm-prod/prod
   // (infra-shared), NOT /mnemo-mcp/prod -- compose both namespaces at `wrangler secret put`.
   "vars": {
-    "PUBLIC_URL": "https://mnemo.n24q02m.com",
+    "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "DOCS_DB_BACKEND": "cf-d1",
@@ -48,6 +48,6 @@
     "LLM_MODELS": "vertex_express/gemini-3.5-flash",
     "EMBEDDING_DIMS": "768"
   },
-  "routes": [{ "pattern": "mnemo.n24q02m.com", "custom_domain": true }],
+  "routes": [{ "pattern": "<YOUR_WORKER_DOMAIN>", "custom_domain": true }],
   "observability": { "enabled": true }
 }


### PR DESCRIPTION
Base wrangler.jsonc reference template now fully BYO: PUBLIC_URL + routes use placeholders like account/KV/D1. deploy_cf.py uses gitignored wrangler.deploy.jsonc, so maintainer CD is unaffected.