### PR TITLE
feat: adopt bundled client BYO resolution chain for Google Drive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.1",
     # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.18.2,<2",
+    "n24q02m-mcp-core[llm]>=1.19.0b2,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.5",

--- a/src/mnemo_mcp/config.py
+++ b/src/mnemo_mcp/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from loguru import logger
+from mcp_core.auth import BundledClientSpec, resolve_bundled_client
 from mcp_core.chains import resolve_backend
 from mcp_core.llm.providers import key_env_for_model
 from pydantic import AliasChoices, Field
@@ -42,6 +43,25 @@ def _resolve_local_model(onnx_name: str, gguf_name: str) -> str:
     if _detect_gpu() and _has_gguf_support():
         return gguf_name
     return onnx_name
+
+
+# Google Drive OAuth client identity (BYO resolver chain: CLI > env pair >
+# bundled default, unless USE_BUNDLED_GOOGLE_CLIENT explicitly disables it).
+# The Desktop/Installed OAuth client_secret is public by design per
+# https://developers.google.com/identity/protocols/oauth2#installed -- hardcoding
+# it here is safe and gives users zero-config sync after relay submit.
+_BUNDLED_GOOGLE_CLIENT_ID = (
+    "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
+)
+_BUNDLED_GOOGLE_CLIENT_SECRET = "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"  # gitleaks:allow
+_GOOGLE_CLIENT_SPEC = BundledClientSpec(
+    provider="google-drive",
+    env_id="GOOGLE_DRIVE_CLIENT_ID",
+    env_secret="GOOGLE_DRIVE_CLIENT_SECRET",
+    bundled_id=_BUNDLED_GOOGLE_CLIENT_ID,
+    bundled_secret=_BUNDLED_GOOGLE_CLIENT_SECRET,
+    use_bundled_env="USE_BUNDLED_GOOGLE_CLIENT",
+)
 
 
 class Settings(BaseSettings):
@@ -134,10 +154,14 @@ class Settings(BaseSettings):
     sync_enabled: bool = True
     sync_folder: str = "mnemo-mcp"  # Google Drive folder name
     sync_interval: int = 300  # seconds, 0 = manual only
-    google_drive_client_id: str = (
-        "147668446467-olf2cf6e49rshqv9quvhq639110oc6hc.apps.googleusercontent.com"
+    google_drive_client_id: str = Field(
+        default_factory=lambda: resolve_bundled_client(_GOOGLE_CLIENT_SPEC).client_id
     )
-    google_drive_client_secret: str = "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"
+    google_drive_client_secret: str = Field(
+        default_factory=lambda: (
+            resolve_bundled_client(_GOOGLE_CLIENT_SPEC).client_secret
+        )
+    )
 
     # Archive
     archive_enabled: bool = True

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 from loguru import logger
+from mcp_core.auth import token_client_mismatch
 
 from mnemo_mcp.config import settings
 from mnemo_mcp.sync.base import SyncBackend
@@ -92,6 +93,13 @@ async def _save_token(token: dict) -> None:
     await async_save_token(_TOKEN_PROVIDER, token)
 
 
+async def _clear_token() -> None:
+    """Delete the stored Google Drive OAuth token from local storage."""
+    from mnemo_mcp.token_store import async_delete_token
+
+    await async_delete_token(_TOKEN_PROVIDER)
+
+
 async def _has_token_available() -> bool:
     """Check if a Google Drive token is available."""
     return await _load_token() is not None
@@ -102,6 +110,14 @@ async def _refresh_token(token: dict) -> dict | None:
 
     Returns updated token dict, or None if refresh failed.
     """
+    if token_client_mismatch(token, settings.google_drive_client_id):
+        logger.warning(
+            "Stored Google Drive token was minted by a different client_id; "
+            "clearing it -- re-run setup_sync to authorize with the current client"
+        )
+        await _clear_token()
+        return None
+
     refresh_token = token.get("refresh_token")
     client_id = token.get("client_id", settings.google_drive_client_id)
     client_secret = settings.google_drive_client_secret

--- a/src/mnemo_mcp/token_store.py
+++ b/src/mnemo_mcp/token_store.py
@@ -140,6 +140,11 @@ async def async_save_token(provider: str, token: dict) -> None:
     await asyncio.to_thread(save_token, provider, token)
 
 
+async def async_delete_token(provider: str) -> bool:
+    """Delete a stored token asynchronously. Returns True if deleted."""
+    return await asyncio.to_thread(delete_token, provider)
+
+
 def save_token_for_sub(sub: str, provider: str, token: dict) -> None:
     """Save OAuth token under the per-sub directory (multi-user remote).
 

--- a/tests/sync/test_gdrive.py
+++ b/tests/sync/test_gdrive.py
@@ -74,8 +74,9 @@ async def test_refresh_token_success():
 
 
 async def test_refresh_token_missing_params():
-    # Trigger line 91
-    token = {"refresh_token": ""}
+    # Trigger line 91. client_id must match the mocked settings so the
+    # client-mismatch guard doesn't intercept before this branch.
+    token = {"refresh_token": "", "client_id": ""}
     with patch("mnemo_mcp.sync.gdrive.settings") as mock_settings:
         mock_settings.google_drive_client_id = ""
         new_token = await _refresh_token(token)
@@ -83,7 +84,9 @@ async def test_refresh_token_missing_params():
 
 
 async def test_refresh_token_failure():
-    token = {"refresh_token": "ref"}
+    # client_id matches the mocked settings so this exercises the
+    # HTTP-failure branch, not the client-mismatch guard.
+    token = {"refresh_token": "ref", "client_id": "cid"}
     mock_resp = MagicMock()
     mock_resp.status_code = 400
     mock_resp.text = "invalid grant"
@@ -99,7 +102,9 @@ async def test_refresh_token_failure():
 
 
 async def test_refresh_token_exception():
-    token = {"refresh_token": "ref"}
+    # client_id matches the mocked settings so this exercises the
+    # network-exception branch, not the client-mismatch guard.
+    token = {"refresh_token": "ref", "client_id": "cid"}
     with (
         patch("httpx.AsyncClient.post", side_effect=Exception("net error")),
         patch("mnemo_mcp.sync.gdrive.settings") as mock_settings,

--- a/tests/sync/test_gdrive.py
+++ b/tests/sync/test_gdrive.py
@@ -41,6 +41,20 @@ def fake_token():
 # --- Token management ---
 
 
+async def test_clear_token_deletes_file(tmp_path):
+    """_clear_token deletes the on-disk token via the real token_store."""
+    from mnemo_mcp.sync.gdrive import _clear_token, _load_token, _save_token
+
+    with patch("mnemo_mcp.token_store.settings") as mock_settings:
+        mock_settings.get_data_dir.return_value = tmp_path
+        await _save_token({"access_token": "to-clear"})
+        assert await _load_token() is not None
+
+        await _clear_token()
+
+        assert await _load_token() is None
+
+
 async def test_refresh_token_success():
     token = {"refresh_token": "ref", "client_id": "cid", "client_secret": "sec"}
     mock_resp = MagicMock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,7 @@ def clean_env(monkeypatch):
         "SYNC_INTERVAL",
         "GOOGLE_DRIVE_CLIENT_ID",
         "GOOGLE_DRIVE_CLIENT_SECRET",
+        "USE_BUNDLED_GOOGLE_CLIENT",
         "DB_PATH",
         "MNEMO_DB_PATH",
         "LOG_LEVEL",
@@ -451,6 +452,28 @@ class TestGoogleDriveCredentials:
         s = Settings()
         assert s.google_drive_client_id == "123456.apps.googleusercontent.com"
         assert s.google_drive_client_secret == "test-secret"
+
+    def test_env_pair_beats_bundled(self, monkeypatch):
+        """A full BYO env pair overrides the bundled default."""
+        monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_ID", "my-id")
+        monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_SECRET", "my-secret")
+        s = Settings()
+        assert (s.google_drive_client_id, s.google_drive_client_secret) == (
+            "my-id",
+            "my-secret",
+        )
+
+    def test_env_half_pair_fails_loud(self, monkeypatch):
+        """Setting only one half of the BYO pair raises instead of silently falling back."""
+        monkeypatch.setenv("GOOGLE_DRIVE_CLIENT_ID", "only-id")
+        with pytest.raises(Exception, match="together"):
+            Settings()
+
+    def test_kill_switch_fails_loud_without_override(self, monkeypatch):
+        """USE_BUNDLED_GOOGLE_CLIENT=false with no BYO pair raises instead of using bundled."""
+        monkeypatch.setenv("USE_BUNDLED_GOOGLE_CLIENT", "false")
+        with pytest.raises(Exception, match="disables the bundled client"):
+            Settings()
 
 
 class TestSetupProviders:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -84,7 +84,14 @@ class TestTokenManagement:
         mock_response.status_code = 401
         mock_response.text = "invalid_grant"
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
+        # client_id matches the mocked settings so this exercises the
+        # HTTP-failure branch, not the client-mismatch guard.
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch("mnemo_mcp.sync.settings") as mock_settings,
+        ):
+            mock_settings.google_drive_client_id = "client123"
+            mock_settings.google_drive_client_secret = "secret123"
             mock_client = AsyncMock()
             mock_client.post.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -99,7 +106,12 @@ class TestTokenManagement:
         from mnemo_mcp.sync import _refresh_token
 
         token = {"access_token": "old", "client_id": "client123"}
-        result = await _refresh_token(token)
+        # client_id matches the mocked settings so this exercises the
+        # missing-refresh_token branch, not the client-mismatch guard.
+        with patch("mnemo_mcp.sync.settings") as mock_settings:
+            mock_settings.google_drive_client_id = "client123"
+            mock_settings.google_drive_client_secret = "secret123"
+            result = await _refresh_token(token)
         assert result is None
 
     async def test_get_valid_token_no_token(self):

--- a/tests/test_sync_gdrive_auth.py
+++ b/tests/test_sync_gdrive_auth.py
@@ -59,7 +59,14 @@ class TestRefreshTokenException:
             "client_id": "client123",
         }
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
+        # client_id matches the mocked settings so this exercises the
+        # network-exception branch, not the client-mismatch guard.
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch("mnemo_mcp.sync.settings") as mock_settings,
+        ):
+            mock_settings.google_drive_client_id = "client123"
+            mock_settings.google_drive_client_secret = "secret123"
             mock_client = AsyncMock()
             mock_client.post.side_effect = Exception("Connection refused")
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -88,8 +88,15 @@ async def test_token_refresh_updates_refresh_token():
 
 
 @pytest.mark.asyncio
-async def test_token_refresh_uses_settings_client_id():
-    """Test that _refresh_token falls back to settings.google_drive_client_id."""
+async def test_token_refresh_clears_token_missing_client_id():
+    """A token with no client_id key is treated as a client mismatch.
+
+    token_client_mismatch() flags a missing client_id the same as a
+    different one -- a token that never recorded which client minted it
+    cannot be trusted, so the old "fall back to
+    settings.google_drive_client_id" refresh behavior is unreachable for
+    this token; it is cleared and None is returned instead of refreshed.
+    """
     from mnemo_mcp.sync import _refresh_token
 
     token = {
@@ -98,27 +105,44 @@ async def test_token_refresh_uses_settings_client_id():
         # No client_id in token
     }
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "access_token": "new",
-        "expires_in": 3600,
-    }
-
     with (
-        patch("httpx.AsyncClient") as mock_client_cls,
-        patch("mnemo_mcp.sync._save_token"),
+        patch("mnemo_mcp.sync._clear_token") as mock_clear,
+        patch("mnemo_mcp.sync.httpx.AsyncClient") as mock_client_cls,
         patch("mnemo_mcp.sync.settings") as mock_settings,
     ):
         mock_settings.google_drive_client_id = "settings_client_id"
         mock_settings.google_drive_client_secret = "secret123"
-        mock_client = AsyncMock()
-        mock_client.post.return_value = mock_response
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
 
         result = await _refresh_token(token)
 
-    assert result is not None
-    assert result["client_id"] == "settings_client_id"
+    assert result is None
+    mock_clear.assert_called_once()
+    mock_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_clears_token_on_client_mismatch():
+    """A token minted by a different client_id is cleared, not refreshed."""
+    from mnemo_mcp.sync import _refresh_token
+
+    token = {
+        "access_token": "old",
+        "refresh_token": "refresh123",
+        "client_id": "other-client",
+    }
+
+    with (
+        patch("mnemo_mcp.sync._clear_token") as mock_clear,
+        patch("mnemo_mcp.sync.logger.warning") as mock_warn,
+        patch("mnemo_mcp.sync.httpx.AsyncClient") as mock_client_cls,
+        patch("mnemo_mcp.sync.settings") as mock_settings,
+    ):
+        mock_settings.google_drive_client_id = "current-client"
+        mock_settings.google_drive_client_secret = "secret123"
+
+        result = await _refresh_token(token)
+
+    assert result is None
+    mock_clear.assert_called_once()
+    mock_warn.assert_called_once()
+    mock_client_cls.assert_not_called()

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -301,6 +301,31 @@ class TestAsyncTokenStore:
         saved = json.loads((token_dir / "async_drive_save.json").read_text())
         assert saved["access_token"] == "async_save"
 
+    @pytest.mark.asyncio
+    async def test_async_delete_removes_file(self, token_dir):
+        from mnemo_mcp.token_store import async_delete_token, async_save_token
+
+        token = {"access_token": "async_delete", "token_type": "Bearer"}
+        with patch("mnemo_mcp.token_store.settings") as m:
+            m.get_data_dir.return_value = token_dir.parent
+            await async_save_token("async_drive_delete", token)
+            assert (token_dir / "async_drive_delete.json").exists()
+
+            deleted = await async_delete_token("async_drive_delete")
+
+        assert deleted is True
+        assert not (token_dir / "async_drive_delete.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_async_delete_missing_is_noop(self, token_dir):
+        from mnemo_mcp.token_store import async_delete_token
+
+        with patch("mnemo_mcp.token_store.settings") as m:
+            m.get_data_dir.return_value = token_dir.parent
+            deleted = await async_delete_token("async_drive_missing")
+
+        assert deleted is False
+
 
 class TestSubTokenStore:
     @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -1089,7 +1089,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0b2,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1195,7 +1195,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.2"
+version = "1.19.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1210,9 +1210,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/de/0e08cc5b07e1818d9028b3ea9da7e6852ffd14bc3893143e20c4eb3bdf85/n24q02m_mcp_core-1.18.2.tar.gz", hash = "sha256:0ea9e06c89fc8427c175cad14121b68ad9f8e4a2e9be03e5fa0beb62382d3d19", size = 305617, upload-time = "2026-07-05T13:09:09.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/4d/b5497a65f4239ae1663cd0418d57ec9ba36139bea6d1b89d2e1f9d5e16fb/n24q02m_mcp_core-1.19.0b3.tar.gz", hash = "sha256:4f8326eea6894ee47549ed2340bd7d51912398c9466dda13faf845fc0e505be7", size = 316647, upload-time = "2026-07-11T04:40:40.513Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/22/462bc0faebcd9f322cd4fff96bd0fb6bcc0464fb994836c97c2af59505d3/n24q02m_mcp_core-1.18.2-py3-none-any.whl", hash = "sha256:5a26acaa7d57267e5b7d42a1c4d1367ac33a3b27346db995e1cc982f77e01262", size = 170061, upload-time = "2026-07-05T13:09:08.315Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d8/f2af4b8b136e2b57ce2fae71496f8d4a248628c1b7be793260ab4bb8376e/n24q02m_mcp_core-1.19.0b3-py3-none-any.whl", hash = "sha256:222d82996394d51f3fcc9f91c4e107e43ee364c4d1c0111bc59ee142e971ea68", size = 176504, upload-time = "2026-07-11T04:40:39.207Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## S5 / WS-A2 (mnemo half — ships in the same batch as wet-mcp per category parity)

- `config.py`: Google client pair now resolves via `mcp_core.auth.resolve_bundled_client` (default_factory) — byte-identical shape to wet's change; env pair still beats bundled; half-pair env + `USE_BUNDLED_GOOGLE_CLIENT=false` kill-switch fail loud at Settings() construction. Bundled Desktop OAuth pair unchanged (public by design, value-pin tests kept).
- `_refresh_token`: `token_client_mismatch` guard (async shape — `await _clear_token()` via new `async_delete_token`, provider-scoped) clears tokens minted by a different client_id, forcing one clean re-auth instead of the mixed-pair `invalid_client` loop.
- Exhaustive collision audit: all 13 `_refresh_token` test call sites individually verified; 6 pre-existing tests that would have silently passed-for-the-wrong-reason were re-pinned to keep exercising their original branches.
- Pin bump `n24q02m-mcp-core[llm]>=1.19.0b2,<2`.

Evidence: full suite 1336 passed / 5 skipped; ruff + pre-commit hooks green; task-reviewed + re-audit RESOLVED.