### PR TITLE
fix: make renovate automerge effective (isolated groups, digest+lockfile automerge, 7-day cooldown)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,40 +18,61 @@
     "enabled": true,
     "schedule": [
       "before 5am"
-    ]
+    ],
+    "automerge": true,
+    "automergeType": "pr"
   },
   "packageRules": [
     {
-      "description": "Auto-merge non-major devDependencies",
-      "matchDepTypes": [
-        "devDependencies"
-      ],
+      "description": "Group minor updates for review (prod scope by default)",
       "matchUpdateTypes": [
-        "minor",
-        "patch"
+        "minor"
       ],
-      "automerge": true,
-      "automergeType": "pr"
+      "groupName": "minor dependencies",
+      "groupSlug": "all-minor"
     },
     {
-      "description": "Auto-merge patch production dependencies",
-      "matchDepTypes": [
-        "dependencies"
-      ],
+      "description": "Auto-merge dev-scope minor updates after cooldown",
       "matchUpdateTypes": [
-        "patch"
+        "minor"
       ],
+      "matchDepTypes": [
+        "devDependencies",
+        "dependency-groups",
+        "tool.uv.dev-dependencies",
+        "tool.pdm.dev-dependencies"
+      ],
+      "groupName": "non-major dev dependencies",
+      "groupSlug": "non-major-dev",
       "automerge": true,
-      "automergeType": "pr"
+      "automergeType": "pr",
+      "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Group all non-major updates",
+      "description": "Auto-merge patch updates after cooldown",
       "matchUpdateTypes": [
-        "minor",
         "patch"
       ],
-      "groupName": "non-major dependencies",
-      "groupSlug": "non-major"
+      "groupName": "patch dependencies",
+      "groupSlug": "all-patch",
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Auto-merge GitHub Actions digest updates after cooldown",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "pinDigest"
+      ],
+      "groupName": "github-actions digests",
+      "groupSlug": "gha-digests",
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Pin GitHub Actions to SHA for security",


### PR DESCRIPTION
Root cause: group all-non-major trộn dev+prod làm mất automerge eligibility; depTypes npm-only không match pep621; digest+lockfile không có rule automerge. Evidence: 0 PR nào mergedBy=renovate trong toàn lịch sử repo.

Change: tách group minor-review / dev-minor / patch / gha-digests; automerge 3 nhóm sau + lockFileMaintenance; minimumReleaseAge 7 days (cooldown supply-chain, theo precedent mcp-core); allow_auto_merge đã bật repo-level.

Expected: PR digest+lockfile+patch đang mở sẽ tự merge sau khi Renovate chạy lại với config mới; PR non-major cũ sẽ được Renovate tự đóng/regroup.