### PR TITLE
🎨 Palette: [DX] Add fuzzy matching validation for enumerated inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## $(date +%Y-%m-%d) - Extending fuzzy matching to domain inputs
 **Learning:** Returning a raw "Invalid context_type" without a fallback leaves developers guessing. Applying fuzzy matching to domain-specific enumerations (like context_type) improves DX immediately.
 **Action:** Always wrap the first argument to `difflib.get_close_matches` with `str()` and use `is not None` when providing fuzzy matching suggestions for API inputs, including domain-specific variables like context_type.
+## 2026-05-18 - [DX] Fuzzy matching for enumerated inputs
+**Learning:** Developers and LLMs often provide slightly incorrect or typo'd strings for enumerated inputs like filter categories (`entity_type`) or configuration modes (`mode` for import). Failing silently, returning 0 results, or defaulting to an internal fallback without warning leads to a poor developer experience (DX) and confusion.
+**Action:** When validating enumerated API parameters, use `difflib.get_close_matches` to identify potential typos and return a structured JSON error response that includes the closest fuzzy match as a `suggestion`. This allows the caller to easily identify their mistake and quickly self-correct.

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -818,6 +818,19 @@ async def _handle_import(
             "suggestion": "Provide the 'data' parameter containing the JSONL data or a list of JSON objects to import.",
         }
 
+    _VALID_MODES = ["merge", "replace"]
+    if mode is not None and mode not in _VALID_MODES:
+        closest = difflib.get_close_matches(str(mode), _VALID_MODES, n=1)
+        resp = {
+            "error": f"Invalid mode '{mode}'.",
+            "valid_modes": _VALID_MODES,
+        }
+        if closest:
+            resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+        else:
+            resp["suggestion"] = f"Pick a mode from {_VALID_MODES}."
+        return resp
+
     # Bolt Performance Optimization: Pass raw list/dict directly to database layer.
     # Avoids unnecessary JSON serialization and deserialization cycles for parsed inputs.
     if data is None:
@@ -1046,6 +1059,28 @@ async def _handle_entity_search(
                 "org/location/event)."
             ),
         }
+
+    _VALID_ENTITY_TYPES = [
+        "person",
+        "project",
+        "tool",
+        "concept",
+        "org",
+        "location",
+        "event",
+    ]
+    if entity_type is not None and entity_type not in _VALID_ENTITY_TYPES:
+        closest = difflib.get_close_matches(str(entity_type), _VALID_ENTITY_TYPES, n=1)
+        resp = {
+            "error": f"Invalid entity_type '{entity_type}'.",
+            "valid_entity_types": _VALID_ENTITY_TYPES,
+        }
+        if closest:
+            resp["suggestion"] = f"Did you mean '{closest[0]}'?"
+        else:
+            resp["suggestion"] = f"Pick an entity_type from {_VALID_ENTITY_TYPES}."
+        return resp
+
     from mnemo_mcp.temporal.queries import entity_search
 
     rows = await asyncio.to_thread(

--- a/tests/temporal/test_server_kg_handlers.py
+++ b/tests/temporal/test_server_kg_handlers.py
@@ -49,6 +49,15 @@ class TestEntitySearchHandler:
         assert "error" in data
         assert "name" in data["error"].lower()
 
+    async def test_invalid_entity_type_returns_fuzzy_suggestion(self, tmp_db: MemoryDB):
+        ctx = _make_ctx(tmp_db)
+        result = await _handle_entity_search(ctx, name="Python", entity_type="tooool")
+        data = result
+        assert "error" in data
+        assert "Invalid entity_type 'tooool'" in data["error"]
+        assert "tool" in data["suggestion"]
+        assert "valid_entity_types" in data
+
     async def test_returns_results(self, tmp_db: MemoryDB):
         _seed_kg(tmp_db, "FastAPI is fast", [{"name": "FastAPI", "type": "tool"}])
         ctx = _make_ctx(tmp_db)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -266,6 +266,15 @@ class TestMemoryExportImport:
         assert "error" in result
         assert "suggestion" in result
 
+    async def test_import_invalid_mode_returns_fuzzy_suggestion(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        data = json.dumps({"id": "imp1", "content": "imported"})
+        result = await memory(action="import", data=data, mode="marge", ctx=ctx)
+        assert "error" in result
+        assert "Invalid mode 'marge'" in result["error"]
+        assert "merge" in result["suggestion"]
+        assert "valid_modes" in result
+
 
 class TestMemoryStats:
     async def test_stats(self, ctx_with_db):

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.6.0b6"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Implements a Developer Experience (DX) enhancement by validating enumerated parameters `entity_type` (in `_handle_entity_search`) and `mode` (in `_handle_import`) early in the request lifecycle. 

Instead of silently failing or using a generic fallback when a user or LLM provides an invalid value, the API now returns a structured JSON error response featuring a fuzzy-matched `suggestion` (using `difflib.get_close_matches`) and the list of valid options. This improves self-correction and overall API usability.

Includes unit tests for both edge cases.

---
*PR created automatically by Jules for task [6756831804199382725](https://jules.google.com/task/6756831804199382725) started by @n24q02m*