### PR TITLE
🎨 Palette: Add fallback suggestions to API responses

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## $(date +%Y-%m-%d) - Consistent Error Suggestions
 **Learning:** Returning error messages without actionable next steps leaves the developer guessing what went wrong, which degrades Developer Experience (DX). In backend MCP servers, returning structured errors with `suggestion` strings is crucial.
 **Action:** When a tool returns an error structure (e.g., in `import_passport`), ensure it includes a `suggestion` key to guide the developer/agent on how to fix the issue.
+## 2024-05-23 - Add fallback suggestions to API responses
+**Learning:** Returning raw errors for invalid API inputs without actionable suggestions creates a poor Developer Experience (DX). In a backend/CLI project, DX is equivalent to UX.
+**Action:** Always provide a default `suggestion` key in JSON error responses to guide the user/LLM, even when fuzzy matching yields no direct corrections.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1622,6 +1622,7 @@ async def memory(
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
                 "hint": "Common actions: 'add' to store new info, 'search' to find existing, 'update' to modify by ID.",
+                "suggestion": "Check the spelling of the action.",
             }
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
@@ -1721,6 +1722,7 @@ async def config(
                 "error": f"Unknown action '{action}'.",
                 "valid_actions": valid_actions,
                 "hint": "Common actions: 'status' to view config, 'set' to update settings, 'sync' to manual sync.",
+                "suggestion": "Check the spelling of the action.",
             }
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
@@ -1784,6 +1786,7 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
         resp: dict[str, typing.Any] = {
             "error": f"Invalid key: {key}",
             "valid_keys": sorted(valid_keys),
+            "suggestion": "Check the spelling of the configuration key.",
         }
         if closest:
             resp["suggestion"] = f"Did you mean '{closest[0]}'?"
@@ -1816,6 +1819,7 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
             resp = {
                 "error": f"Invalid log level: {value}",
                 "valid_levels": sorted(valid_levels),
+                "suggestion": "Check the spelling of the log level.",
             }
             if closest:
                 resp["suggestion"] = f"Did you mean '{closest[0]}'?"
@@ -2267,6 +2271,7 @@ async def help(topic: str = "memory") -> str:
         resp: dict[str, typing.Any] = {
             "error": f"Unknown topic '{topic}'.",
             "valid_topics": list(valid_topics.keys()),
+            "suggestion": "Check the spelling of the topic.",
         }
         if closest:
             resp["suggestion"] = f"Did you mean '{closest[0]}'?"


### PR DESCRIPTION
💡 What: The UX enhancement added:
Added a `suggestion` key to API error responses (for unknown actions, invalid configurations, and unknown help topics) at the initial dictionary creation when handling invalid user input.

🎯 Why: The user problem it solves:
Returning raw errors for invalid inputs without actionable suggestions creates a poor Developer Experience (DX) for consumers (e.g. MCP clients or LLMs). By adding a concrete fallback default suggestion (e.g., "Check the spelling of the action.") even before or when fuzzy matching (`difflib`) fails to find a closest match, we ensure the API response is always guiding the consumer towards a fix.

📸 Before/After:
Before, when passing an invalid action like `"unknown_action"`, the dictionary lacked a `suggestion` key until a subsequent `if/else` block, which could lead to missing suggestions in edge cases or a less predictable API error structure. 

♿ Accessibility / DX: 
Provides better, more consistent error output structure for agents and users relying on this MCP server.

---
*PR created automatically by Jules for task [15444500611558595945](https://jules.google.com/task/15444500611558595945) started by @n24q02m*