### PR TITLE
🎨 Palette: Improve DX by guarding difflib against non-string inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## $(date +%Y-%m-%d) - Consistent Error Suggestions
 **Learning:** Returning error messages without actionable next steps leaves the developer guessing what went wrong, which degrades Developer Experience (DX). In backend MCP servers, returning structured errors with `suggestion` strings is crucial.
 **Action:** When a tool returns an error structure (e.g., in `import_passport`), ensure it includes a `suggestion` key to guide the developer/agent on how to fix the issue.
+## 2024-07-04 - Guarding difflib against non-string inputs
+**Learning:** `difflib.get_close_matches` throws an exception when the first argument is not iterable (e.g. integer or dict), crashing the MCP tool error handler. While `if action:` catches `None`, it doesn't protect against `0` or other non-string types.
+**Action:** Always wrap the first argument to `difflib.get_close_matches` with `str()` and use `is not None` when providing fuzzy matching suggestions for API inputs, to avoid unhandled TypeErrors.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1616,7 +1616,9 @@ async def memory(
                 "update",
             ]
             closest = (
-                difflib.get_close_matches(str(action), valid_actions, n=1) if action is not None else []
+                difflib.get_close_matches(str(action), valid_actions, n=1)
+                if action is not None
+                else []
             )
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
@@ -1715,7 +1717,9 @@ async def config(
                 "warmup",
             ]
             closest = (
-                difflib.get_close_matches(str(action), valid_actions, n=1) if action is not None else []
+                difflib.get_close_matches(str(action), valid_actions, n=1)
+                if action is not None
+                else []
             )
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
@@ -1780,7 +1784,11 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
         "log_level",
     }
     if key not in valid_keys:
-        closest = difflib.get_close_matches(str(key), list(valid_keys), n=1) if key is not None else []
+        closest = (
+            difflib.get_close_matches(str(key), list(valid_keys), n=1)
+            if key is not None
+            else []
+        )
         resp: dict[str, typing.Any] = {
             "error": f"Invalid key: {key}",
             "valid_keys": sorted(valid_keys),

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1616,7 +1616,7 @@ async def memory(
                 "update",
             ]
             closest = (
-                difflib.get_close_matches(action, valid_actions, n=1) if action else []
+                difflib.get_close_matches(str(action), valid_actions, n=1) if action is not None else []
             )
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
@@ -1715,7 +1715,7 @@ async def config(
                 "warmup",
             ]
             closest = (
-                difflib.get_close_matches(action, valid_actions, n=1) if action else []
+                difflib.get_close_matches(str(action), valid_actions, n=1) if action is not None else []
             )
             resp: dict[str, typing.Any] = {
                 "error": f"Unknown action '{action}'.",
@@ -1780,7 +1780,7 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
         "log_level",
     }
     if key not in valid_keys:
-        closest = difflib.get_close_matches(key, list(valid_keys), n=1) if key else []
+        closest = difflib.get_close_matches(str(key), list(valid_keys), n=1) if key is not None else []
         resp: dict[str, typing.Any] = {
             "error": f"Invalid key: {key}",
             "valid_keys": sorted(valid_keys),
@@ -1809,8 +1809,8 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
         }
         if level not in valid_levels:
             closest = (
-                difflib.get_close_matches(level, list(valid_levels), n=1)
-                if level
+                difflib.get_close_matches(str(level), list(valid_levels), n=1)
+                if level is not None
                 else []
             )
             resp = {
@@ -2260,8 +2260,8 @@ async def help(topic: str = "memory") -> str:
     filename = valid_topics.get(topic)
     if not filename:
         closest = (
-            difflib.get_close_matches(topic, list(valid_topics.keys()), n=1)
-            if topic
+            difflib.get_close_matches(str(topic), list(valid_topics.keys()), n=1)
+            if topic is not None
             else []
         )
         resp: dict[str, typing.Any] = {

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.4.0"
+version = "2.4.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.4.0b4"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### 💡 What:
Updated multiple instances in `src/mnemo_mcp/server.py` where `difflib.get_close_matches` is used to provide fuzzy matching error suggestions. The first argument is now explicitly cast using `str()` and evaluated using `is not None` instead of an implicit truthy check.

### 🎯 Why:
To prevent unhandled `TypeError` crashes. `difflib.get_close_matches` raises an exception if the first argument is not iterable (e.g., an integer or a dict). Previously, the code only guarded against `None` or empty strings via implicit evaluation (`if action:`). If a user/agent passed a number, the entire error handler would crash instead of providing the helpful fallback suggestion. This ensures a robust Developer Experience (DX) for the API.

### ♿ Accessibility (DX):
Ensures the API gracefully degrades and provides helpful "Did you mean X?" or fallback suggestions even when provided with severely malformed JSON inputs.

---
*PR created automatically by Jules for task [16226086729463927635](https://jules.google.com/task/16226086729463927635) started by @n24q02m*