### PR TITLE
🎨 Palette: Add fuzzy matching for context_type

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-07-04 - Guarding difflib against non-string inputs
 **Learning:** `difflib.get_close_matches` throws an exception when the first argument is not iterable (e.g. integer or dict), crashing the MCP tool error handler. While `if action:` catches `None`, it doesn't protect against `0` or other non-string types.
 **Action:** Always wrap the first argument to `difflib.get_close_matches` with `str()` and use `is not None` when providing fuzzy matching suggestions for API inputs, to avoid unhandled TypeErrors.
+## $(date +%Y-%m-%d) - Extending fuzzy matching to domain inputs
+**Learning:** Returning a raw "Invalid context_type" without a fallback leaves developers guessing. Applying fuzzy matching to domain-specific enumerations (like context_type) improves DX immediately.
+**Action:** Always wrap the first argument to `difflib.get_close_matches` with `str()` and use `is not None` when providing fuzzy matching suggestions for API inputs, including domain-specific variables like context_type.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -980,15 +980,22 @@ async def _handle_capture(
     except ValueError as e:
         msg = str(e)
         if "context_type" in msg:
-            return _json(
-                {
-                    "error": msg,
-                    "valid_context_types": sorted(CONTEXT_TYPES),
-                    "suggestion": (
-                        f"Pick a context_type from {sorted(CONTEXT_TYPES)}."
-                    ),
-                }
+            closest = (
+                difflib.get_close_matches(str(context_type), list(CONTEXT_TYPES), n=1)
+                if context_type is not None
+                else []
             )
+            resp = {
+                "error": msg,
+                "valid_context_types": sorted(CONTEXT_TYPES),
+            }
+            if closest:
+                resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+            else:
+                resp["suggestion"] = (
+                    f"Pick a context_type from {sorted(CONTEXT_TYPES)}."
+                )
+            return _json(resp)
         return _json(
             {"error": msg, "suggestion": "Check payload length and constraints."}
         )

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -144,6 +144,16 @@ async def test_handle_capture_invalid_context_type_returns_error(mock_ctx):
     assert "conversation" in payload["valid_context_types"]
 
 
+async def test_handle_capture_invalid_context_type_fuzzy_matching(mock_ctx):
+    ctx, _db = mock_ctx
+    raw = await _handle_capture(ctx, text="something", context_type="prefernnce")
+    payload = json.loads(raw)
+
+    assert "error" in payload
+    assert "suggestion" in payload
+    assert "Did you mean 'preference'?" in payload["suggestion"]
+
+
 async def test_handle_capture_inserts_and_returns_id(mock_ctx):
     ctx, db = mock_ctx
     raw = await _handle_capture(


### PR DESCRIPTION
Adds a Developer Experience (DX) improvement to the backend by utilizing fuzzy matching (`difflib.get_close_matches`) on the `context_type` parameter in the `_handle_capture` function. This provides actionable `suggestion` hints (e.g. `Did you mean 'preference'?`) to developers/agents interacting with the API when an invalid `context_type` string is provided, making the API more intuitive to use. Included a test case for validation and updated the UX learnings journal.

---
*PR created automatically by Jules for task [3005156748565637949](https://jules.google.com/task/3005156748565637949) started by @n24q02m*