### PR TITLE
feat: mount shared cli builder with auth and warmup subcommands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,10 @@ dependencies = [
     "sqlite-vec",
     # Local ONNX embedding (auto-fallback when no cloud API)
     "qwen3-embed>=1.12.1",
-    # Zero-env-config credential relay + LLM/embed/rerank via litellm passthrough
-    "n24q02m-mcp-core[llm]>=1.19.0b2,<2",
+    # Beta pin: 1.19.0b4 ships mcp_core.cli's argument-spec extra
+    # subcommand support ((configure, handler) tuples) this repo's
+    # cli.py auth subcommand consumes.
+    "n24q02m-mcp-core[llm]>=1.19.0b4,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 ]
 
 [project.scripts]
-mnemo-mcp = "mnemo_mcp.server:main"
+mnemo-mcp = "mnemo_mcp.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/n24q02m/mnemo-mcp"

--- a/src/mnemo_mcp/cli.py
+++ b/src/mnemo_mcp/cli.py
@@ -1,0 +1,61 @@
+"""Console-script entry: mounts the shared mcp_core CLI builder.
+
+Bare invocation and any leading-dash argv (e.g. --http) start the server
+exactly as before; subcommands run one-shot operator actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from mcp_core import build_cli
+
+
+def _serve(argv: list[str]) -> int | None:
+    from mnemo_mcp.server import main as server_main
+
+    server_main()
+    return 0
+
+
+def _configure_auth(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "provider", choices=["google"], help="Credential provider to authorize"
+    )
+
+
+def _handle_auth(args: argparse.Namespace) -> int:
+    from mnemo_mcp.setup_tool import run_setup_sync
+
+    result = asyncio.run(run_setup_sync())
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result.get("status") == "authenticated" else 1
+
+
+def _handle_warmup(args: argparse.Namespace) -> int:
+    from mnemo_mcp.setup_tool import run_warmup
+
+    result = asyncio.run(run_warmup())
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result.get("status") == "ok" else 1
+
+
+def _extras() -> dict:
+    return {
+        "auth": (_configure_auth, _handle_auth),
+        "warmup": _handle_warmup,
+    }
+
+
+def _version() -> str:
+    from mnemo_mcp import __version__
+
+    return __version__
+
+
+def main() -> int:
+    return build_cli("mnemo-mcp", serve=_serve, extra=_extras(), version=_version())(
+        None
+    )

--- a/src/mnemo_mcp/cli.py
+++ b/src/mnemo_mcp/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import sys
 
 from mcp_core import build_cli
 
@@ -24,12 +25,44 @@ def _configure_auth(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "provider", choices=["google"], help="Credential provider to authorize"
     )
+    p.add_argument(
+        "--client-id",
+        default=None,
+        help="BYO OAuth client id (must be paired with --client-secret)",
+    )
+    p.add_argument("--client-secret", default=None, help="BYO OAuth client secret")
 
 
 def _handle_auth(args: argparse.Namespace) -> int:
     from mnemo_mcp.setup_tool import run_setup_sync
 
-    result = asyncio.run(run_setup_sync())
+    # Single-user / local machine only: writes the token via the local store.
+    # mnemo_mcp.config.settings is a module-level singleton resolved once at
+    # import time -- a BYO client pair can never reach it via os.environ
+    # after that point. The pair is threaded through run_setup_sync's
+    # client_id/client_secret params instead.
+    if args.client_id or args.client_secret:
+        from mcp_core.auth import resolve_bundled_client
+
+        from mnemo_mcp.config import _GOOGLE_CLIENT_SPEC
+
+        try:
+            resolved = resolve_bundled_client(
+                _GOOGLE_CLIENT_SPEC,
+                cli_id=args.client_id,
+                cli_secret=args.client_secret,
+            )
+        except ValueError as exc:
+            print(f"mnemo-mcp: {exc}", file=sys.stderr)
+            return 2
+        result = asyncio.run(
+            run_setup_sync(
+                client_id=resolved.client_id, client_secret=resolved.client_secret
+            )
+        )
+    else:
+        result = asyncio.run(run_setup_sync())
+
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0 if result.get("status") == "authenticated" else 1
 

--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -151,16 +151,26 @@ async def run_warmup() -> dict:
     }
 
 
-async def run_setup_sync() -> dict:
+async def run_setup_sync(
+    client_id: str | None = None,
+    client_secret: str | None = None,
+) -> dict:
     """Authenticate Google Drive via Device Code OAuth flow.
+
+    ``client_id``/``client_secret`` optionally override the upstream OAuth
+    client identity for this call (BYO client, e.g. from the CLI's ``auth
+    google --client-id/--client-secret`` flags) without mutating the
+    ``mnemo_mcp.config.settings`` singleton -- both default to ``None``,
+    which falls back to ``settings.google_drive_client_id/secret`` exactly
+    as before.
 
     Returns a structured dict with setup results.
     """
     from mnemo_mcp.sync import setup_google_auth
     from mnemo_mcp.token_store import get_token_path
 
-    client_id = settings.google_drive_client_id
-    if not client_id:
+    effective_id = client_id or settings.google_drive_client_id
+    if not effective_id:
         return {
             "status": "error",
             "error": "GOOGLE_DRIVE_CLIENT_ID not configured. "
@@ -168,7 +178,7 @@ async def run_setup_sync() -> dict:
             "suggestion": "Set the GOOGLE_DRIVE_CLIENT_ID environment variable or create one in Google Cloud Console.",
         }
 
-    success = await setup_google_auth()
+    success = await setup_google_auth(client_id=client_id, client_secret=client_secret)
     if not success:
         return {
             "status": "error",
@@ -183,6 +193,6 @@ async def run_setup_sync() -> dict:
         "token_path": str(token_path),
         "next_steps": {
             "SYNC_ENABLED": "true",
-            "GOOGLE_DRIVE_CLIENT_ID": client_id,
+            "GOOGLE_DRIVE_CLIENT_ID": effective_id,
         },
     }

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -743,16 +743,23 @@ async def _poll_for_token(
 async def setup_google_auth(
     relay_url: str | None = None,
     session_id: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
 ) -> bool:
     """Interactive Google OAuth setup via Device Code flow.
 
     If relay_url + session_id provided, send device code via relay messaging.
     Otherwise print to stderr.
 
+    ``client_id``/``client_secret`` optionally override the OAuth client
+    identity used for the device-code request, token poll, and saved token
+    payload; both default to ``None``, which falls back to
+    ``settings.google_drive_client_id/secret`` exactly as before.
+
     Returns True on success, False on failure.
     """
-    client_id = settings.google_drive_client_id
-    client_secret = settings.google_drive_client_secret
+    client_id = client_id or settings.google_drive_client_id
+    client_secret = client_secret or settings.google_drive_client_secret
     if not client_id or not client_secret:
         logger.error("GOOGLE_DRIVE_CLIENT_ID or CLIENT_SECRET not configured")
         return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,124 @@
+"""Tests for mnemo_mcp.cli -- shared mcp_core CLI builder mount.
+
+Bare invocation and any leading-dash argv start the server unchanged;
+subcommands (auth/warmup) run one-shot operator actions. No network or
+model calls -- run_setup_sync/run_warmup are mocked.
+"""
+
+import sys
+from unittest.mock import AsyncMock, patch
+
+
+class TestServeDispatch:
+    """Bare/flag argv route to the server unchanged."""
+
+    def test_bare_invocation_starts_server(self):
+        from mnemo_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp"]),
+            patch("mnemo_mcp.server.main") as mock_server_main,
+        ):
+            rc = cli.main()
+
+        mock_server_main.assert_called_once()
+        assert rc == 0
+
+    def test_http_flag_passes_through_argv_unchanged(self):
+        from mnemo_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "--http"]),
+            patch("mnemo_mcp.server.main") as mock_server_main,
+        ):
+            rc = cli.main()
+
+        mock_server_main.assert_called_once()
+        assert rc == 0
+
+
+class TestAuthSubcommand:
+    """`mnemo-mcp auth google` -- run_setup_sync dispatch."""
+
+    def test_happy_path(self, capsys):
+        from mnemo_mcp import cli
+
+        result = {"status": "authenticated", "provider": "google_drive"}
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "auth", "google"]),
+            patch(
+                "mnemo_mcp.setup_tool.run_setup_sync",
+                new=AsyncMock(return_value=result),
+            ) as mock_setup,
+        ):
+            rc = cli.main()
+
+        mock_setup.assert_awaited_once_with()
+        assert rc == 0
+        assert '"status": "authenticated"' in capsys.readouterr().out
+
+    def test_error_status_returns_nonzero(self):
+        from mnemo_mcp import cli
+
+        result = {"status": "error", "error": "boom"}
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "auth", "google"]),
+            patch(
+                "mnemo_mcp.setup_tool.run_setup_sync",
+                new=AsyncMock(return_value=result),
+            ),
+        ):
+            rc = cli.main()
+
+        assert rc == 1
+
+
+class TestUnknownSubcommand:
+    """build_cli's own unrecognized-subcommand handling -- rc 2, no server start."""
+
+    def test_unknown_subcommand_returns_rc_2(self, capsys):
+        from mnemo_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "bogus"]),
+            patch("mnemo_mcp.server.main") as mock_server_main,
+        ):
+            rc = cli.main()
+
+        mock_server_main.assert_not_called()
+        assert rc == 2
+        assert "unknown subcommand" in capsys.readouterr().err
+
+
+class TestWarmupSubcommand:
+    """`mnemo-mcp warmup` -- run_warmup, no argument-taking configure."""
+
+    def test_happy_path(self, capsys):
+        from mnemo_mcp import cli
+
+        result = {"status": "ok", "mode": "local", "steps": []}
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "warmup"]),
+            patch(
+                "mnemo_mcp.setup_tool.run_warmup", new=AsyncMock(return_value=result)
+            ) as mock_warmup,
+        ):
+            rc = cli.main()
+
+        mock_warmup.assert_awaited_once_with()
+        assert rc == 0
+        assert '"mode": "local"' in capsys.readouterr().out
+
+    def test_error_status_returns_nonzero(self):
+        from mnemo_mcp import cli
+
+        result = {"status": "error", "steps": []}
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "warmup"]),
+            patch(
+                "mnemo_mcp.setup_tool.run_warmup", new=AsyncMock(return_value=result)
+            ),
+        ):
+            rc = cli.main()
+
+        assert rc == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@
 
 Bare invocation and any leading-dash argv start the server unchanged;
 subcommands (auth/warmup) run one-shot operator actions. No network or
-model calls -- run_setup_sync/run_warmup are mocked.
+model calls -- run_setup_sync/run_warmup/setup_google_auth are mocked.
 """
 
 import sys
@@ -38,12 +38,67 @@ class TestServeDispatch:
 
 
 class TestAuthSubcommand:
-    """`mnemo-mcp auth google` -- run_setup_sync dispatch."""
+    """`mnemo-mcp auth google` -- BYO client resolution + run_setup_sync."""
 
-    def test_happy_path(self, capsys):
+    def test_half_pair_flags_returns_clean_error(self, capsys):
         from mnemo_mcp import cli
 
-        result = {"status": "authenticated", "provider": "google_drive"}
+        with patch.object(
+            sys, "argv", ["mnemo-mcp", "auth", "google", "--client-secret", "shh"]
+        ):
+            rc = cli.main()
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "set both together" in err
+        assert "shh" not in err  # never print the secret value
+
+    def test_happy_path_threads_byo_pair_to_setup_google_auth(self, capsys):
+        """auth google --client-id/--client-secret must reach setup_google_auth.
+
+        mnemo_mcp.config.settings is a module-level singleton resolved at
+        import time, so a prior regression wrote the BYO pair to os.environ
+        (a no-op -- the singleton was already frozen) instead of threading
+        it through run_setup_sync's params. This does NOT blanket-mock
+        run_setup_sync: it lets the real function run (including its
+        missing-credentials check) and only mocks the network-touching
+        setup_google_auth, so the assertion below proves the pair actually
+        reaches that call rather than being silently dropped.
+        """
+        from mnemo_mcp import cli
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "mnemo-mcp",
+                    "auth",
+                    "google",
+                    "--client-id",
+                    "my-id",
+                    "--client-secret",
+                    "my-secret",
+                ],
+            ),
+            patch(
+                "mnemo_mcp.sync.setup_google_auth",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_setup_google_auth,
+        ):
+            rc = cli.main()
+
+        mock_setup_google_auth.assert_awaited_once_with(
+            client_id="my-id", client_secret="my-secret"
+        )
+        assert rc == 0
+        assert '"status": "authenticated"' in capsys.readouterr().out
+
+    def test_no_flags_skips_byo_resolution(self, capsys):
+        from mnemo_mcp import cli
+
+        result = {"status": "error", "error": "boom"}
         with (
             patch.object(sys, "argv", ["mnemo-mcp", "auth", "google"]),
             patch(
@@ -54,22 +109,6 @@ class TestAuthSubcommand:
             rc = cli.main()
 
         mock_setup.assert_awaited_once_with()
-        assert rc == 0
-        assert '"status": "authenticated"' in capsys.readouterr().out
-
-    def test_error_status_returns_nonzero(self):
-        from mnemo_mcp import cli
-
-        result = {"status": "error", "error": "boom"}
-        with (
-            patch.object(sys, "argv", ["mnemo-mcp", "auth", "google"]),
-            patch(
-                "mnemo_mcp.setup_tool.run_setup_sync",
-                new=AsyncMock(return_value=result),
-            ),
-        ):
-            rc = cli.main()
-
         assert rc == 1
 
 

--- a/tests/test_sync_gdrive_auth.py
+++ b/tests/test_sync_gdrive_auth.py
@@ -92,6 +92,63 @@ class TestSetupGoogleAuthFull:
             result = await setup_google_auth()
         assert result is False
 
+    async def test_byo_client_pair_overrides_frozen_settings_singleton(self):
+        """client_id/client_secret args must override settings, not be dropped.
+
+        mnemo_mcp.config.settings is a module-level singleton resolved once
+        at import time -- a BYO client pair can never reach it via
+        os.environ after that point. This guards the actual fix: the
+        override has to win at every point client_id/client_secret are
+        used (outgoing device-code request, outgoing token request, saved
+        token payload).
+        """
+        device_response = MagicMock()
+        device_response.status_code = 200
+        device_response.json.return_value = {
+            "device_code": "dev123",
+            "user_code": "ABC-DEF",
+            "verification_url": "https://google.com/device",
+            "interval": 0,
+            "expires_in": 5,
+        }
+        token_response = MagicMock()
+        token_response.status_code = 200
+        token_response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        with (
+            patch("mnemo_mcp.sync.settings") as mock_settings,
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch("mnemo_mcp.sync._save_token") as mock_save,
+            patch("mnemo_mcp.sync.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            # Settings singleton still holds the bundled defaults -- the BYO
+            # pair below must win over these, not be silently ignored.
+            mock_settings.google_drive_client_id = "bundled-id"
+            mock_settings.google_drive_client_secret = "bundled-secret"
+
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = [device_response, token_response]
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await setup_google_auth(
+                client_id="byo-id", client_secret="byo-secret"
+            )
+
+        assert result is True
+        device_call, token_call = mock_client.post.await_args_list
+        assert device_call.kwargs["data"]["client_id"] == "byo-id"
+        assert token_call.kwargs["data"]["client_id"] == "byo-id"
+        assert token_call.kwargs["data"]["client_secret"] == "byo-secret"
+        saved_token = mock_save.call_args.args[0]
+        assert saved_token["client_id"] == "byo-id"
+
     async def test_success_flow_via_relay(self):
         """Full success flow: device code request, relay message, token poll success."""
         device_response = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -1044,7 +1044,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.6.0b2"
+version = "2.6.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1089,7 +1089,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0b2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0b4,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1195,7 +1195,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.19.0b3"
+version = "1.19.0b4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1210,9 +1210,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/4d/b5497a65f4239ae1663cd0418d57ec9ba36139bea6d1b89d2e1f9d5e16fb/n24q02m_mcp_core-1.19.0b3.tar.gz", hash = "sha256:4f8326eea6894ee47549ed2340bd7d51912398c9466dda13faf845fc0e505be7", size = 316647, upload-time = "2026-07-11T04:40:40.513Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/94/4a0f9d5407080cf82cc96d666ea9ec60fc4f34e2db9421181cc71cf39eee/n24q02m_mcp_core-1.19.0b4.tar.gz", hash = "sha256:37a9895b2dad090b1299642d812b5ebf31a3fcb884bf825355edfa1f142d6c58", size = 317619, upload-time = "2026-07-11T07:13:12.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/d8/f2af4b8b136e2b57ce2fae71496f8d4a248628c1b7be793260ab4bb8376e/n24q02m_mcp_core-1.19.0b3-py3-none-any.whl", hash = "sha256:222d82996394d51f3fcc9f91c4e107e43ee364c4d1c0111bc59ee142e971ea68", size = 176504, upload-time = "2026-07-11T04:40:39.207Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f5/c979129112a73c433559be78d613c6ec989f5e11423e9257b51bcbdc7c47/n24q02m_mcp_core-1.19.0b4-py3-none-any.whl", hash = "sha256:65cb2060b37d3d726ff573509b6ff443812dc71d44654475b38c1c0840e6752f", size = 176888, upload-time = "2026-07-11T07:13:11.319Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## S6 / WS-B2 (mnemo half — same-batch mirror of wet-mcp#1517)

- New `mnemo_mcp.cli:main` mounts `mcp_core.build_cli`: bare/`--http` start the server byte-identically; subcommands `auth google [--client-id --client-secret]` and `warmup`.
- BYO pair is THREADED EXPLICITLY (cli → `run_setup_sync` → `setup_google_auth` → device-code/token-poll/saved-payload) — mirrors the Critical fix from the wet review: env-var writes after entry are silent no-ops because the settings singleton freezes at package import. Anti-regression test pins BYO override against a deliberately different frozen singleton at all 3 injection points.
- Half-pair flags → clean stderr + rc 2 (secret never printed); unknown subcommand → rc 2. Live console-script smoke included.
- Pin bump `n24q02m-mcp-core[llm]>=1.19.0b4,<2`.

Evidence: 1345 passed / 5 skipped; ruff/ty clean; task-reviewed Approved (3-tier fix verified by direct source reads; parity with wet template confirmed with authorized deltas only).