### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix S101 Use of assert for runtime validation

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -841,7 +841,8 @@ async def _handle_import(
 
     # Bolt Performance Optimization: Pass raw list/dict directly to database layer.
     # Avoids unnecessary JSON serialization and deserialization cycles for parsed inputs.
-    assert data is not None  # guarded above
+    if data is None:
+        raise ValueError("data is required")
     result = await asyncio.to_thread(db.import_jsonl, data, mode=mode)
     return _json(
         {

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.4.0b4"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Use of `assert` statement for runtime validation/type narrowing in `src/mnemo_mcp/server.py`.
🎯 Impact: If the Python interpreter is run in optimized mode (`python -O`), `assert` statements are stripped. This could lead to validation bypass if the `data` variable were unexpectedly `None`, resulting in unhandled exceptions or downstream errors in the database layer.
🔧 Fix: Replaced `assert data is not None` with an explicit `if data is None: raise ValueError(...)`. This ensures the validation is always executed and satisfies the Ruff `S101` security check.
✅ Verification: Ran `uv run pytest` and verified the `S101` warning is resolved in `src/mnemo_mcp/server.py`.

---
*PR created automatically by Jules for task [1770730991205620645](https://jules.google.com/task/1770730991205620645) started by @n24q02m*