### PR TITLE
feat: add opencode github agent (responds to /oc)

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,20 @@
+name: opencode
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+jobs:
+  opencode:
+    if: ${{ github.event.comment != null && (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) }}
+    runs-on: [self-hosted, oc-github]
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anomalyco/opencode/github@latest
+        with:
+          model: ${{ secrets.OC_MODEL }}
+          use_github_token: true


### PR DESCRIPTION
Adds an opencode github agent workflow that replies to /oc and /opencode mentions on issues and pull requests.