### PR TITLE
fix: restore Google Desktop OAuth default for GDrive sync

### DIFF
--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -128,11 +128,16 @@ class Settings(BaseSettings):
     rerank_model: str = ""
     rerank_top_n: int = 10
     # Sync (Google Drive API)
+    # GDrive Desktop OAuth client — Google explicitly treats the Desktop/Installed
+    # app client_secret as PUBLIC (per https://developers.google.com/identity/protocols/oauth2#installed).
+    # Hardcoding default keeps parity with wet-mcp so end-users get zero-config sync after relay submit.
     sync_enabled: bool = True
     sync_folder: str = "mnemo-mcp"  # Google Drive folder name
     sync_interval: int = 300  # seconds, 0 = manual only
-    google_drive_client_id: str = ""
-    google_drive_client_secret: str = ""
+    google_drive_client_id: str = (
+        "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
+    )
+    google_drive_client_secret: str = "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"
 
     # Archive
     archive_enabled: bool = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -430,13 +430,18 @@ class TestRerankSettings:
 
 
 class TestGoogleDriveCredentials:
-    def test_default_is_empty(self, monkeypatch):
-        """Default should not ship hardcoded credentials."""
+    def test_default_ships_desktop_oauth_client(self, monkeypatch):
+        """Default ships Google Desktop OAuth client (PUBLIC per Google docs).
+
+        Parity with wet-mcp: Desktop/Installed OAuth client_secret is
+        explicitly PUBLIC per https://developers.google.com/identity/protocols/oauth2#installed,
+        so hardcoding is safe and gives users zero-config sync after relay submit.
+        """
         monkeypatch.delenv("GOOGLE_DRIVE_CLIENT_ID", raising=False)
         monkeypatch.delenv("GOOGLE_DRIVE_CLIENT_SECRET", raising=False)
         s = Settings()
-        assert s.google_drive_client_id == ""
-        assert s.google_drive_client_secret == ""
+        assert s.google_drive_client_id.endswith(".apps.googleusercontent.com")
+        assert s.google_drive_client_secret.startswith("GOCSPX-")
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -62,10 +62,6 @@ def _build_server_env(
         # Blank out GDrive OAuth to prevent setup_sync from triggering real OAuth
         base_env["GOOGLE_DRIVE_CLIENT_ID"] = ""
         base_env["GOOGLE_DRIVE_CLIENT_SECRET"] = ""
-    else:
-        # Provide dummy values to allow GDrive setup to run since there are no hardcoded defaults anymore
-        base_env["GOOGLE_DRIVE_CLIENT_ID"] = "dummy_id"
-        base_env["GOOGLE_DRIVE_CLIENT_SECRET"] = "dummy_secret"
     if setup_mode == "relay":
         return {k: v for k, v in base_env.items() if k not in CREDENTIAL_ENV_VARS}
     return base_env
@@ -563,7 +559,7 @@ async def test_gdrive_oauth(request, tmp_path):
     """GDrive OAuth Device Code: call setup_sync, user authorizes via Google.
 
     Run with: uv run pytest tests/test_e2e.py -m e2e -k gdrive --setup=env -v -s
-    Uses dummy GOOGLE_DRIVE_CLIENT_ID from environment.
+    Uses hardcoded GOOGLE_DRIVE_CLIENT_ID from config defaults.
     """
     env = _build_server_env(tmp_path, "env", allow_gdrive=True)
     params = _build_server_params("env", env)

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -8,12 +8,17 @@ from mnemo_mcp.config import Settings
 
 
 def test_google_drive_client_id_default(monkeypatch):
-    """Google Drive client ID and secret are empty by default."""
+    """Default ships Google Desktop OAuth client (PUBLIC per Google docs).
+
+    Parity with wet-mcp (both are "http local relay" category MCP servers).
+    Desktop/Installed OAuth client_secret is explicitly PUBLIC per
+    https://developers.google.com/identity/protocols/oauth2#installed.
+    """
     monkeypatch.delenv("GOOGLE_DRIVE_CLIENT_ID", raising=False)
     monkeypatch.delenv("GOOGLE_DRIVE_CLIENT_SECRET", raising=False)
     s = Settings(api_keys=None)
-    assert s.google_drive_client_id == ""
-    assert s.google_drive_client_secret == ""
+    assert s.google_drive_client_id.endswith(".apps.googleusercontent.com")
+    assert s.google_drive_client_secret.startswith("GOCSPX-")
 
 
 def test_google_drive_credentials_from_env(monkeypatch):


### PR DESCRIPTION
## Summary

Commit 48ff433 ("Sentinel: [CRITICAL] Fix Hardcoded Secrets", PR #632, merged 2026-05-24) removed the hardcoded Google Desktop/Installed-app OAuth `client_id`/`client_secret` default from `Settings`, flagging it as a hardcoded secret. This was a false positive: Google explicitly classifies the Desktop/Installed-app OAuth `client_secret` as **public**, not a secret (https://developers.google.com/identity/protocols/oauth2#installed). The identical Sentinel finding on the sibling repo `wet-mcp` (PR #1287) was correctly **closed** as a false positive, so `wet-mcp` still ships the default and `mnemo-mcp` does not — a category-parity break, since both repos are "http local relay" category MCP servers that are expected to have identical config defaults for this credential.

**Consequence of the regression**: mnemo-mcp ships `sync_enabled: bool = True` with `google_drive_client_id = ""`. Every zero-config user hitting Google Drive sync gets `{"status":"error","message":"GOOGLE_DRIVE_CLIENT_ID not configured"}` from `sync/gdrive.py`. GDrive sync has been silently broken for all zero-config users since 2026-05-24.

## What this PR does

Forward-fix (not a revert — 10 later commits touched the same files, so `git revert 48ff433` would conflict). Restores exactly what 48ff433 removed, nothing else:

1. `src/mnemo_mcp/config.py` — restores the comment + the two hardcoded OAuth defaults (`google_drive_client_id`, `google_drive_client_secret`).
2. `tests/test_config.py` — reverts `TestGoogleDriveCredentials::test_default_is_empty` back to `test_default_ships_desktop_oauth_client`, asserting the non-empty public-client defaults.
3. `tests/test_sync_security.py` — reverts `test_google_drive_client_id_default` back to asserting the non-empty public-client defaults.
4. `tests/test_e2e.py` — removes the dummy-credential injection branch added to compensate for the empty default, restores the `test_gdrive_oauth` docstring to reference the hardcoded default.

## References

- Regression commit: 48ff433 ("Sentinel: [CRITICAL] Fix Hardcoded Secrets")
- Regression PR: #632
- Sibling-repo false-positive precedent: wet-mcp PR #1287 (closed, not merged)
- Category-parity rule: wet-mcp and mnemo-mcp are both "http local relay" category MCP servers and must share identical config defaults for this credential.

## Test plan

- [x] `uv run pytest tests/test_config.py -k GoogleDrive -q` — 2 passed
- [x] `uv run pytest tests/test_sync_security.py -q` — 9 passed
- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run ruff format --check src tests` — all files already formatted
- [x] `uv run ty check` (repo's type checker; no `mypy` configured) — all checks passed
- [x] Full pre-commit suite (gitleaks, ruff lint/format, ty check, pytest, whitespace/EOF checks) passed on commit

**DO NOT MERGE** — leaving open for review.