### PR TITLE
fix: wire the dead as_of parameter to the point-in-time query

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1081,6 +1081,29 @@ async def _handle_entity_graph(
     return result
 
 
+async def _handle_as_of(
+    ctx: Context | None,
+    as_of: str | None,
+    limit: int = 5,
+) -> dict[str, typing.Any]:
+    """``memory(action="as_of")`` -- point-in-time view of memories valid at
+    ``as_of`` (ISO timestamp). Delegates to ``temporal.queries.memories_as_of``.
+    """
+    db, _, _ = _get_ctx(ctx)
+
+    if isinstance(limit, int):
+        limit = max(1, min(limit, 100))
+
+    from mnemo_mcp.temporal.queries import memories_as_of
+
+    rows = await asyncio.to_thread(memories_as_of, db, as_of, limit)
+    return {
+        "memories": [_format_memory(m) for m in rows],
+        "count": len(rows),
+        "as_of": as_of,
+    }
+
+
 async def _handle_history(
     ctx: Context | None,
     entity_id: str | None,
@@ -1476,11 +1499,24 @@ async def memory(
     - restore: Restore archived memory (memory_id required)
     - archived: List archived memories (limit optional)
     - consolidate: LLM summarize similar memories (category required)
+    - as_of: Point-in-time view of memories valid at a given ISO timestamp
+      (as_of required, limit optional). Only combinable with action='as_of';
+      passing as_of with any other action is an error, not a silent no-op.
     """
     # Clamp limit to reasonable bounds to prevent DoS
 
     if isinstance(limit, int):
         limit = max(1, min(limit, 100))
+
+    if as_of is not None and action != "as_of":
+        return {
+            "error": (
+                f"as_of is only supported with action='as_of' (got action={action!r}). "
+                "Point-in-time filtering for search/list is not implemented; "
+                "refusing to silently return current-state results."
+            ),
+            "suggestion": "Use action='as_of' with the as_of parameter, or drop as_of for current-state results.",
+        }
 
     match action:
         case "add":
@@ -1515,6 +1551,8 @@ async def memory(
             )
         case "list":
             return await _handle_list(ctx, category, limit)
+        case "as_of":
+            return await _handle_as_of(ctx, as_of, limit)
         case "update":
             return await _handle_update(
                 ctx, memory_id, content, category, tags, source, importance
@@ -1557,6 +1595,7 @@ async def memory(
                 "add",
                 "archive_now",
                 "archived",
+                "as_of",
                 "capture",
                 "compress",
                 "consolidate",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -141,6 +141,37 @@ class TestMemoryList:
         assert result["count"] == 1
 
 
+class TestMemoryAsOf:
+    async def test_as_of_action_returns_point_in_time_view(self, ctx_with_db):
+        ctx, db = ctx_with_db
+        old_id = db.add("old fact, later superseded")
+        db._conn.execute(
+            "UPDATE memories SET valid_from = '2026-01-01T00:00:00', "
+            "valid_to = '2026-02-01T00:00:00' WHERE id = ?",
+            (old_id,),
+        )
+        db._conn.commit()
+        # Unrelated memory with no temporal backfill: created_at is "now",
+        # well outside the 2026-01-01..2026-02-01 window, so it must not
+        # leak into the historical as_of query below.
+        db.add("unrelated current fact")
+
+        result = await memory(
+            action="as_of", as_of="2026-01-15T00:00:00", limit=10, ctx=ctx
+        )
+        assert [m["id"] for m in result["memories"]] == [old_id]
+        assert result["count"] == 1
+        assert result["as_of"] == "2026-01-15T00:00:00"
+
+    async def test_as_of_param_with_other_action_errors_not_ignores(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(
+            action="search", query="x", as_of="2026-01-01T00:00:00", ctx=ctx
+        )
+        assert "error" in result
+        assert "as_of" in result["error"]
+
+
 class TestMemoryUpdate:
     async def test_update(self, ctx_with_db):
         ctx, db = ctx_with_db


### PR DESCRIPTION
## Bug (S14 Task 3, Wave 1)

`memory()` accepted an `as_of` parameter on its signature but never referenced it in the body — a user asking for a point-in-time view silently got the current-state answer. Meanwhile `memories_as_of()` (temporal/queries.py) was fully implemented with zero non-test callers.

## Fix

Two behaviors, nothing else (no N+2 redesign, specialized tools untouched):
1. New `case "as_of":` → `_handle_as_of` calls `memories_as_of(db, as_of, limit)`, returns `{memories, count, as_of}`.
2. A guard fires *before* dispatch: `as_of` set with any action other than `"as_of"` returns an explicit error instead of silently returning current-state results.

Plus docstring + `valid_actions` updated so the unknown-action suggestion works.

## Tests

2 new (point-in-time view returns the superseded memory not the current one; as_of+search errors rather than ignores) — both verified to fail against pre-fix code. Full suite 0 failures (pre-existing ambient-env config test failures unrelated). ruff + ty clean.

Reviewed (adversarial): SPEC + CODE QUALITY pass. Minor follow-up tracked: docstring wording vs the `action='as_of'` with `as_of=None` "current state" default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)