### PR TITLE
⚡ Bolt: Optimize JSON payload serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-07 - Optimize JSON payload serialization
+**Learning:** Returning large JSON lists of objects (like search or list results) with `indent=2` adds significant byte overhead due to unnecessary whitespace and newlines, hurting serialization performance and increasing network latency/token cost.
+**Action:** Replaced `json.dumps(obj, indent=2)` with `json.dumps(obj, separators=(",", ":"))` in `_json` helper to eliminate all unnecessary whitespace from MCP tool responses while preserving schema compatibility.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -367,8 +367,11 @@ def _get_ctx(ctx: Context | None) -> tuple[MemoryDB, str | None, int]:
 
 
 def _json(obj: object) -> str:
-    """Serialize to readable JSON."""
-    return json.dumps(obj, indent=2)
+    """Serialize to dense JSON."""
+    # Bolt Performance Optimization:
+    # Removing indent=2 drastically reduces payload size for large lists
+    # of memories, reducing serialization time and network/token overhead.
+    return json.dumps(obj, separators=(",", ":"))
 
 
 async def _maybe_include_setup_hint(result: dict) -> dict:

--- a/tests/test_security_log_level.py
+++ b/tests/test_security_log_level.py
@@ -77,6 +77,6 @@ async def test_log_level_valid_update(mock_dependencies):
                 result = await server.config(
                     action="set", key="log_level", value="DEBUG"
                 )
-                assert '"status": "updated"' in result
+                assert "\"status\":\"updated\"" in result
                 mock_logger.remove.assert_called_once()
                 mock_logger.add.assert_called_once()

--- a/tests/test_security_log_level.py
+++ b/tests/test_security_log_level.py
@@ -77,6 +77,6 @@ async def test_log_level_valid_update(mock_dependencies):
                 result = await server.config(
                     action="set", key="log_level", value="DEBUG"
                 )
-                assert "\"status\":\"updated\"" in result
+                assert '"status":"updated"' in result
                 mock_logger.remove.assert_called_once()
                 mock_logger.add.assert_called_once()

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -623,6 +623,6 @@ class TestJsonHelper:
         """Verify _json serializes with indent=2."""
         data = {"a": 1, "b": [2, 3]}
         result = _json(data)
-        expected = json.dumps(data, indent=2)
+        expected = json.dumps(data, separators=(",", ":"))
         assert result == expected
-        assert "\n  " in result  # Check for 2-space indentation
+        # assert "\n  " in result  # Check for 2-space indentation

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.5.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
💡 **What**: Replaced `json.dumps(obj, indent=2)` with `json.dumps(obj, separators=(",", ":"))` in the MCP server's `_json` response builder. Updated dependent tests in `test_server_coverage.py` and `test_security_log_level.py`.
🎯 **Why**: When returning large arrays of objects (such as those from `list_memories` or `search_memory`), `indent=2` introduced massive byte overhead purely in whitespace and newlines. 
📊 **Impact**: Reduces payload string size significantly for large responses, saving both serialization time on the backend and network latency / LLM token costs on the client side.
🔬 **Measurement**: Verify by running `uv run pytest tests/` which includes specific assertions against the densely-packed strings in `_json` output tests.

---
*PR created automatically by Jules for task [18435988430725830312](https://jules.google.com/task/18435988430725830312) started by @n24q02m*