### PR TITLE
fix: decline standing GET /mcp SSE stream at the edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -188,6 +188,17 @@ export default {
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
+    // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
+    // scale-to-zero container this is pure idle cost: @cloudflare/containers
+    // counts an open stream as an in-flight request forever (inflight > 0 =>
+    // activity never expires), so a single idle client pins the container
+    // awake 24/7. None of this stack's servers send server-initiated
+    // messages; request-scoped notifications ride the POST's own SSE
+    // response. The spec allows declining the stream: both official SDKs
+    // treat 405 as the optional-feature path and continue POST-only.
+    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+      return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
+    }
     if (env.MNEMO) {
       const userId = await extractUserId(request)
       const stub = env.MNEMO.get(env.MNEMO.idFromName(userId))

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -156,3 +156,51 @@ describe('edge auth gate (/mcp)', () => {
     expect(fetchCalls.length).toBe(1)
   })
 })
+
+describe('standing GET /mcp SSE stream declined at the edge (idle-cost fix)', () => {
+  function envWithDoSpy() {
+    const fetchCalls: Request[] = []
+    return {
+      fetchCalls,
+      env: {
+        MNEMO: {
+          idFromName: (n: string) => ({ name: n }),
+          get: (_id: unknown) => ({
+            fetch: async (r: Request) => {
+              fetchCalls.push(r)
+              return new Response('routed', { status: 200 })
+            },
+          }),
+        },
+      },
+    }
+  }
+
+  it('GET /mcp with Authorization -> 405, Allow: POST, DELETE, stub never called', async () => {
+    const { fetchCalls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://mnemo.n24q02m.com/mcp', { method: 'GET', headers: { authorization: 'Bearer x' } }),
+      env as never,
+    )
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('POST, DELETE')
+    expect(fetchCalls.length).toBe(0)
+  })
+
+  it('GET /mcp/sub-path with Authorization -> 405, stub never called', async () => {
+    const { fetchCalls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://mnemo.n24q02m.com/mcp/sub', { method: 'GET', headers: { authorization: 'Bearer x' } }),
+      env as never,
+    )
+    expect(res.status).toBe(405)
+    expect(fetchCalls.length).toBe(0)
+  })
+
+  it('GET /mcp with no Authorization -> still 401 (bearer gate runs before the 405 decline)', async () => {
+    const { fetchCalls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://mnemo.n24q02m.com/mcp', { method: 'GET' }), env as never)
+    expect(res.status).toBe(401)
+    expect(fetchCalls.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- @cloudflare/containers counts an open proxied stream as an in-flight request forever (inflight > 0 => activity never expires => container never sleeps). A standing GET /mcp SSE stream from any idle MCP client therefore pins the container awake 24/7.
- The streamable-HTTP spec allows a server to decline the GET stream with 405. Both official SDKs handle it as the optional-feature path: the TS client treats 405 as an expected case and continues POST-only; the Python client retries a couple of times then gives up quietly.
- Request-scoped notifications ride the POST's own SSE response, so nothing is lost by declining the standing GET stream. None of this stack's servers send server-initiated (out-of-band) messages.
- Added the 405 short-circuit in `src/worker.ts` immediately after the existing bearer-auth gate for `/mcp` and `/mcp/*`, before the request is routed to the container Durable Object.

## Test plan
- [x] `npm run test:worker` (vitest) — all 14 tests pass, including 3 new cases: GET /mcp with bearer -> 405 (Allow: POST, DELETE), GET /mcp/sub-path with bearer -> 405, GET /mcp with no Authorization -> still 401 (bearer gate runs before the 405 decline).
- [x] `git diff --stat` confirms exactly 2 files changed: `src/worker.ts`, `tests/worker.test.ts`.