### PR TITLE
fix: fail the release when the computed version already exists on PyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,6 +55,56 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
+      # Dry-run PSR (no_operation_mode => --noop: no commit/tag/push/release) purely to
+      # learn the version it WOULD publish, so the PyPI-collision guard below can fire
+      # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and
+      # same prerelease inputs as the real step, run against the same untouched checkout,
+      # so the computed version is identical.
+      - uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10
+        id: dryrun
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          prerelease: ${{ inputs.release_type == 'beta' }}
+          prerelease_token: beta
+          no_operation_mode: true
+
+      # Fail early and loudly if the version PSR intends to publish already exists on
+      # PyPI. PyPI never allows reusing a version number, so a hit here means the git
+      # history has diverged from the registry. Catching it here converts two nasty
+      # failure modes -- PSR silently setting released=false on a matching tag (every
+      # publish job skipped) and an opaque PyPI 400 deep inside `uv publish` -- into one
+      # explicit, actionable error, before any tag or Release is created.
+      - name: Guard against re-publishing an already-published PyPI version
+        if: steps.dryrun.outputs.released == 'true'
+        env:
+          COMPUTED_VERSION: ${{ steps.dryrun.outputs.version }}
+        run: |
+          set -uo pipefail
+          PKG='mnemo-mcp'
+          URL="https://pypi.org/pypi/${PKG}/${COMPUTED_VERSION}/json"
+          echo "Checking PyPI for ${PKG} ${COMPUTED_VERSION} before semantic-release tags anything..."
+
+          # PyPI JSON API for a specific release (behaviour verified live, unauthenticated):
+          #   200                 -> the version EXISTS  -> COLLISION
+          #   404                 -> the version is FREE -> proceed
+          #   empty/000/anything else -> UNKNOWN (network, 5xx, 429, curl failure) -> refuse
+          # A transient error must NEVER be read as "free": that could let a real
+          # collision slip through, which is worse than the bug this guard prevents.
+          status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "${URL}" 2>/dev/null)"
+
+          if [ "${status}" = "200" ]; then
+            echo "::error::Computed release version ${COMPUTED_VERSION} already exists on PyPI as ${PKG} ${COMPUTED_VERSION} (${URL} returned 200). PyPI NEVER allows re-publishing a version number, even one later yanked. This almost always means the git history diverged from what was published to PyPI -- tags/commits were rewritten while the registry kept the original releases. Do NOT retry the same version: bump PAST the already-published range (higher than any version ever published) and dispatch the release again."
+            exit 1
+          fi
+
+          if [ "${status}" = "404" ]; then
+            echo "OK: ${PKG} ${COMPUTED_VERSION} is not on PyPI (404) -- safe to publish."
+            exit 0
+          fi
+
+          echo "::error::Could not verify whether ${PKG} ${COMPUTED_VERSION} exists on PyPI: ${URL} returned HTTP '${status:-<no response>}' (expected 200 or 404). Refusing to proceed so a genuine collision cannot slip through as a false 'free'. Re-run the release once the registry is reachable."
+          exit 1
+
       - uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10
         id: release
         with:


### PR DESCRIPTION
## Summary

PyPI never allows reusing a version number. If this repo's git history is ever rewritten away from what was actually published (tags/commits dropped via a force-push or rebase), python-semantic-release can later recompute an already-published version number. That produces one of two silent failure modes:

- PSR sees a matching git tag, reports "already released", sets `released=false`, and every downstream publish job is skipped without warning -- a release freeze nobody notices.
- The version collision surfaces as an opaque error deep inside `uv publish`.

This adds a dry-run PSR step (`no_operation_mode: true`, same pinned action SHA and same inputs as the real release step) purely to learn the version PSR would publish, then probes PyPI's JSON API for that exact version before the real release step runs. It fires before any tag or GitHub Release is created, converting both failure modes into one explicit, actionable error.

A transient registry error (non-200/404 response, timeout, or no response at all) is deliberately treated as fatal rather than as "free" -- a real collision slipping through would be worse than the bug this guard prevents.

This mirrors the guard already shipped to `better-notion-mcp` (PR #1097) and `wet-mcp`, adapted for PyPI instead of npm (`curl` against `https://pypi.org/pypi/<package>/<version>/json` instead of `npm view`).

## Verification

- YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/cd.yml'))"` -> OK.
- Pre-commit hooks passed locally (gitleaks, YAML check, trailing whitespace, etc.) on commit.
- Exercised the guard's exact shell classification logic against live PyPI, three ways:
  - `mnemo-mcp` `2.6.0-beta.1` (an existing published version, current `pyproject.toml` version) -> HTTP 200 -> **COLLISION**
  - `mnemo-mcp` `99.99.99` (never published) -> HTTP 404 -> **FREE**
  - `https://127.0.0.1:1/` (forced-unreachable host) -> no response -> **UNKNOWN** (refused, not treated as free)
- Confirmed live: PyPI normalizes PSR's raw hyphenated version output to the same release as the PEP 440 form, so the dry-run's raw `version` output can be passed straight into the probe URL without PEP 440 normalization.

## Test plan

- [ ] Dispatch a beta release on this branch (or after merge) and confirm the new `dryrun` + guard steps run and pass before the real `release` step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01HPMH1tLcusxCDrgvbTUqHB