### PR TITLE
🎨 Palette: Add suggestion fields to error responses

### DIFF
--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -165,6 +165,7 @@ async def run_setup_sync() -> dict:
             "status": "error",
             "error": "GOOGLE_DRIVE_CLIENT_ID not configured. "
             "Create an OAuth client ID at console.cloud.google.com/apis/credentials",
+            "suggestion": "Set the GOOGLE_DRIVE_CLIENT_ID environment variable or create one in Google Cloud Console.",
         }
 
     success = await setup_google_auth()
@@ -172,6 +173,7 @@ async def run_setup_sync() -> dict:
         return {
             "status": "error",
             "error": "Google Drive authentication failed. Please try again.",
+            "suggestion": "Check your client credentials and verify network connectivity.",
         }
 
     token_path = get_token_path("google_drive")

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -574,7 +574,10 @@ async def sync_full(db: MemoryDB) -> dict:
 
         except Exception as e:
             logger.error(f"Merge failed: {e}")
-            result["pull"] = {"error": str(e)}
+            result["pull"] = {
+                "error": str(e),
+                "suggestion": "Check remote database consistency and sync credentials.",
+            }
         finally:
             # Cleanup temp file and directory
             remote_db_path.unlink(missing_ok=True)


### PR DESCRIPTION
### 💡 What
Added `suggestion` keys to error dictionaries returned by `setup_tool.py` (when GOOGLE_DRIVE_CLIENT_ID is missing or auth fails) and `sync/gdrive.py` (when a merge exception occurs).

### 🎯 Why
When working with backend MCP servers, the Developer/Agent Experience (DX) is critical. Returning errors without actionable next steps leaves the caller guessing. By providing a `suggestion` key, we guide the user to the correct path, directly improving clarity and usability (a core Palette UX principle).

### 📸 Before/After
**Before:**
```json
{
  "status": "error",
  "error": "Google Drive authentication failed. Please try again."
}
```

**After:**
```json
{
  "status": "error",
  "error": "Google Drive authentication failed. Please try again.",
  "suggestion": "Check your client credentials and verify network connectivity."
}
```

### ♿ Accessibility
This improves error message accessibility/clarity by ensuring the user always knows what to do next to recover from a failure state.

---
*PR created automatically by Jules for task [1489700775209549696](https://jules.google.com/task/1489700775209549696) started by @n24q02m*