### PR TITLE
feat: return structured content from domain tools

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -452,17 +452,15 @@ async def _handle_add(
     content: str | None,
     category: str | None = None,
     tags: list[str] | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
     db, embedding_model, embedding_dims = _get_ctx(ctx)
 
     if not content:
-        return _json(
-            {
-                "error": "content is required for add",
-                "example": "action='add', content='User prefers Python for data tasks', category='preference', tags=['python']",
-                "suggestion": "Provide the 'content' parameter to save a new memory.",
-            }
-        )
+        return {
+            "error": "content is required for add",
+            "example": "action='add', content='User prefers Python for data tasks', category='preference', tags=['python']",
+            "suggestion": "Provide the 'content' parameter to save a new memory.",
+        }
 
     # Dedup check before insert
     dedup_warning = None
@@ -487,20 +485,16 @@ async def _handle_add(
             embedding=embedding,
         )
     except ValueError as e:
-        return _json(
-            {
-                "error": str(e),
-                "suggestion": "Ensure input parameters meet validation rules.",
-            }
-        )
+        return {
+            "error": str(e),
+            "suggestion": "Ensure input parameters meet validation rules.",
+        }
     except Exception:
         logger.exception("Unexpected error in _handle_add")
-        return _json(
-            {
-                "error": "Internal error while adding memory",
-                "suggestion": "Check server logs for tracebacks or verify database permissions.",
-            }
-        )
+        return {
+            "error": "Internal error while adding memory",
+            "suggestion": "Check server logs for tracebacks or verify database permissions.",
+        }
 
     result: dict = {
         "id": memory_id,
@@ -514,7 +508,7 @@ async def _handle_add(
     # Background: score importance + extract entities (non-blocking)
     asyncio.create_task(_enrich_memory(db, memory_id, content))
 
-    return _json(result)
+    return result
 
 
 async def _enrich_memory(db: MemoryDB, memory_id: str, content: str) -> None:
@@ -591,17 +585,15 @@ async def _handle_search(
     until: str | None = None,
     min_importance: float = 0.0,
     include_archived: bool = False,
-) -> str:
+) -> dict[str, typing.Any]:
     db, embedding_model, embedding_dims = _get_ctx(ctx)
 
     if not query:
-        return _json(
-            {
-                "error": "query is required for search",
-                "example": "action='search', query='user preferences for UI theme'",
-                "suggestion": "Provide the 'query' parameter to perform a search.",
-            }
-        )
+        return {
+            "error": "query is required for search",
+            "example": "action='search', query='user preferences for UI theme'",
+            "suggestion": "Provide the 'query' parameter to perform a search.",
+        }
 
     db, _, _ = _get_ctx(ctx)
 
@@ -689,14 +681,14 @@ async def _handle_search(
         )
 
     response = await _maybe_include_setup_hint(response)
-    return _json(response)
+    return response
 
 
 async def _handle_list(
     ctx: Context | None,
     category: str | None = None,
     limit: int = 5,
-) -> str:
+) -> dict[str, typing.Any]:
     db, _, _ = _get_ctx(ctx)
 
     if isinstance(limit, int):
@@ -720,7 +712,7 @@ async def _handle_list(
             response["suggestion"] = (
                 "No memories found. Use action='add' to create some!"
             )
-    return _json(response)
+    return response
 
 
 async def _handle_update(
@@ -731,19 +723,17 @@ async def _handle_update(
     tags: list[str] | None = None,
     source: str | None = None,
     importance: float | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
 
     db, _, _ = _get_ctx(ctx)
     db, embedding_model, embedding_dims = _get_ctx(ctx)
 
     if not memory_id:
-        return _json(
-            {
-                "error": "memory_id is required for update. Use action='search' or action='list' first to find the memory ID.",
-                "example": "action='update', memory_id='abc123', content='updated content'",
-                "suggestion": "Provide the 'memory_id' parameter to update a specific memory.",
-            }
-        )
+        return {
+            "error": "memory_id is required for update. Use action='search' or action='list' first to find the memory ID.",
+            "example": "action='update', memory_id='abc123', content='updated content'",
+            "suggestion": "Provide the 'memory_id' parameter to update a specific memory.",
+        }
 
     embedding = None
     if content:
@@ -761,141 +751,121 @@ async def _handle_update(
             embedding=embedding,
         )
     except ValueError as e:
-        return _json(
-            {
-                "error": str(e),
-                "suggestion": "Check input parameters for invalid types or values.",
-            }
-        )
+        return {
+            "error": str(e),
+            "suggestion": "Check input parameters for invalid types or values.",
+        }
     except Exception:
         logger.exception("Unexpected error in _handle_update")
-        return _json(
-            {
-                "error": "Internal error while updating memory",
-                "suggestion": "Check server logs for tracebacks or verify database connection.",
-            }
-        )
+        return {
+            "error": "Internal error while updating memory",
+            "suggestion": "Check server logs for tracebacks or verify database connection.",
+        }
     if ok:
         # Background: re-extract entities if content changed
         if content:
             asyncio.create_task(_enrich_memory(db, memory_id, content))
-        return _json({"status": "updated", "id": memory_id})
-    return _json(
-        {
-            "error": f"Memory {memory_id} not found",
-            "suggestion": "Verify the memory_id using action='search' or action='list'.",
-        }
-    )
+        return {"status": "updated", "id": memory_id}
+    return {
+        "error": f"Memory {memory_id} not found",
+        "suggestion": "Verify the memory_id using action='search' or action='list'.",
+    }
 
 
 async def _handle_delete(
     ctx: Context | None,
     memory_id: str | None,
-) -> str:
+) -> dict[str, typing.Any]:
 
     db, _, _ = _get_ctx(ctx)
 
     if not memory_id:
-        return _json(
-            {
-                "error": "memory_id is required for delete. Use action='search' or action='list' first to find the memory ID.",
-                "example": "action='delete', memory_id='abc123'",
-                "suggestion": "Provide the 'memory_id' parameter to delete a specific memory.",
-            }
-        )
+        return {
+            "error": "memory_id is required for delete. Use action='search' or action='list' first to find the memory ID.",
+            "example": "action='delete', memory_id='abc123'",
+            "suggestion": "Provide the 'memory_id' parameter to delete a specific memory.",
+        }
 
     ok = await asyncio.to_thread(db.delete, memory_id)
     if ok:
-        return _json({"status": "deleted", "id": memory_id})
-    return _json(
-        {
-            "error": f"Memory {memory_id} not found",
-            "suggestion": "Verify the memory_id using action='search' or action='list'.",
-        }
-    )
+        return {"status": "deleted", "id": memory_id}
+    return {
+        "error": f"Memory {memory_id} not found",
+        "suggestion": "Verify the memory_id using action='search' or action='list'.",
+    }
 
 
-async def _handle_export(ctx: Context | None) -> str:
+async def _handle_export(ctx: Context | None) -> dict[str, typing.Any]:
     db, _, _ = _get_ctx(ctx)
     jsonl, count = await asyncio.to_thread(db.export_jsonl)
-    return _json(
-        {
-            "format": "jsonl",
-            "data": jsonl,
-            "count": count,
-        }
-    )
+    return {
+        "format": "jsonl",
+        "data": jsonl,
+        "count": count,
+    }
 
 
 async def _handle_import(
     ctx: Context | None,
     data: str | list | None,
     mode: str = "merge",
-) -> str:
+) -> dict[str, typing.Any]:
     db, _, _ = _get_ctx(ctx)
 
     if not data:
-        return _json(
-            {
-                "error": "data (JSONL string or list of objects) is required for import",
-                "suggestion": "Provide the 'data' parameter containing the JSONL data or a list of JSON objects to import.",
-            }
-        )
+        return {
+            "error": "data (JSONL string or list of objects) is required for import",
+            "suggestion": "Provide the 'data' parameter containing the JSONL data or a list of JSON objects to import.",
+        }
 
     # Bolt Performance Optimization: Pass raw list/dict directly to database layer.
     # Avoids unnecessary JSON serialization and deserialization cycles for parsed inputs.
     if data is None:
         raise ValueError("data is required")
     result = await asyncio.to_thread(db.import_jsonl, data, mode=mode)
-    return _json(
-        {
-            "status": "imported",
-            **result,
-        }
-    )
+    return {
+        "status": "imported",
+        **result,
+    }
 
 
-async def _handle_stats(ctx: Context | None) -> str:
+async def _handle_stats(ctx: Context | None) -> dict[str, typing.Any]:
     db, embedding_model, embedding_dims = _get_ctx(ctx)
     s = await asyncio.to_thread(db.stats)
     s["embedding_model"] = embedding_model
     s["embedding_dims"] = embedding_dims
     s["sync_enabled"] = settings.sync_enabled
     s["sync_folder"] = settings.sync_folder
-    return _json(s)
+    return s
 
 
 async def _handle_restore(
     ctx: Context | None,
     memory_id: str | None,
-) -> str:
+) -> dict[str, typing.Any]:
 
     db, _, _ = _get_ctx(ctx)
 
     if not memory_id:
-        return _json(
-            {
-                "error": "memory_id is required for restore. Use action='archived' first to find archived memory IDs.",
-                "example": "action='restore', memory_id='abc123'",
-                "suggestion": "Provide the 'memory_id' parameter to restore a specific memory.",
-            }
-        )
+        return {
+            "error": "memory_id is required for restore. Use action='archived' first to find archived memory IDs.",
+            "example": "action='restore', memory_id='abc123'",
+            "suggestion": "Provide the 'memory_id' parameter to restore a specific memory.",
+        }
 
     ok = await asyncio.to_thread(db.restore_memory, memory_id)
     if ok:
-        return _json({"status": "restored", "id": memory_id})
-    return _json(
-        {
-            "error": f"Archived memory {memory_id} not found",
-            "suggestion": "Verify the memory_id using action='archived'.",
-        }
-    )
+        return {"status": "restored", "id": memory_id}
+    return {
+        "error": f"Archived memory {memory_id} not found",
+        "suggestion": "Verify the memory_id using action='archived'.",
+    }
 
 
 async def _handle_archived(
     ctx: Context | None,
     limit: int = 5,
-) -> str:
+) -> dict[str, typing.Any]:
     db, _, _ = _get_ctx(ctx)
 
     if isinstance(limit, int):
@@ -910,7 +880,7 @@ async def _handle_archived(
         response["suggestion"] = (
             "No archived memories found. Use action='list' to view active memories."
         )
-    return _json(response)
+    return response
 
 
 _CAPTURE_COUNTER: dict[str, int] = {"calls": 0}
@@ -937,7 +907,7 @@ async def _handle_capture(
     source: str | None = None,
     importance: float | None = None,
     auto: bool = False,
-) -> str:
+) -> dict[str, typing.Any]:
     """Handle ``memory(action="capture")`` -- typed capture with dedup.
 
     Wraps :func:`mnemo_mcp.capture.capture` with the shared lifespan ctx so
@@ -947,18 +917,14 @@ async def _handle_capture(
     db, embedding_model, embedding_dims = _get_ctx(ctx)
 
     if not text:
-        return _json(
-            {
-                "error": "text is required for capture",
-                "example": (
-                    "action='capture', text='User prefers dark mode', "
-                    "context_type='preference'"
-                ),
-                "suggestion": (
-                    "Provide the 'text' parameter to capture a typed memory."
-                ),
-            }
-        )
+        return {
+            "error": "text is required for capture",
+            "example": (
+                "action='capture', text='User prefers dark mode', "
+                "context_type='preference'"
+            ),
+            "suggestion": ("Provide the 'text' parameter to capture a typed memory."),
+        }
 
     embedding = await _embed(text, embedding_model, embedding_dims)
 
@@ -995,18 +961,14 @@ async def _handle_capture(
                 resp["suggestion"] = (
                     f"Pick a context_type from {sorted(CONTEXT_TYPES)}."
                 )
-            return _json(resp)
-        return _json(
-            {"error": msg, "suggestion": "Check payload length and constraints."}
-        )
+            return resp
+        return {"error": msg, "suggestion": "Check payload length and constraints."}
     except Exception:
         logger.exception("Unexpected error in _handle_capture")
-        return _json(
-            {
-                "error": "Internal error while capturing memory",
-                "suggestion": "Check server logs for tracebacks.",
-            }
-        )
+        return {
+            "error": "Internal error while capturing memory",
+            "suggestion": "Check server logs for tracebacks.",
+        }
 
     # Background enrichment only when we actually inserted a new row.
     if not result.get("deduplicated"):
@@ -1026,43 +988,39 @@ async def _handle_capture(
                 )
             )
 
-    return _json(
-        {
-            "status": "deduplicated" if result.get("deduplicated") else "captured",
-            "id": result["memory_id"],
-            "context_type": result.get("context_type", context_type),
-            "deduplicated": bool(result.get("deduplicated")),
-            "auto": bool(result.get("auto")),
-            "semantic": embedding is not None,
-            **(
-                {
-                    "similarity": result["similarity"],
-                    "existing_content": result.get("existing_content"),
-                }
-                if result.get("deduplicated")
-                else {}
-            ),
-        }
-    )
+    return {
+        "status": "deduplicated" if result.get("deduplicated") else "captured",
+        "id": result["memory_id"],
+        "context_type": result.get("context_type", context_type),
+        "deduplicated": bool(result.get("deduplicated")),
+        "auto": bool(result.get("auto")),
+        "semantic": embedding is not None,
+        **(
+            {
+                "similarity": result["similarity"],
+                "existing_content": result.get("existing_content"),
+            }
+            if result.get("deduplicated")
+            else {}
+        ),
+    }
 
 
 async def _handle_archive_now(
     ctx: Context | None,
-) -> str:
+) -> dict[str, typing.Any]:
     """Trigger ``archive_by_score`` on demand using current settings."""
     db, _, _ = _get_ctx(ctx)
     archive_after_days = int(settings.archive_after_days)
     count = await asyncio.to_thread(
         db.archive_by_score, archive_after_days=archive_after_days
     )
-    return _json(
-        {
-            "status": "archived",
-            "count": count,
-            "archive_after_days": archive_after_days,
-            "scoring": "recency_factor * (1 - importance) > 1.0",
-        }
-    )
+    return {
+        "status": "archived",
+        "count": count,
+        "archive_after_days": archive_after_days,
+        "scoring": "recency_factor * (1 - importance) > 1.0",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1075,33 +1033,29 @@ async def _handle_entity_search(
     name: str | None,
     entity_type: str | None,
     limit: int = 20,
-) -> str:
+) -> dict[str, typing.Any]:
     """``memory(action="entity_search")`` -- find memories by entity name."""
     db, _, _ = _get_ctx(ctx)
     if not name:
-        return _json(
-            {
-                "error": "name is required for entity_search",
-                "example": "action='entity_search', name='FastAPI'",
-                "suggestion": (
-                    "Pass 'name' (entity name, case-insensitive) and "
-                    "optionally 'entity_type' (person/project/tool/concept/"
-                    "org/location/event)."
-                ),
-            }
-        )
+        return {
+            "error": "name is required for entity_search",
+            "example": "action='entity_search', name='FastAPI'",
+            "suggestion": (
+                "Pass 'name' (entity name, case-insensitive) and "
+                "optionally 'entity_type' (person/project/tool/concept/"
+                "org/location/event)."
+            ),
+        }
     from mnemo_mcp.temporal.queries import entity_search
 
     rows = await asyncio.to_thread(
         entity_search, db, name=name, entity_type=entity_type, limit=limit
     )
-    return _json(
-        {
-            "count": len(rows),
-            "results": [_format_memory(r) for r in rows],
-            "matched_name": name,
-        }
-    )
+    return {
+        "count": len(rows),
+        "results": [_format_memory(r) for r in rows],
+        "matched_name": name,
+    }
 
 
 async def _handle_entity_graph(
@@ -1110,86 +1064,74 @@ async def _handle_entity_graph(
     name: str | None,
     depth: int = 2,
     limit: int = 50,
-) -> str:
+) -> dict[str, typing.Any]:
     """``memory(action="entity_graph")`` -- KG neighbourhood subgraph."""
     db, _, _ = _get_ctx(ctx)
     if not entity_id and not name:
-        return _json(
-            {
-                "error": "entity_id or name required for entity_graph",
-                "example": "action='entity_graph', name='Python', depth=2",
-                "suggestion": "Provide either 'entity_id' or 'name' to specify the root of the graph.",
-            }
-        )
+        return {
+            "error": "entity_id or name required for entity_graph",
+            "example": "action='entity_graph', name='Python', depth=2",
+            "suggestion": "Provide either 'entity_id' or 'name' to specify the root of the graph.",
+        }
     from mnemo_mcp.temporal.queries import entity_graph
 
     result = await asyncio.to_thread(
         entity_graph, db, entity_id=entity_id, name=name, depth=depth, limit=limit
     )
-    return _json(result)
+    return result
 
 
 async def _handle_history(
     ctx: Context | None,
     entity_id: str | None,
-) -> str:
+) -> dict[str, typing.Any]:
     """``memory(action="history")`` -- timeline of memories linked to an entity."""
     db, _, _ = _get_ctx(ctx)
     if not entity_id:
-        return _json(
-            {
-                "error": "entity_id required for history",
-                "example": "action='history', entity_id='<uuid>'",
-                "suggestion": (
-                    "Get an entity_id from entity_graph or entity_search results."
-                ),
-            }
-        )
+        return {
+            "error": "entity_id required for history",
+            "example": "action='history', entity_id='<uuid>'",
+            "suggestion": (
+                "Get an entity_id from entity_graph or entity_search results."
+            ),
+        }
     from mnemo_mcp.temporal.queries import history_for_entity
 
     timeline = await asyncio.to_thread(history_for_entity, db, entity_id)
-    return _json(
-        {
-            "entity_id": entity_id,
-            "count": len(timeline),
-            "timeline": [_format_memory(m) for m in timeline],
-        }
-    )
+    return {
+        "entity_id": entity_id,
+        "count": len(timeline),
+        "timeline": [_format_memory(m) for m in timeline],
+    }
 
 
 async def _handle_consolidate(
     ctx: Context | None,
     category: str | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
     """Consolidate similar memories in a category using LLM summarization."""
     db, _, _ = _get_ctx(ctx)
     from mnemo_mcp.graph import _has_llm_provider
 
     mode = settings.resolve_provider_mode()
     if mode == "local" and not _has_llm_provider():
-        return _json(
-            {
-                "error": "Consolidation requires LLM (SDK mode with API keys)",
-                "suggestion": "Run the setup flow or provide API keys via environment variables (e.g. GEMINI_API_KEY).",
-            }
-        )
+        return {
+            "error": "Consolidation requires LLM (SDK mode with API keys)",
+            "suggestion": "Run the setup flow or provide API keys via environment variables (e.g. GEMINI_API_KEY).",
+        }
 
     if not category:
-        return _json(
-            {
-                "error": "category is required for consolidate",
-                "suggestion": "Provide the 'category' parameter to specify which memories to consolidate.",
-            }
-        )
+        return {
+            "error": "category is required for consolidate",
+            "suggestion": "Provide the 'category' parameter to specify which memories to consolidate.",
+        }
 
     memories = await asyncio.to_thread(db.list_memories, category=category, limit=50)
     if len(memories) < 2:
-        return _json(
-            {
-                "error": f"Need at least 2 memories in '{category}' to consolidate",
-                "suggestion": f"Use action='list' with category='{category}' to see existing memories.",
-            }
-        )
+        return {
+            "error": f"Need at least 2 memories in '{category}' to consolidate",
+            "suggestion": f"Use action='list' with category='{category}' to see existing memories.",
+        }
 
     try:
         from mnemo_mcp.graph import _llm_completion, _resolve_llm_model
@@ -1216,22 +1158,18 @@ async def _handle_consolidate(
             max_tokens=1000,
         )
 
-        return _json(
-            {
-                "status": "consolidated",
-                "category": category,
-                "original_count": len(memories),
-                "summary": summary.strip(),
-                "note": "Review the summary and use add/delete to apply changes.",
-            }
-        )
+        return {
+            "status": "consolidated",
+            "category": category,
+            "original_count": len(memories),
+            "summary": summary.strip(),
+            "note": "Review the summary and use add/delete to apply changes.",
+        }
     except Exception as e:
-        return _json(
-            {
-                "error": f"Consolidation failed: {e}",
-                "suggestion": "Check LLM provider configuration and network connectivity.",
-            }
-        )
+        return {
+            "error": f"Consolidation failed: {e}",
+            "suggestion": "Check LLM provider configuration and network connectivity.",
+        }
 
 
 # --- Tools ---
@@ -1256,7 +1194,7 @@ async def add_memory(
     category: str | None = None,
     tags: list[str] | None = None,
     ctx: Context | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
     return await _handle_add(ctx, content, category, tags)
 
 
@@ -1280,7 +1218,7 @@ async def search_memory(
     tags: list[str] | None = None,
     limit: int = 5,
     ctx: Context | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
     return await _handle_search(ctx, query, category, tags, limit)
 
 
@@ -1300,7 +1238,7 @@ async def search_memory(
 )
 async def list_memories(
     category: str | None = None, limit: int = 5, ctx: Context | None = None
-) -> str:
+) -> dict[str, typing.Any]:
     return await _handle_list(ctx, category, limit)
 
 
@@ -1326,7 +1264,7 @@ async def update_memory(
     source: str | None = None,
     importance: float | None = None,
     ctx: Context | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
     return await _handle_update(
         ctx, memory_id, content, category, tags, source, importance
     )
@@ -1346,7 +1284,9 @@ async def update_memory(
         destructiveHint=True,
     ),
 )
-async def delete_memory(memory_id: str, ctx: Context | None = None) -> str:
+async def delete_memory(
+    memory_id: str, ctx: Context | None = None
+) -> dict[str, typing.Any]:
     return await _handle_delete(ctx, memory_id)
 
 
@@ -1363,7 +1303,7 @@ async def delete_memory(memory_id: str, ctx: Context | None = None) -> str:
         destructiveHint=False,
     ),
 )
-async def export_memories(ctx: Context | None = None) -> str:
+async def export_memories(ctx: Context | None = None) -> dict[str, typing.Any]:
     return await _handle_export(ctx)
 
 
@@ -1383,7 +1323,7 @@ async def export_memories(ctx: Context | None = None) -> str:
 )
 async def import_memories(
     data: str | list, mode: str = "merge", ctx: Context | None = None
-) -> str:
+) -> dict[str, typing.Any]:
     return await _handle_import(ctx, data, mode)
 
 
@@ -1400,7 +1340,7 @@ async def import_memories(
         destructiveHint=False,
     ),
 )
-async def memory_stats(ctx: Context | None = None) -> str:
+async def memory_stats(ctx: Context | None = None) -> dict[str, typing.Any]:
     return await _handle_stats(ctx)
 
 
@@ -1418,7 +1358,9 @@ async def memory_stats(ctx: Context | None = None) -> str:
         destructiveHint=False,
     ),
 )
-async def restore_memory(memory_id: str, ctx: Context | None = None) -> str:
+async def restore_memory(
+    memory_id: str, ctx: Context | None = None
+) -> dict[str, typing.Any]:
     return await _handle_restore(ctx, memory_id)
 
 
@@ -1435,7 +1377,9 @@ async def restore_memory(memory_id: str, ctx: Context | None = None) -> str:
         destructiveHint=False,
     ),
 )
-async def archived_memories(limit: int = 5, ctx: Context | None = None) -> str:
+async def archived_memories(
+    limit: int = 5, ctx: Context | None = None
+) -> dict[str, typing.Any]:
     return await _handle_archived(ctx, limit)
 
 
@@ -1453,7 +1397,9 @@ async def archived_memories(limit: int = 5, ctx: Context | None = None) -> str:
         destructiveHint=False,
     ),
 )
-async def consolidate_memories(category: str, ctx: Context | None = None) -> str:
+async def consolidate_memories(
+    category: str, ctx: Context | None = None
+) -> dict[str, typing.Any]:
     return await _handle_consolidate(ctx, category)
 
 
@@ -1512,7 +1458,7 @@ async def memory(
     depth: int = 2,
     as_of: str | None = None,
     ctx: Context | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
     """Execute a memory action.
 
     Actions:
@@ -1642,7 +1588,7 @@ async def memory(
                 resp["suggestion"] = (
                     f"Available actions are: {', '.join(valid_actions)}."
                 )
-            return _json(resp)
+            return resp
 
 
 @mcp.tool(
@@ -1671,7 +1617,7 @@ async def config(
     key: str | None = None,
     value: str | None = None,
     ctx: Context | None = None,
-) -> str:
+) -> dict[str, typing.Any]:
     """Server configuration, sync control, and setup.
 
     Actions:
@@ -1743,51 +1689,49 @@ async def config(
                 resp["suggestion"] = (
                     f"Available actions are: {', '.join(valid_actions)}."
                 )
-            return _json(resp)
+            return resp
 
 
-async def _handle_config_status(ctx: Context | None) -> str:
+async def _handle_config_status(ctx: Context | None) -> dict[str, typing.Any]:
     db, embedding_model, embedding_dims = _get_ctx(ctx)
     s = await asyncio.to_thread(db.stats)
-    return _json(
-        {
-            "database": {
-                "path": str(settings.get_db_path()),
-                "total_memories": s["total_memories"],
-                "categories": s["categories"],
-                "vec_enabled": s["vec_enabled"],
-            },
-            "embedding": {
-                "model": embedding_model,
-                "dims": embedding_dims,
-                "available": embedding_model is not None,
-            },
-            "sync": {
-                "enabled": settings.sync_enabled,
-                "provider": "google_drive",
-                "folder": settings.sync_folder,
-                "interval": settings.sync_interval,
-            },
-        }
-    )
+    return {
+        "database": {
+            "path": str(settings.get_db_path()),
+            "total_memories": s["total_memories"],
+            "categories": s["categories"],
+            "vec_enabled": s["vec_enabled"],
+        },
+        "embedding": {
+            "model": embedding_model,
+            "dims": embedding_dims,
+            "available": embedding_model is not None,
+        },
+        "sync": {
+            "enabled": settings.sync_enabled,
+            "provider": "google_drive",
+            "folder": settings.sync_folder,
+            "interval": settings.sync_interval,
+        },
+    }
 
 
-async def _handle_config_sync(ctx: Context | None) -> str:
+async def _handle_config_sync(ctx: Context | None) -> dict[str, typing.Any]:
     db, _, _ = _get_ctx(ctx)
     from mnemo_mcp.sync import sync_full
 
     result = await sync_full(db)
-    return _json(result)
+    return result
 
 
-async def _handle_config_set(key: str | None, value: str | None) -> str:
+async def _handle_config_set(
+    key: str | None, value: str | None
+) -> dict[str, typing.Any]:
     if not key or value is None:
-        return _json(
-            {
-                "error": "key and value are required for set",
-                "suggestion": "Provide both 'key' and 'value' parameters to update a configuration setting.",
-            }
-        )
+        return {
+            "error": "key and value are required for set",
+            "suggestion": "Provide both 'key' and 'value' parameters to update a configuration setting.",
+        }
 
     valid_keys = {
         "sync_enabled",
@@ -1808,7 +1752,7 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
             resp["suggestion"] = f"Did you mean '{closest[0]}'?"
         else:
             resp["suggestion"] = f"Available keys are: {', '.join(sorted(valid_keys))}."
-        return _json(resp)
+        return resp
 
     # Apply setting
     if key == "sync_enabled":
@@ -1842,7 +1786,7 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
                 resp["suggestion"] = (
                     f"Available log levels are: {', '.join(sorted(valid_levels))}."
                 )
-            return _json(resp)
+            return resp
 
         settings.log_level = level
         logger.remove()
@@ -1851,30 +1795,28 @@ async def _handle_config_set(key: str | None, value: str | None) -> str:
             level=settings.log_level,
         )
 
-    return _json(
-        {
-            "status": "updated",
-            "key": key,
-            "value": getattr(settings, key),
-        }
-    )
+    return {
+        "status": "updated",
+        "key": key,
+        "value": getattr(settings, key),
+    }
 
 
-async def _handle_config_warmup() -> str:
+async def _handle_config_warmup() -> dict[str, typing.Any]:
     from mnemo_mcp.setup_tool import run_warmup
 
     result = await run_warmup()
-    return _json(result)
+    return result
 
 
-async def _handle_config_setup_sync() -> str:
+async def _handle_config_setup_sync() -> dict[str, typing.Any]:
     from mnemo_mcp.setup_tool import run_setup_sync
 
     result = await run_setup_sync()
-    return _json(result)
+    return result
 
 
-async def _handle_config_setup_status() -> str:
+async def _handle_config_setup_status() -> dict[str, typing.Any]:
     from mcp_core.storage.per_plugin_store import PerPluginStore
 
     from mnemo_mcp.credential_state import (
@@ -1912,72 +1854,62 @@ async def _handle_config_setup_status() -> str:
         _derived_state = "setup_in_progress"
     else:
         _derived_state = "awaiting_setup"
-    return _json(
-        {
-            "state": _derived_state,
-            "setup_url": get_setup_url(),
-            "cloud_keys_in_env": [k for k in _env_keys if k in CLOUD_KEYS],
-            "providers_configured": _providers,
-        }
-    )
+    return {
+        "state": _derived_state,
+        "setup_url": get_setup_url(),
+        "cloud_keys_in_env": [k for k in _env_keys if k in CLOUD_KEYS],
+        "providers_configured": _providers,
+    }
 
 
-async def _handle_config_setup_start(key: str | None) -> str:
+async def _handle_config_setup_start(key: str | None) -> dict[str, typing.Any]:
     from mnemo_mcp.credential_state import CredentialState, get_state
 
     if get_state() == CredentialState.CONFIGURED and not (
         key and key.lower() == "force"
     ):
-        return _json(
-            {
-                "status": "already_configured",
-                "message": "Already configured. Use key='force' to reconfigure.",
-            }
-        )
-    return _json(
-        {
-            "status": "stdio_unsupported",
-            "message": (
-                "Setup form is only available in HTTP mode. Run mnemo-mcp "
-                "with --http (or MCP_TRANSPORT=http) and visit /authorize to "
-                "configure API keys via browser. In stdio mode, set env vars "
-                "directly (JINA_AI_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, "
-                "COHERE_API_KEY, GOOGLE_DRIVE_CLIENT_ID)."
-            ),
+        return {
+            "status": "already_configured",
+            "message": "Already configured. Use key='force' to reconfigure.",
         }
-    )
+    return {
+        "status": "stdio_unsupported",
+        "message": (
+            "Setup form is only available in HTTP mode. Run mnemo-mcp "
+            "with --http (or MCP_TRANSPORT=http) and visit /authorize to "
+            "configure API keys via browser. In stdio mode, set env vars "
+            "directly (JINA_AI_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, "
+            "COHERE_API_KEY, GOOGLE_DRIVE_CLIENT_ID)."
+        ),
+    }
 
 
-async def _handle_config_setup_skip() -> str:
+async def _handle_config_setup_skip() -> dict[str, typing.Any]:
     from mcp_core import set_local_mode
 
     from mnemo_mcp.credential_state import CredentialState, set_state
 
     set_local_mode("mnemo-mcp")
     set_state(CredentialState.LOCAL)
-    return _json(
-        {
-            "status": "ok",
-            "message": "Local mode set. Relay will not trigger on restart.",
-        }
-    )
+    return {
+        "status": "ok",
+        "message": "Local mode set. Relay will not trigger on restart.",
+    }
 
 
-async def _handle_config_setup_reset() -> str:
+async def _handle_config_setup_reset() -> dict[str, typing.Any]:
     from mnemo_mcp.credential_state import reset_state
 
     reset_state()
-    return _json(
-        {
-            "status": "ok",
-            "message": "Credentials cleared. Next tool call will offer setup.",
-        }
-    )
+    return {
+        "status": "ok",
+        "message": "Credentials cleared. Next tool call will offer setup.",
+    }
 
 
 async def _handle_config_setup_complete(
     ctx: Context | None,
-) -> str:
+) -> dict[str, typing.Any]:
     from mnemo_mcp.credential_state import (
         CredentialState,
         get_state,
@@ -1995,16 +1927,14 @@ async def _handle_config_setup_complete(
         mode = settings.setup_providers()
         await _init_embedding_backend(mode, lc)
 
-    return _json(
-        {
-            "status": "ok",
-            "state": state.value,
-            "message": "Credential state refreshed.",
-        }
-    )
+    return {
+        "status": "ok",
+        "state": state.value,
+        "message": "Credential state refreshed.",
+    }
 
 
-async def _handle_config_setup_relay() -> str:
+async def _handle_config_setup_relay() -> dict[str, typing.Any]:
     # Backward compat alias for setup_start.
     return await _handle_config_setup_start(key="force")
 
@@ -2049,61 +1979,55 @@ def _resolve_default_backend() -> str:
     return resolve_active_backend()
 
 
-async def _handle_config_sync_now(ctx: Context | None, backend: str | None) -> str:
+async def _handle_config_sync_now(
+    ctx: Context | None, backend: str | None
+) -> dict[str, typing.Any]:
     """``config(action="sync_now")`` - delta push (or full-pull-push on gap)."""
     db, _, _ = _get_ctx(ctx)
     passphrase = _resolve_sync_passphrase()
     if not passphrase:
-        return _json(
-            {
-                "error": "SYNC_PASSPHRASE not set",
-                "hint": (
-                    "Set SYNC_PASSPHRASE env var (stdio mode) or submit "
-                    "the relay form passphrase field (HTTP mode) before "
-                    "triggering passport sync."
-                ),
-                "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
-            }
-        )
+        return {
+            "error": "SYNC_PASSPHRASE not set",
+            "hint": (
+                "Set SYNC_PASSPHRASE env var (stdio mode) or submit "
+                "the relay form passphrase field (HTTP mode) before "
+                "triggering passport sync."
+            ),
+            "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
+        }
 
     target = (backend or _resolve_default_backend()).strip()
     try:
         from mnemo_mcp.sync.delta import sync_now
 
         result = await sync_now(db, target, passphrase)
-        return _json({"backend": target, **result})
+        return {"backend": target, **result}
     except KeyError as e:
-        return _json(
-            {
-                "error": str(e),
-                "suggestion": "Check if backend configuration is complete.",
-            }
-        )
+        return {
+            "error": str(e),
+            "suggestion": "Check if backend configuration is complete.",
+        }
     except Exception as e:
         logger.exception("sync_now failed")
-        return _json(
-            {
-                "error": f"sync_now failed: {e}",
-                "suggestion": "Check network connectivity and provider credentials.",
-            }
-        )
+        return {
+            "error": f"sync_now failed: {e}",
+            "suggestion": "Check network connectivity and provider credentials.",
+        }
 
 
-async def _handle_config_export_passport(ctx: Context | None) -> str:
+async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typing.Any]:
     """``config(action="export_passport")`` - write encrypted passport file."""
     db, _, _ = _get_ctx(ctx)
     passphrase = _resolve_sync_passphrase()
     if not passphrase:
-        return _json(
-            {
-                "error": "SYNC_PASSPHRASE not set",
-                "hint": (
-                    "Set SYNC_PASSPHRASE env var or submit the relay form "
-                    "passphrase before exporting a passport."
-                ),
-                "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
-            }
-        )
+        return {
+            "error": "SYNC_PASSPHRASE not set",
+            "hint": (
+                "Set SYNC_PASSPHRASE env var or submit the relay form "
+                "passphrase before exporting a passport."
+            ),
+            "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
+        }
 
     from mnemo_mcp.sync.delta import build_full_bundle
 
@@ -2112,26 +2036,24 @@ async def _handle_config_export_passport(ctx: Context | None) -> str:
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"passport-{int(__import__('time').time())}.mnemo"
     await asyncio.to_thread(path.write_bytes, bundle)
-    return _json({"status": "exported", "path": str(path), "size": len(bundle)})
+    return {"status": "exported", "path": str(path), "size": len(bundle)}
 
 
 async def _handle_config_import_passport(
     ctx: Context | None, source: str | None
-) -> str:
+) -> dict[str, typing.Any]:
     """``config(action="import_passport", from="s3"|"gdrive")``."""
     db, _, _ = _get_ctx(ctx)
     passphrase = _resolve_sync_passphrase()
     if not passphrase:
-        return _json(
-            {
-                "error": "SYNC_PASSPHRASE not set",
-                "hint": (
-                    "Set SYNC_PASSPHRASE env var or submit the relay form "
-                    "passphrase before importing a passport."
-                ),
-                "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
-            }
-        )
+        return {
+            "error": "SYNC_PASSPHRASE not set",
+            "hint": (
+                "Set SYNC_PASSPHRASE env var or submit the relay form "
+                "passphrase before importing a passport."
+            ),
+            "suggestion": "Provide the SYNC_PASSPHRASE environment variable or use the HTTP setup form.",
+        }
 
     target = (source or _resolve_default_backend()).strip()
     try:
@@ -2141,47 +2063,41 @@ async def _handle_config_import_passport(
         backend = get_backend(target)
         bundle = await backend.pull(sequence=None)
     except KeyError as e:
-        return _json(
-            {
-                "error": str(e),
-                "suggestion": "Ensure the specified backend is properly configured.",
-            }
-        )
+        return {
+            "error": str(e),
+            "suggestion": "Ensure the specified backend is properly configured.",
+        }
     except Exception as e:
         logger.exception("import_passport: backend pull failed")
-        return _json(
-            {
-                "error": f"backend pull failed: {e}",
-                "suggestion": "Verify remote backend access and network connectivity.",
-            }
-        )
+        return {
+            "error": f"backend pull failed: {e}",
+            "suggestion": "Verify remote backend access and network connectivity.",
+        }
 
     if not bundle:
-        return _json(
-            {
-                "status": "no_passport",
-                "backend": target,
-                "message": "No passport bundle found on backend.",
-            }
-        )
+        return {
+            "status": "no_passport",
+            "backend": target,
+            "message": "No passport bundle found on backend.",
+        }
 
     try:
         result = await apply_bundle(db, bundle, passphrase)
     except Exception as e:
         logger.exception("import_passport: apply_bundle failed")
-        return _json(
-            {
-                "error": "Passphrase mismatch or tampered bundle",
-                "detail": f"{type(e).__name__}: {e}",
-                "backend": target,
-                "suggestion": "Verify the passphrase matches the one used to export the passport bundle and that the bundle has not been modified.",
-            }
-        )
+        return {
+            "error": "Passphrase mismatch or tampered bundle",
+            "detail": f"{type(e).__name__}: {e}",
+            "backend": target,
+            "suggestion": "Verify the passphrase matches the one used to export the passport bundle and that the bundle has not been modified.",
+        }
 
-    return _json({"status": "imported", "backend": target, **result})
+    return {"status": "imported", "backend": target, **result}
 
 
-async def _handle_memory_compress(ctx: Context | None, memory_id: str | None) -> str:
+async def _handle_memory_compress(
+    ctx: Context | None, memory_id: str | None
+) -> dict[str, typing.Any]:
     """``memory(action="compress", memory_id=...)`` - manual compression.
 
     Reruns the LLM compression pipeline against an existing row whose
@@ -2192,41 +2108,33 @@ async def _handle_memory_compress(ctx: Context | None, memory_id: str | None) ->
     """
     db, _, _ = _get_ctx(ctx)
     if not memory_id:
-        return _json(
-            {
-                "error": "memory_id required for compress",
-                "suggestion": "Pass memory_id from search/list results.",
-            }
-        )
+        return {
+            "error": "memory_id required for compress",
+            "suggestion": "Pass memory_id from search/list results.",
+        }
 
     row = await asyncio.to_thread(db.get, memory_id)
     if not row:
-        return _json(
-            {
-                "error": f"Memory {memory_id} not found",
-                "suggestion": "Verify the memory_id using action='search' or action='list'.",
-            }
-        )
+        return {
+            "error": f"Memory {memory_id} not found",
+            "suggestion": "Verify the memory_id using action='search' or action='list'.",
+        }
     if row.get("compressed"):
-        return _json(
-            {
-                "status": "already_compressed",
-                "id": memory_id,
-                "compression_provider": row.get("compression_provider"),
-            }
-        )
+        return {
+            "status": "already_compressed",
+            "id": memory_id,
+            "compression_provider": row.get("compression_provider"),
+        }
 
     from mnemo_mcp.compression import compress
 
     result = await compress(row["content"])
     if not result["compressed"]:
-        return _json(
-            {
-                "status": "skipped",
-                "id": memory_id,
-                "reason": "no LLM provider available or compression disabled",
-            }
-        )
+        return {
+            "status": "skipped",
+            "id": memory_id,
+            "reason": "no LLM provider available or compression disabled",
+        }
 
     cursor = db._conn.cursor()
     cursor.execute(
@@ -2241,15 +2149,13 @@ async def _handle_memory_compress(ctx: Context | None, memory_id: str | None) ->
         ),
     )
     db._conn.commit()
-    return _json(
-        {
-            "status": "compressed",
-            "id": memory_id,
-            "compression_provider": result["compression_provider"],
-            "tokens_in": result["tokens_in"],
-            "tokens_out": result["tokens_out"],
-        }
-    )
+    return {
+        "status": "compressed",
+        "id": memory_id,
+        "compression_provider": result["compression_provider"],
+        "tokens_in": result["tokens_in"],
+        "tokens_out": result["tokens_out"],
+    }
 
 
 @mcp.tool(
@@ -2316,7 +2222,7 @@ register_open_relay_tool(mcp, "mnemo-mcp", os.environ.get("PUBLIC_URL"))
 @mcp.resource("mnemo://stats")
 async def stats_resource(ctx: Context | None = None) -> str:
     """Database statistics and server status."""
-    return await _handle_stats(ctx)
+    return _json(await _handle_stats(ctx))
 
 
 # --- Prompts ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,20 @@ pytest_plugins = ["conftest_e2e"]
 
 
 @pytest.fixture(autouse=True)
+def _never_open_a_real_browser(monkeypatch):
+    """Keep the GDrive device-code path from hijacking the developer's browser.
+
+    ``credential_state._trigger_gdrive_device_code`` calls ``try_open_browser``
+    on the verification URL. Newer mcp-core honours ``MCP_NO_BROWSER``, but the
+    import is lazy and older installs lack that guard, so patch the symbol too.
+    Tests that assert on the launch patch ``mcp_core.try_open_browser``
+    themselves, which shadows this fixture.
+    """
+    monkeypatch.setenv("MCP_NO_BROWSER", "1")
+    monkeypatch.setattr("mcp_core.try_open_browser", lambda url: False, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_per_plugin_home(tmp_path_factory, monkeypatch):
     """Redirect ~/ to a per-test tmp dir so PerPluginStore writes don't
     pollute real ~/.mnemo-mcp/ between test runs (or worse, between

--- a/tests/temporal/test_server_kg_handlers.py
+++ b/tests/temporal/test_server_kg_handlers.py
@@ -3,7 +3,6 @@ history dispatch + memory() routing."""
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock
 
 from mnemo_mcp.db import MemoryDB
@@ -46,7 +45,7 @@ class TestEntitySearchHandler:
     async def test_missing_name_returns_error(self, tmp_db: MemoryDB):
         ctx = _make_ctx(tmp_db)
         result = await _handle_entity_search(ctx, name=None, entity_type=None)
-        data = json.loads(result)
+        data = result
         assert "error" in data
         assert "name" in data["error"].lower()
 
@@ -54,7 +53,7 @@ class TestEntitySearchHandler:
         _seed_kg(tmp_db, "FastAPI is fast", [{"name": "FastAPI", "type": "tool"}])
         ctx = _make_ctx(tmp_db)
         result = await _handle_entity_search(ctx, name="FastAPI", entity_type=None)
-        data = json.loads(result)
+        data = result
         assert data["count"] == 1
         assert data["matched_name"] == "FastAPI"
 
@@ -63,7 +62,7 @@ class TestEntityGraphHandler:
     async def test_missing_anchor_returns_error(self, tmp_db: MemoryDB):
         ctx = _make_ctx(tmp_db)
         result = await _handle_entity_graph(ctx, entity_id=None, name=None)
-        data = json.loads(result)
+        data = result
         assert "error" in data
 
     async def test_returns_subgraph_for_known_anchor(self, tmp_db: MemoryDB):
@@ -80,7 +79,7 @@ class TestEntityGraphHandler:
         )
         ctx = _make_ctx(tmp_db)
         result = await _handle_entity_graph(ctx, entity_id=None, name="Alice")
-        data = json.loads(result)
+        data = result
         assert data["nodes"]
         assert data["edges"]
 
@@ -89,7 +88,7 @@ class TestHistoryHandler:
     async def test_missing_entity_id_returns_error(self, tmp_db: MemoryDB):
         ctx = _make_ctx(tmp_db)
         result = await _handle_history(ctx, entity_id=None)
-        data = json.loads(result)
+        data = result
         assert "error" in data
 
     async def test_returns_timeline(self, tmp_db: MemoryDB):
@@ -98,7 +97,7 @@ class TestHistoryHandler:
         eid = ents["Z"]
         ctx = _make_ctx(tmp_db)
         result = await _handle_history(ctx, entity_id=eid)
-        data = json.loads(result)
+        data = result
         assert data["entity_id"] == eid
         assert data["count"] == 2
 
@@ -108,14 +107,14 @@ class TestMemoryDispatchKGActions:
         _seed_kg(tmp_db, "About Python", [{"name": "Python", "type": "tool"}])
         ctx = _make_ctx(tmp_db)
         result = await memory(action="entity_search", name="Python", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert data["count"] == 1
 
     async def test_dispatch_entity_graph(self, tmp_db: MemoryDB):
         _seed_kg(tmp_db, "About Python", [{"name": "Python", "type": "tool"}])
         ctx = _make_ctx(tmp_db)
         result = await memory(action="entity_graph", name="Python", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "nodes" in data
         assert "edges" in data
 
@@ -123,13 +122,13 @@ class TestMemoryDispatchKGActions:
         _, ents = _seed_kg(tmp_db, "h1", [{"name": "EntH", "type": "concept"}])
         ctx = _make_ctx(tmp_db)
         result = await memory(action="history", entity_id=ents["EntH"], ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "timeline" in data
 
     async def test_unknown_action_lists_kg_actions(self, tmp_db: MemoryDB):
         ctx = _make_ctx(tmp_db)
         result = await memory(action="bogus_action_xyz", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "valid_actions" in data
         assert "entity_search" in data["valid_actions"]
         assert "entity_graph" in data["valid_actions"]

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -225,7 +225,6 @@ async def test_capture_does_not_unset_archived_at(tmp_db: MemoryDB):
 
 
 async def test_handle_archive_now_runs_archive_by_score(mock_ctx):
-    import json
 
     from mnemo_mcp.server import _handle_archive_now
 
@@ -235,7 +234,7 @@ async def test_handle_archive_now_runs_archive_by_score(mock_ctx):
     _set_age(db, mid, days_old=200)
 
     raw = await _handle_archive_now(ctx)
-    payload = json.loads(raw)
+    payload = raw
 
     assert payload["status"] == "archived"
     assert payload["count"] >= 1
@@ -243,7 +242,6 @@ async def test_handle_archive_now_runs_archive_by_score(mock_ctx):
 
 
 async def test_archive_now_via_memory_dispatcher(mock_ctx):
-    import json
 
     from mnemo_mcp.server import memory
 
@@ -253,7 +251,7 @@ async def test_archive_now_via_memory_dispatcher(mock_ctx):
     _set_age(db, mid, days_old=300)
 
     raw = await memory(action="archive_now", ctx=ctx)
-    payload = json.loads(raw)
+    payload = raw
 
     assert payload["status"] == "archived"
     assert payload["count"] >= 1
@@ -267,7 +265,6 @@ async def test_archive_now_via_memory_dispatcher(mock_ctx):
 
 async def test_capture_triggers_archive_at_interval(mock_ctx, monkeypatch):
     """ARCHIVE_TRIGGER_EVERY=1 -> every capture schedules an archive sweep."""
-    import json
 
     from mnemo_mcp.server import _CAPTURE_COUNTER, memory
 
@@ -282,7 +279,7 @@ async def test_capture_triggers_archive_at_interval(mock_ctx, monkeypatch):
     raw = await memory(
         action="capture", text="brand new note", context_type="fact", ctx=ctx
     )
-    payload = json.loads(raw)
+    payload = raw
     assert payload["status"] == "captured"
 
     # Background task may need a tick to land; await any scheduled tasks.

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -128,7 +128,7 @@ async def test_capture_passes_category_tags_source(tmp_db: MemoryDB):
 async def test_handle_capture_missing_text_returns_error(mock_ctx):
     ctx, _db = mock_ctx
     raw = await _handle_capture(ctx, text=None, context_type="fact")
-    payload = json.loads(raw)
+    payload = raw
 
     assert "error" in payload
     assert "text" in payload["error"]
@@ -137,7 +137,7 @@ async def test_handle_capture_missing_text_returns_error(mock_ctx):
 async def test_handle_capture_invalid_context_type_returns_error(mock_ctx):
     ctx, _db = mock_ctx
     raw = await _handle_capture(ctx, text="something", context_type="not-real")
-    payload = json.loads(raw)
+    payload = raw
 
     assert "error" in payload
     assert "valid_context_types" in payload
@@ -147,7 +147,7 @@ async def test_handle_capture_invalid_context_type_returns_error(mock_ctx):
 async def test_handle_capture_invalid_context_type_fuzzy_matching(mock_ctx):
     ctx, _db = mock_ctx
     raw = await _handle_capture(ctx, text="something", context_type="prefernnce")
-    payload = json.loads(raw)
+    payload = raw
 
     assert "error" in payload
     assert "suggestion" in payload
@@ -162,7 +162,7 @@ async def test_handle_capture_inserts_and_returns_id(mock_ctx):
         context_type="decision",
         category="architecture",
     )
-    payload = json.loads(raw)
+    payload = raw
 
     assert payload["status"] == "captured"
     assert payload["context_type"] == "decision"
@@ -177,8 +177,8 @@ async def test_handle_capture_dedup_returns_status_deduplicated(mock_ctx):
     ctx, _db = mock_ctx
 
     text = "All API errors return JSON with code, message, and request_id"
-    first = json.loads(await _handle_capture(ctx, text=text, context_type="decision"))
-    second = json.loads(await _handle_capture(ctx, text=text, context_type="decision"))
+    first = await _handle_capture(ctx, text=text, context_type="decision")
+    second = await _handle_capture(ctx, text=text, context_type="decision")
 
     assert first["status"] == "captured"
     assert second["status"] == "deduplicated"
@@ -229,7 +229,7 @@ async def test_handle_capture_oversized_text_returns_error(mock_ctx):
     huge = "x" * (MAX_CONTENT_LENGTH + 10)
 
     raw = await _handle_capture(ctx, text=huge, context_type="fact")
-    payload = json.loads(raw)
+    payload = raw
 
     assert "error" in payload
     assert "valid_context_types" not in payload
@@ -248,7 +248,7 @@ async def test_handle_capture_unexpected_exception_returns_internal_error(
 
     ctx, _db = mock_ctx
     raw = await _handle_capture(ctx, text="anything", context_type="fact")
-    payload = json.loads(raw)
+    payload = raw
 
     assert "error" in payload
     assert "Internal error" in payload["error"]

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -9,7 +9,6 @@ load + env, and always includes providers_configured in the response.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -23,7 +22,7 @@ def _call_config_setup_status_sync() -> dict[str, Any]:
     from mnemo_mcp.server import _handle_config_setup_status
 
     raw = asyncio.run(_handle_config_setup_status())
-    return json.loads(raw)
+    return raw
 
 
 class TestSetupStatusLiveDerivedState:

--- a/tests/test_passport_actions.py
+++ b/tests/test_passport_actions.py
@@ -14,7 +14,6 @@ Covers:
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -87,7 +86,7 @@ async def test_sync_now_returns_error_without_passphrase(
 ) -> None:
     ctx = _make_ctx(isolated_db)
     raw = await _handle_config_sync_now(ctx, backend="s3")
-    payload = json.loads(raw)
+    payload = raw
     assert "error" in payload
     assert "SYNC_PASSPHRASE" in payload["error"]
 
@@ -115,7 +114,7 @@ async def test_sync_now_delta_push_end_to_end(
 
         ctx = _make_ctx(isolated_db)
         raw = await _handle_config_sync_now(ctx, backend="s3")
-        payload = json.loads(raw)
+        payload = raw
 
     assert payload["backend"] == "s3"
     assert payload["mode"] == "delta"
@@ -129,7 +128,7 @@ async def test_sync_now_unknown_backend(
     monkeypatch.setenv("SYNC_PASSPHRASE", "test-pass")
     ctx = _make_ctx(isolated_db)
     raw = await _handle_config_sync_now(ctx, backend="nonexistent")
-    payload = json.loads(raw)
+    payload = raw
     assert "error" in payload
     assert "nonexistent" in payload["error"]
 
@@ -158,7 +157,7 @@ async def test_export_passport_writes_file(
 
     ctx = _make_ctx(isolated_db)
     raw = await _handle_config_export_passport(ctx)
-    payload = json.loads(raw)
+    payload = raw
 
     assert payload["status"] == "exported"
     assert payload["size"] > 0
@@ -172,7 +171,7 @@ async def test_export_passport_requires_passphrase(
 ) -> None:
     ctx = _make_ctx(isolated_db)
     raw = await _handle_config_export_passport(ctx)
-    payload = json.loads(raw)
+    payload = raw
     assert "error" in payload
     assert "SYNC_PASSPHRASE" in payload["error"]
 
@@ -187,7 +186,7 @@ async def test_import_passport_requires_passphrase(
 ) -> None:
     ctx = _make_ctx(isolated_db)
     raw = await _handle_config_import_passport(ctx, source="s3")
-    payload = json.loads(raw)
+    payload = raw
     assert "error" in payload
     assert "SYNC_PASSPHRASE" in payload["error"]
 
@@ -210,7 +209,7 @@ async def test_import_passport_no_bundle_returns_status(
 
         ctx = _make_ctx(isolated_db)
         raw = await _handle_config_import_passport(ctx, source="s3")
-        payload = json.loads(raw)
+        payload = raw
 
     assert payload["status"] == "no_passport"
     assert payload["backend"] == "s3"
@@ -250,7 +249,7 @@ async def test_import_passport_round_trip(
 
         ctx = _make_ctx(isolated_db)
         raw = await _handle_config_import_passport(ctx, source="s3")
-        payload = json.loads(raw)
+        payload = raw
 
     assert payload["status"] == "imported"
     assert payload["inserted"] == 1
@@ -283,7 +282,7 @@ async def test_memory_compress_rewrites_existing_row(
     with patch("mnemo_mcp.compression.call_llm", side_effect=_fake_call):
         raw = await _handle_memory_compress(ctx, memory_id="a")
 
-    payload = json.loads(raw)
+    payload = raw
     assert payload["status"] == "compressed"
     assert payload["compression_provider"] == "gemini"
 
@@ -308,7 +307,7 @@ async def test_memory_compress_no_provider_returns_skipped(
 
     ctx = _make_ctx(isolated_db)
     raw = await _handle_memory_compress(ctx, memory_id="a")
-    payload = json.loads(raw)
+    payload = raw
     assert payload["status"] == "skipped"
 
 
@@ -325,7 +324,7 @@ async def test_memory_compress_already_compressed_noops(
 
     ctx = _make_ctx(isolated_db)
     raw = await _handle_memory_compress(ctx, memory_id="a")
-    payload = json.loads(raw)
+    payload = raw
     assert payload["status"] == "already_compressed"
     assert payload["compression_provider"] == "gemini"
 
@@ -333,7 +332,7 @@ async def test_memory_compress_already_compressed_noops(
 async def test_memory_compress_missing_id_errors(isolated_db: MemoryDB) -> None:
     ctx = _make_ctx(isolated_db)
     raw = await _handle_memory_compress(ctx, memory_id=None)
-    payload = json.loads(raw)
+    payload = raw
     assert "error" in payload
     assert "memory_id" in payload["error"]
 
@@ -341,7 +340,7 @@ async def test_memory_compress_missing_id_errors(isolated_db: MemoryDB) -> None:
 async def test_memory_compress_unknown_id_errors(isolated_db: MemoryDB) -> None:
     ctx = _make_ctx(isolated_db)
     raw = await _handle_memory_compress(ctx, memory_id="nonexistent")
-    payload = json.loads(raw)
+    payload = raw
     assert "error" in payload
     assert "not found" in payload["error"]
 
@@ -361,7 +360,7 @@ async def test_sync_now_propagates_unexpected_error(
         ctx = _make_ctx(isolated_db)
         raw = await _handle_config_sync_now(ctx, backend="gdrive")
 
-    payload = json.loads(raw)
+    payload = raw
     assert "error" in payload
     assert "sync_now failed" in payload["error"]
 
@@ -398,7 +397,7 @@ async def test_import_passport_decryption_failure(
 
         ctx = _make_ctx(isolated_db)
         raw = await _handle_config_import_passport(ctx, source="s3")
-        payload = json.loads(raw)
+        payload = raw
 
     assert "error" in payload
     assert "Passphrase mismatch" in payload["error"]
@@ -431,7 +430,7 @@ async def test_import_passport_pull_exception(
 
     ctx = _make_ctx(isolated_db)
     raw = await _handle_config_import_passport(ctx, source="s3")
-    payload = json.loads(raw)
+    payload = raw
 
     assert "error" in payload
     assert "backend pull failed" in payload["error"]

--- a/tests/test_save_credentials_single_user.py
+++ b/tests/test_save_credentials_single_user.py
@@ -188,3 +188,17 @@ class TestSaveCredentialsSingleUserWithGDrive:
 
         assert result is None
         cleanup.assert_called_once()
+
+
+def test_conftest_blocks_real_browser_launch():
+    """The autouse fixture must neutralise try_open_browser for the whole suite.
+
+    Regression guard: the GDrive device-code path used to open a real tab in the
+    developer's browser on every unmocked test run.
+    """
+    import os
+
+    import mcp_core
+
+    assert os.environ.get("MCP_NO_BROWSER") == "1"
+    assert mcp_core.try_open_browser("https://example.com/device") is False

--- a/tests/test_security_log_level.py
+++ b/tests/test_security_log_level.py
@@ -58,8 +58,8 @@ async def test_log_level_invalid_rejection(mock_dependencies):
                 result = await server.config(
                     action="set", key="log_level", value="INVALID_LEVEL"
                 )
-                assert '"error":' in result
-                assert "Invalid log level" in result
+                assert "error" in result
+                assert "Invalid log level" in result["error"]
                 mock_logger.remove.assert_not_called()
                 mock_logger.add.assert_not_called()
 
@@ -77,6 +77,6 @@ async def test_log_level_valid_update(mock_dependencies):
                 result = await server.config(
                     action="set", key="log_level", value="DEBUG"
                 )
-                assert '"status":"updated"' in result
+                assert result["status"] == "updated"
                 mock_logger.remove.assert_called_once()
                 mock_logger.add.assert_called_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,21 +54,19 @@ def ctx_with_db(tmp_path: Path) -> Generator[tuple[MagicMock, MemoryDB]]:
 class TestMemoryAdd:
     async def test_add(self, ctx_with_db):
         ctx, db = ctx_with_db
-        result = json.loads(await memory(action="add", content="test memory", ctx=ctx))
+        result = await memory(action="add", content="test memory", ctx=ctx)
         assert result["status"] == "saved"
         assert result["id"]
         assert result["semantic"] is False
 
     async def test_add_with_category(self, ctx_with_db):
         ctx, db = ctx_with_db
-        result = json.loads(
-            await memory(
-                action="add",
-                content="test",
-                category="work",
-                tags=["urgent"],
-                ctx=ctx,
-            )
+        result = await memory(
+            action="add",
+            content="test",
+            category="work",
+            tags=["urgent"],
+            ctx=ctx,
         )
         assert result["category"] == "work"
         mem = db.get(result["id"])
@@ -77,18 +75,16 @@ class TestMemoryAdd:
 
     async def test_add_no_content(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="add", ctx=ctx))
+        result = await memory(action="add", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
     async def test_add_exceeds_content_length(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await memory(
-                action="add",
-                content="x" * (MAX_CONTENT_LENGTH + 1),
-                ctx=ctx,
-            )
+        result = await memory(
+            action="add",
+            content="x" * (MAX_CONTENT_LENGTH + 1),
+            ctx=ctx,
         )
         assert "error" in result
         assert "exceeds limit" in result["error"]
@@ -98,7 +94,7 @@ class TestMemorySearch:
     async def test_search(self, ctx_with_db):
         ctx, db = ctx_with_db
         db.add("Python is great for AI and machine learning")
-        result = json.loads(await memory(action="search", query="Python AI", ctx=ctx))
+        result = await memory(action="search", query="Python AI", ctx=ctx)
         assert result["count"] > 0
         assert result["semantic"] is False
         # Tags should be parsed list, not JSON string
@@ -109,7 +105,7 @@ class TestMemorySearch:
 
     async def test_search_no_query(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="search", ctx=ctx))
+        result = await memory(action="search", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
@@ -117,13 +113,11 @@ class TestMemorySearch:
         ctx, db = ctx_with_db
         db.add("Python tip", category="tech", tags=["python"])
         db.add("Python recipe", category="food", tags=["cooking"])
-        result = json.loads(
-            await memory(
-                action="search",
-                query="Python",
-                category="tech",
-                ctx=ctx,
-            )
+        result = await memory(
+            action="search",
+            query="Python",
+            category="tech",
+            ctx=ctx,
         )
         assert all(r["category"] == "tech" for r in result["results"])
 
@@ -133,7 +127,7 @@ class TestMemoryList:
         ctx, db = ctx_with_db
         db.add("mem1", tags=["a", "b"])
         db.add("mem2")
-        result = json.loads(await memory(action="list", ctx=ctx))
+        result = await memory(action="list", ctx=ctx)
         assert result["count"] == 2
         # Tags should be parsed lists
         for r in result["results"]:
@@ -143,7 +137,7 @@ class TestMemoryList:
         ctx, db = ctx_with_db
         db.add("a", category="x")
         db.add("b", category="y")
-        result = json.loads(await memory(action="list", category="x", ctx=ctx))
+        result = await memory(action="list", category="x", ctx=ctx)
         assert result["count"] == 1
 
 
@@ -151,13 +145,11 @@ class TestMemoryUpdate:
     async def test_update(self, ctx_with_db):
         ctx, db = ctx_with_db
         mid = db.add("original")
-        result = json.loads(
-            await memory(
-                action="update",
-                memory_id=mid,
-                content="updated",
-                ctx=ctx,
-            )
+        result = await memory(
+            action="update",
+            memory_id=mid,
+            content="updated",
+            ctx=ctx,
         )
         assert result["status"] == "updated"
         mem = db.get(mid)
@@ -166,32 +158,28 @@ class TestMemoryUpdate:
 
     async def test_update_no_id(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="update", content="x", ctx=ctx))
+        result = await memory(action="update", content="x", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
     async def test_update_nonexistent(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await memory(
-                action="update",
-                memory_id="fake123",
-                content="x",
-                ctx=ctx,
-            )
+        result = await memory(
+            action="update",
+            memory_id="fake123",
+            content="x",
+            ctx=ctx,
         )
         assert "error" in result
 
     async def test_update_exceeds_content_length(self, ctx_with_db):
         ctx, db = ctx_with_db
         mid = db.add("original")
-        result = json.loads(
-            await memory(
-                action="update",
-                memory_id=mid,
-                content="x" * (MAX_CONTENT_LENGTH + 1),
-                ctx=ctx,
-            )
+        result = await memory(
+            action="update",
+            memory_id=mid,
+            content="x" * (MAX_CONTENT_LENGTH + 1),
+            ctx=ctx,
         )
         assert "error" in result
         assert "exceeds limit" in result["error"]
@@ -205,24 +193,22 @@ class TestMemoryDelete:
     async def test_delete(self, ctx_with_db):
         ctx, db = ctx_with_db
         mid = db.add("to delete")
-        result = json.loads(await memory(action="delete", memory_id=mid, ctx=ctx))
+        result = await memory(action="delete", memory_id=mid, ctx=ctx)
         assert result["status"] == "deleted"
         assert db.get(mid) is None
 
     async def test_delete_no_id(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="delete", ctx=ctx))
+        result = await memory(action="delete", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
     async def test_delete_nonexistent(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await memory(
-                action="delete",
-                memory_id="fake123",
-                ctx=ctx,
-            )
+        result = await memory(
+            action="delete",
+            memory_id="fake123",
+            ctx=ctx,
         )
         assert "error" in result
 
@@ -232,20 +218,20 @@ class TestMemoryExportImport:
         ctx, db = ctx_with_db
         db.add("mem1")
         db.add("mem2")
-        result = json.loads(await memory(action="export", ctx=ctx))
+        result = await memory(action="export", ctx=ctx)
         assert result["format"] == "jsonl"
         assert result["count"] == 2
 
     async def test_import(self, ctx_with_db):
         ctx, _ = ctx_with_db
         data = json.dumps({"id": "imp1", "content": "imported"})
-        result = json.loads(await memory(action="import", data=data, ctx=ctx))
+        result = await memory(action="import", data=data, ctx=ctx)
         assert result["status"] == "imported"
         assert result["imported"] == 1
 
     async def test_import_no_data(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="import", ctx=ctx))
+        result = await memory(action="import", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
@@ -254,14 +240,14 @@ class TestMemoryStats:
     async def test_stats(self, ctx_with_db):
         ctx, db = ctx_with_db
         db.add("test")
-        result = json.loads(await memory(action="stats", ctx=ctx))
+        result = await memory(action="stats", ctx=ctx)
         assert result["total_memories"] == 1
         assert "embedding_model" in result
         assert "sync_enabled" in result
 
     async def test_stats_empty(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="stats", ctx=ctx))
+        result = await memory(action="stats", ctx=ctx)
         assert result["total_memories"] == 0
 
 
@@ -280,7 +266,7 @@ class TestMemoryRestore:
         assert archived is not None
         assert archived["archived_at"] is not None
 
-        result = json.loads(await memory(action="restore", memory_id=mid, ctx=ctx))
+        result = await memory(action="restore", memory_id=mid, ctx=ctx)
         assert result["status"] == "restored"
         restored = db.get(mid)
         assert restored is not None
@@ -288,22 +274,20 @@ class TestMemoryRestore:
 
     async def test_restore_no_id(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="restore", ctx=ctx))
+        result = await memory(action="restore", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
     async def test_restore_nonexistent(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await memory(action="restore", memory_id="fake123", ctx=ctx)
-        )
+        result = await memory(action="restore", memory_id="fake123", ctx=ctx)
         assert "error" in result
 
 
 class TestMemoryArchived:
     async def test_archived_empty(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="archived", ctx=ctx))
+        result = await memory(action="archived", ctx=ctx)
         assert result["count"] == 0
         assert result["results"] == []
 
@@ -317,7 +301,7 @@ class TestMemoryArchived:
         db._conn.commit()
         db.archive_old_memories(days=90, importance_threshold=0.3)
 
-        result = json.loads(await memory(action="archived", ctx=ctx))
+        result = await memory(action="archived", ctx=ctx)
         assert result["count"] == 1
         assert result["results"][0]["id"] == mid
 
@@ -333,7 +317,7 @@ class TestMemoryConsolidate:
             patch("mnemo_mcp.graph._has_llm_provider", return_value=False),
         ):
             mock_settings.resolve_provider_mode.return_value = "local"
-            result = json.loads(await _handle_consolidate(ctx, "tech"))
+            result = await _handle_consolidate(ctx, "tech")
         assert "error" in result
         assert "LLM" in result["error"]
 
@@ -341,7 +325,7 @@ class TestMemoryConsolidate:
         ctx, _ = ctx_with_db
         with patch("mnemo_mcp.server.settings") as mock_settings:
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            result = json.loads(await memory(action="consolidate", ctx=ctx))
+            result = await memory(action="consolidate", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
@@ -349,7 +333,7 @@ class TestMemoryConsolidate:
 class TestMemoryUnknownAction:
     async def test_unknown_action(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await memory(action="invalid", ctx=ctx))
+        result = await memory(action="invalid", ctx=ctx)
         assert "error" in result
         assert "valid_actions" in result
         assert "add" in result["valid_actions"]
@@ -360,7 +344,7 @@ class TestMemoryUnknownAction:
 class TestConfigTool:
     async def test_status(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await config(action="status", ctx=ctx))
+        result = await config(action="status", ctx=ctx)
         assert "database" in result
         assert "embedding" in result
         assert "sync" in result
@@ -368,38 +352,32 @@ class TestConfigTool:
 
     async def test_set_sync_folder_rejected(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(
-                action="set",
-                key="sync_folder",
-                value="new-folder",
-                ctx=ctx,
-            )
+        result = await config(
+            action="set",
+            key="sync_folder",
+            value="new-folder",
+            ctx=ctx,
         )
         assert "error" in result
         assert "valid_keys" in result
 
     async def test_set_sync_enabled(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(
-                action="set",
-                key="sync_enabled",
-                value="true",
-                ctx=ctx,
-            )
+        result = await config(
+            action="set",
+            key="sync_enabled",
+            value="true",
+            ctx=ctx,
         )
         assert result["status"] == "updated"
 
     async def test_set_invalid_key(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(
-                action="set",
-                key="invalid_key",
-                value="x",
-                ctx=ctx,
-            )
+        result = await config(
+            action="set",
+            key="invalid_key",
+            value="x",
+            ctx=ctx,
         )
         assert "error" in result
         assert "valid_keys" in result
@@ -408,13 +386,11 @@ class TestConfigTool:
 
     async def test_set_invalid_key_fuzzy(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(
-                action="set",
-                key="sync_enable",
-                value="x",
-                ctx=ctx,
-            )
+        result = await config(
+            action="set",
+            key="sync_enable",
+            value="x",
+            ctx=ctx,
         )
         assert "error" in result
         assert "suggestion" in result
@@ -422,13 +398,13 @@ class TestConfigTool:
 
     async def test_set_missing_params(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await config(action="set", ctx=ctx))
+        result = await config(action="set", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
 
     async def test_unknown_action(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(await config(action="invalid", ctx=ctx))
+        result = await config(action="invalid", ctx=ctx)
         assert "error" in result
         assert "valid_actions" in result
         assert "suggestion" in result
@@ -437,7 +413,7 @@ class TestConfigTool:
     async def test_models_action_removed(self, ctx_with_db):
         """The 'models' catalog-listing action no longer exists."""
         ctx, _ = ctx_with_db
-        result = json.loads(await config(action="models", ctx=ctx))
+        result = await config(action="models", ctx=ctx)
         assert "Unknown action 'models'" in result["error"]
         assert "models" not in result["valid_actions"]
 
@@ -467,14 +443,14 @@ class TestHelpTool:
 
 class TestNoneActionHandling:
     async def test_memory_none_action(self):
-        result = json.loads(await memory(action=None))
+        result = await memory(action=None)
         assert "error" in result
         assert "Unknown action 'None'" in result["error"]
         assert "suggestion" in result
         assert "Available actions are:" in result["suggestion"]
 
     async def test_config_none_action(self):
-        result = json.loads(await config(action=None))
+        result = await config(action=None)
         assert "error" in result
         assert "Unknown action 'None'" in result["error"]
         assert "suggestion" in result
@@ -493,9 +469,7 @@ class TestDedupWarning:
             "check_duplicate",
             return_value={"similar": True, "match_id": "abc", "score": 0.85},
         ):
-            result = json.loads(
-                await _handle_add(ctx, "Python is excellent for ML", None, None)
-            )
+            result = await _handle_add(ctx, "Python is excellent for ML", None, None)
         assert result["status"] == "saved"
         assert "dedup_warning" in result
 
@@ -507,7 +481,7 @@ class TestDedupWarning:
             "check_duplicate",
             return_value={"duplicate": True, "match_id": "abc", "score": 0.99},
         ):
-            result = json.loads(await _handle_add(ctx, "exact duplicate", None, None))
+            result = await _handle_add(ctx, "exact duplicate", None, None)
         assert result["status"] == "saved"
         assert "dedup_warning" in result
 
@@ -515,7 +489,7 @@ class TestDedupWarning:
         """Cover lines 338-339: dedup exception is non-blocking."""
         ctx, db = ctx_with_db
         with patch.object(db, "check_duplicate", side_effect=RuntimeError("boom")):
-            result = json.loads(await _handle_add(ctx, "test content", None, None))
+            result = await _handle_add(ctx, "test content", None, None)
         assert result["status"] == "saved"
 
 
@@ -524,7 +498,7 @@ class TestHandleAddErrors:
         """Cover lines 352-354: unexpected exception in db.add."""
         ctx, db = ctx_with_db
         with patch.object(db, "add", side_effect=RuntimeError("unexpected")):
-            result = json.loads(await _handle_add(ctx, "test", None, None))
+            result = await _handle_add(ctx, "test", None, None)
         assert "error" in result
         assert "Internal error" in result["error"]
 
@@ -535,8 +509,8 @@ class TestHandleUpdateErrors:
         ctx, db = ctx_with_db
         mid = db.add("original")
         with patch.object(db, "update", side_effect=RuntimeError("unexpected")):
-            result = json.loads(
-                await _handle_update(ctx, mid, "new content", None, None, None, None)
+            result = await _handle_update(
+                ctx, mid, "new content", None, None, None, None
             )
         assert "error" in result
         assert "Internal error" in result["error"]
@@ -614,7 +588,7 @@ class TestSearchRerankerAndGraph:
         mock_reranker = MagicMock()
         mock_reranker.rerank.return_value = [(1, 0.95), (0, 0.85), (2, 0.70)]
         with patch("mnemo_mcp.reranker.get_reranker", return_value=mock_reranker):
-            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
+            result = await _handle_search(ctx, "Python", None, None, 5)
         assert result["reranked"] is True
         assert result["results"][0]["rerank_score"] == 0.95
 
@@ -626,7 +600,7 @@ class TestSearchRerankerAndGraph:
         mock_reranker = MagicMock()
         mock_reranker.rerank.side_effect = RuntimeError("rerank failed")
         with patch("mnemo_mcp.reranker.get_reranker", return_value=mock_reranker):
-            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
+            result = await _handle_search(ctx, "Python", None, None, 5)
         assert result["reranked"] is False
 
     async def test_search_with_graph_boost(self, ctx_with_db):
@@ -635,7 +609,7 @@ class TestSearchRerankerAndGraph:
         db.add("Python for AI")
         mid2 = db.add("Python for web development")
         with patch("mnemo_mcp.graph.find_related_memory_ids", return_value=[mid2]):
-            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
+            result = await _handle_search(ctx, "Python", None, None, 5)
         # At least one result should have graph_related
         related = [r for r in result["results"] if r.get("graph_related")]
         assert len(related) >= 1
@@ -648,7 +622,7 @@ class TestSearchRerankerAndGraph:
             "mnemo_mcp.graph.find_related_memory_ids",
             side_effect=RuntimeError("graph error"),
         ):
-            result = json.loads(await _handle_search(ctx, "Python", None, None, 5))
+            result = await _handle_search(ctx, "Python", None, None, 5)
         assert result["count"] > 0
 
 
@@ -658,7 +632,7 @@ class TestConsolidate:
         ctx, db = ctx_with_db
         with patch("mnemo_mcp.server.settings") as mock_settings:
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            result = json.loads(await _handle_consolidate(ctx, None))
+            result = await _handle_consolidate(ctx, None)
         assert "error" in result
         assert "category is required" in result["error"]
         assert "suggestion" in result
@@ -669,7 +643,7 @@ class TestConsolidate:
         db.add("only one", category="tech")
         with patch("mnemo_mcp.server.settings") as mock_settings:
             mock_settings.resolve_provider_mode.return_value = "sdk"
-            result = json.loads(await _handle_consolidate(ctx, "tech"))
+            result = await _handle_consolidate(ctx, "tech")
         assert "error" in result
         assert "at least 2" in result["error"]
 
@@ -689,7 +663,7 @@ class TestConsolidate:
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
             mock_settings.llm_models = "gpt-4o,gemini-flash"
-            result = json.loads(await _handle_consolidate(ctx, "tech"))
+            result = await _handle_consolidate(ctx, "tech")
 
         assert result["status"] == "consolidated"
         assert result["category"] == "tech"
@@ -711,7 +685,7 @@ class TestConsolidate:
         ):
             mock_settings.resolve_provider_mode.return_value = "sdk"
             mock_settings.llm_models = "gpt-4o"
-            result = json.loads(await _handle_consolidate(ctx, "tech"))
+            result = await _handle_consolidate(ctx, "tech")
         assert "error" in result
         assert "Consolidation failed" in result["error"]
 
@@ -719,23 +693,17 @@ class TestConsolidate:
 class TestConfigSet:
     async def test_set_sync_interval(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(action="set", key="sync_interval", value="600", ctx=ctx)
-        )
+        result = await config(action="set", key="sync_interval", value="600", ctx=ctx)
         assert result["status"] == "updated"
 
     async def test_set_log_level(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(action="set", key="log_level", value="DEBUG", ctx=ctx)
-        )
+        result = await config(action="set", key="log_level", value="DEBUG", ctx=ctx)
         assert result["status"] == "updated"
 
     async def test_set_invalid_log_level(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(action="set", key="log_level", value="INVALID", ctx=ctx)
-        )
+        result = await config(action="set", key="log_level", value="INVALID", ctx=ctx)
         assert "error" in result
         assert "valid_levels" in result
         assert "suggestion" in result
@@ -743,9 +711,7 @@ class TestConfigSet:
 
     async def test_set_invalid_log_level_fuzzy(self, ctx_with_db):
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(action="set", key="log_level", value="DEBG", ctx=ctx)
-        )
+        result = await config(action="set", key="log_level", value="DEBG", ctx=ctx)
         assert "error" in result
         assert "suggestion" in result
         assert "Did you mean 'DEBUG'?" in result["suggestion"]
@@ -876,37 +842,33 @@ class TestSpecializedTools:
         ctx, db = ctx_with_db
 
         # 1. Add
-        add_res = json.loads(
-            await add_memory(content="tool testing", category="test", ctx=ctx)
-        )
+        add_res = await add_memory(content="tool testing", category="test", ctx=ctx)
         assert add_res["status"] == "saved"
         mid = add_res["id"]
 
         # 2. Search
-        search_res = json.loads(await search_memory(query="tool testing", ctx=ctx))
+        search_res = await search_memory(query="tool testing", ctx=ctx)
         assert search_res["count"] >= 1
         assert search_res["results"][0]["id"] == mid
 
         # 3. List
-        list_res = json.loads(await list_memories(category="test", ctx=ctx))
+        list_res = await list_memories(category="test", ctx=ctx)
         assert any(r["id"] == mid for r in list_res["results"])
 
         # 4. Update
-        update_res = json.loads(
-            await update_memory(memory_id=mid, content="updated tool", ctx=ctx)
-        )
+        update_res = await update_memory(memory_id=mid, content="updated tool", ctx=ctx)
         assert update_res["status"] == "updated"
         assert db.get(mid)["content"] == "updated tool"
 
         # 5. Delete
-        delete_res = json.loads(await delete_memory(memory_id=mid, ctx=ctx))
+        delete_res = await delete_memory(memory_id=mid, ctx=ctx)
         assert delete_res["status"] == "deleted"
         assert db.get(mid) is None
 
     async def test_update_memory_error(self, ctx_with_db):
         ctx, _ = ctx_with_db
         # Missing memory_id handled by _handle_update
-        res = json.loads(await update_memory(memory_id="", content="fails", ctx=ctx))
+        res = await update_memory(memory_id="", content="fails", ctx=ctx)
         assert "error" in res
         assert "memory_id is required" in res["error"]
 
@@ -914,7 +876,7 @@ class TestSpecializedTools:
         ctx, db = ctx_with_db
 
         # Add a memory
-        add_res = json.loads(await add_memory(content="to be archived", ctx=ctx))
+        add_res = await add_memory(content="to be archived", ctx=ctx)
         mid = add_res["id"]
 
         # Soft archive it manually in DB since delete_memory does hard delete
@@ -925,11 +887,11 @@ class TestSpecializedTools:
         db._conn.commit()
 
         # 6. Archived list
-        archived_res = json.loads(await archived_memories(ctx=ctx))
+        archived_res = await archived_memories(ctx=ctx)
         assert any(r["id"] == mid for r in archived_res["results"])
 
         # 7. Restore
-        restore_res = json.loads(await restore_memory(memory_id=mid, ctx=ctx))
+        restore_res = await restore_memory(memory_id=mid, ctx=ctx)
         assert restore_res["status"] == "restored"
 
         # Check it is no longer archived
@@ -937,16 +899,16 @@ class TestSpecializedTools:
         assert mem["archived_at"] is None
 
         # 8. Stats
-        stats_res = json.loads(await memory_stats(ctx=ctx))
+        stats_res = await memory_stats(ctx=ctx)
         assert "total_memories" in stats_res
 
         # 9. Export
-        export_payload = json.loads(await export_memories(ctx=ctx))
+        export_payload = await export_memories(ctx=ctx)
         assert mid in export_payload["data"]
 
         # 10. Import
-        import_res = json.loads(
-            await import_memories(data=export_payload["data"], mode="replace", ctx=ctx)
+        import_res = await import_memories(
+            data=export_payload["data"], mode="replace", ctx=ctx
         )
         assert import_res["status"] == "imported"
         assert import_res["imported"] >= 1

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -134,33 +134,27 @@ class TestConfigSync:
         with patch(
             "mnemo_mcp.sync.sync_full", new_callable=AsyncMock, return_value=mock_result
         ):
-            result = json.loads(await config(action="sync", ctx=ctx))
+            result = await config(action="sync", ctx=ctx)
             assert result["status"] == "ok"
 
     async def test_config_set_sync_interval(self, ctx_with_db):
         """Config set sync_interval updates the setting."""
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(action="set", key="sync_interval", value="120", ctx=ctx)
-        )
+        result = await config(action="set", key="sync_interval", value="120", ctx=ctx)
         assert result["status"] == "updated"
         assert result["key"] == "sync_interval"
 
     async def test_config_set_log_level(self, ctx_with_db):
         """Config set log_level updates logger configuration."""
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(action="set", key="log_level", value="DEBUG", ctx=ctx)
-        )
+        result = await config(action="set", key="log_level", value="DEBUG", ctx=ctx)
         assert result["status"] == "updated"
         assert result["key"] == "log_level"
 
     async def test_config_set_invalid_log_level(self, ctx_with_db):
         """Config set with invalid log level returns error."""
         ctx, _ = ctx_with_db
-        result = json.loads(
-            await config(action="set", key="log_level", value="INVALID", ctx=ctx)
-        )
+        result = await config(action="set", key="log_level", value="INVALID", ctx=ctx)
         assert "error" in result
         assert "valid_levels" in result
 
@@ -374,13 +368,13 @@ class TestMemoryLimitClamping:
         """Limit below 1 is clamped to 1."""
         ctx, db = ctx_with_db
         db.add("test")
-        result = json.loads(await memory(action="list", limit=0, ctx=ctx))
+        result = await memory(action="list", limit=0, ctx=ctx)
         assert result["count"] <= 1
 
     async def test_limit_clamped_to_max(self, ctx_with_db):
         """Limit above 100 is clamped to 100."""
         ctx, db = ctx_with_db
-        result = json.loads(await memory(action="list", limit=1000, ctx=ctx))
+        result = await memory(action="list", limit=1000, ctx=ctx)
         # Should not crash, limit is clamped
         assert isinstance(result["results"], list)
 

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -184,7 +184,7 @@ class TestConfigActions:
             new_callable=AsyncMock,
             return_value={"status": "ok", "warmup": True},
         ):
-            result = json.loads(await config(action="warmup", ctx=ctx))
+            result = await config(action="warmup", ctx=ctx)
             assert result["status"] == "ok"
 
     async def test_config_setup_sync(self, ctx_with_db):
@@ -195,13 +195,13 @@ class TestConfigActions:
             new_callable=AsyncMock,
             return_value={"status": "ok", "sync": "configured"},
         ):
-            result = json.loads(await config(action="setup_sync", ctx=ctx))
+            result = await config(action="setup_sync", ctx=ctx)
             assert result["status"] == "ok"
 
     async def test_config_unknown_action(self, ctx_with_db):
         """Config with unknown action returns error with suggestion."""
         ctx, _ = ctx_with_db
-        result = json.loads(await config(action="syncc", ctx=ctx))
+        result = await config(action="syncc", ctx=ctx)
         assert "error" in result
         assert "Unknown action" in result["error"]
         assert "valid_actions" in result
@@ -211,7 +211,7 @@ class TestConfigActions:
     async def test_config_unknown_action_no_match(self, ctx_with_db):
         """Config with completely invalid action returns error with default suggestion."""
         ctx, _ = ctx_with_db
-        result = json.loads(await config(action="xyzxyzxyz", ctx=ctx))
+        result = await config(action="xyzxyzxyz", ctx=ctx)
         assert "error" in result
         assert "Unknown action" in result["error"]
         assert "suggestion" in result

--- a/tests/test_server_setup_actions.py
+++ b/tests/test_server_setup_actions.py
@@ -6,7 +6,6 @@ and _init_reranker_backend AWAITING_SETUP paths, lifespan credential
 resolution exception.
 """
 
-import json
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -52,7 +51,7 @@ class TestSetupStatus:
             "mnemo_mcp.credential_state.get_setup_url",
             return_value="https://setup.url",
         ):
-            result = json.loads(await config(action="setup_status", ctx=ctx))
+            result = await config(action="setup_status", ctx=ctx)
 
         assert result["state"] == "configured"
         assert result["setup_url"] == "https://setup.url"
@@ -64,7 +63,7 @@ class TestSetupStatus:
         monkeypatch.setenv("GEMINI_API_KEY", "test_key")
         set_state(CredentialState.CONFIGURED)
 
-        result = json.loads(await config(action="setup_status", ctx=ctx))
+        result = await config(action="setup_status", ctx=ctx)
 
         assert "GEMINI_API_KEY" in result["cloud_keys_in_env"]
 
@@ -80,7 +79,7 @@ class TestSetupStart:
         ctx, _ = ctx_with_db
         set_state(CredentialState.CONFIGURED)
 
-        result = json.loads(await config(action="setup_start", ctx=ctx))
+        result = await config(action="setup_start", ctx=ctx)
 
         assert result["status"] == "already_configured"
 
@@ -92,7 +91,7 @@ class TestSetupStart:
         ctx, _ = ctx_with_db
         set_state(CredentialState.CONFIGURED)
 
-        result = json.loads(await config(action="setup_start", key="force", ctx=ctx))
+        result = await config(action="setup_start", key="force", ctx=ctx)
 
         assert result["status"] == "stdio_unsupported"
         assert "--http" in result["message"]
@@ -102,7 +101,7 @@ class TestSetupStart:
         ctx, _ = ctx_with_db
         set_state(CredentialState.AWAITING_SETUP)
 
-        result = json.loads(await config(action="setup_start", ctx=ctx))
+        result = await config(action="setup_start", ctx=ctx)
 
         assert result["status"] == "stdio_unsupported"
         assert "JINA_AI_API_KEY" in result["message"]
@@ -119,7 +118,7 @@ class TestSetupSkip:
         ctx, _ = ctx_with_db
 
         with patch("mcp_core.set_local_mode") as mock_set:
-            result = json.loads(await config(action="setup_skip", ctx=ctx))
+            result = await config(action="setup_skip", ctx=ctx)
 
         assert result["status"] == "ok"
         assert get_state() == CredentialState.LOCAL
@@ -141,7 +140,7 @@ class TestSetupReset:
             patch("mcp_core.clear_mode"),
             patch("mcp_core.storage.config_file.delete_config"),
         ):
-            result = json.loads(await config(action="setup_reset", ctx=ctx))
+            result = await config(action="setup_reset", ctx=ctx)
 
         assert result["status"] == "ok"
         assert get_state() == CredentialState.AWAITING_SETUP
@@ -162,7 +161,7 @@ class TestSetupComplete:
             return_value=CredentialState.CONFIGURED,
         ):
             set_state(CredentialState.CONFIGURED)
-            result = json.loads(await config(action="setup_complete", ctx=ctx))
+            result = await config(action="setup_complete", ctx=ctx)
 
         assert result["status"] == "ok"
         assert result["state"] == "configured"
@@ -195,7 +194,7 @@ class TestSetupComplete:
             mock_settings.resolve_embedding_dims.return_value = 768
             mock_settings.resolve_embedding_backend.return_value = "cloud"
 
-            result = json.loads(await config(action="setup_complete", ctx=ctx))
+            result = await config(action="setup_complete", ctx=ctx)
 
         assert result["status"] == "ok"
 
@@ -208,7 +207,7 @@ class TestSetupComplete:
             return_value=CredentialState.LOCAL,
         ):
             set_state(CredentialState.LOCAL)
-            result = json.loads(await config(action="setup_complete", ctx=ctx))
+            result = await config(action="setup_complete", ctx=ctx)
 
         assert result["status"] == "ok"
         assert result["state"] == "local"
@@ -225,7 +224,7 @@ class TestSetupRelay:
         the same stdio_unsupported pointer."""
         ctx, _ = ctx_with_db
 
-        result = json.loads(await config(action="setup_relay", ctx=ctx))
+        result = await config(action="setup_relay", ctx=ctx)
 
         assert result["status"] == "stdio_unsupported"
         assert "--http" in result["message"]

--- a/tests/test_server_tool_wrappers.py
+++ b/tests/test_server_tool_wrappers.py
@@ -46,42 +46,42 @@ class TestToolWrappers:
     async def test_add_memory_wrapper(self, tmp_db: MemoryDB):
         ctx = _make_ctx(tmp_db)
         result = await _call(add_memory, content="hello", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert data["status"] == "saved"
 
     async def test_search_memory_wrapper(self, tmp_db: MemoryDB):
         tmp_db.add("Find me")
         ctx = _make_ctx(tmp_db)
         result = await _call(search_memory, query="Find", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "results" in data
 
     async def test_list_memories_wrapper(self, tmp_db: MemoryDB):
         tmp_db.add("listed")
         ctx = _make_ctx(tmp_db)
         result = await _call(list_memories, ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "results" in data
 
     async def test_update_memory_wrapper(self, tmp_db: MemoryDB):
         mid = tmp_db.add("original")
         ctx = _make_ctx(tmp_db)
         result = await _call(update_memory, memory_id=mid, content="updated", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert data["status"] == "updated"
 
     async def test_delete_memory_wrapper(self, tmp_db: MemoryDB):
         mid = tmp_db.add("to delete")
         ctx = _make_ctx(tmp_db)
         result = await _call(delete_memory, memory_id=mid, ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert data["status"] == "deleted"
 
     async def test_export_memories_wrapper(self, tmp_db: MemoryDB):
         tmp_db.add("export me")
         ctx = _make_ctx(tmp_db)
         result = await _call(export_memories, ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert data["count"] == 1
 
     async def test_import_memories_wrapper(self, tmp_db: MemoryDB):
@@ -98,13 +98,13 @@ class TestToolWrappers:
             }
         )
         result = await _call(import_memories, data=payload, mode="merge", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert data["imported"] == 1
 
     async def test_memory_stats_wrapper(self, tmp_db: MemoryDB):
         ctx = _make_ctx(tmp_db)
         result = await _call(memory_stats, ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "total_memories" in data
 
     async def test_restore_memory_wrapper(self, tmp_db: MemoryDB):
@@ -116,13 +116,13 @@ class TestToolWrappers:
         tmp_db._conn.commit()
         ctx = _make_ctx(tmp_db)
         result = await _call(restore_memory, memory_id=mid, ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert data["status"] == "restored"
 
     async def test_archived_memories_wrapper(self, tmp_db: MemoryDB):
         ctx = _make_ctx(tmp_db)
         result = await _call(archived_memories, ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "results" in data
 
     async def test_consolidate_memories_wrapper_no_llm(
@@ -141,5 +141,5 @@ class TestToolWrappers:
         monkeypatch.setattr(settings, "api_keys", None)
         ctx = _make_ctx(tmp_db)
         result = await _call(consolidate_memories, category="testcat", ctx=ctx)
-        data = json.loads(result)
+        data = result
         assert "error" in data


### PR DESCRIPTION
S13/WS-D X1 (mnemo) + a bundled test-hygiene fix.

**Structured output**: 13 domain+config tools now return -> dict[str, Any] (the _json() wrapper is dropped at the tool boundary — handlers already returned dicts), so FastMCP auto-derives outputSchema ({type:object, additionalProperties:true}) and emits structuredContent alongside the dual TextContent per MCP spec 2025-11-25. help keeps its -> str contract; _json() survives only for help's error path, the mnemo://stats resource, and the two prompts — all outside the tool boundary. No non-tool json.dumps touched (DB tags column, sync bundles, token store, CLI output unchanged). Test json.loads plumbing removed where tools are called directly (219 -> 81 remaining, all classified: protocol-level text parsing, DB/file blobs, help/resource/prompt str contracts); every assertion preserved.

**Test hygiene (bundled)**: the GDrive device-code path called try_open_browser for real, so unmocked test runs opened tabs in the developer's browser. An autouse conftest fixture now sets MCP_NO_BROWSER=1 and patches mcp_core.try_open_browser (version-independent — older installed mcp-core builds predate the env guard). The one test that asserts the launch patches the symbol itself and still shadows the fixture; a regression test pins both halves.

Evidence: 1346 passed / 5 skipped; ruff + ty clean. Task-reviewed: Approved (all 5 named risks verified against live source).