### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file writing permissions

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2074,7 +2074,24 @@ async def _handle_config_export_passport(ctx: Context | None) -> dict[str, typin
     out_dir = settings.get_data_dir()
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"passport-{int(__import__('time').time())}.mnemo"
-    await asyncio.to_thread(path.write_bytes, bundle)
+
+    def _write_secure_bytes(file_path: typing.Any, content: bytes) -> None:
+        import os
+        import stat
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR
+        fd = os.open(file_path, flags, mode)
+        try:
+            if os.name != "nt":
+                os.fchmod(fd, mode)
+        except OSError:
+            pass
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+
+    await asyncio.to_thread(_write_secure_bytes, path, bundle)
     return {"status": "exported", "path": str(path), "size": len(bundle)}
 
 

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -450,8 +450,24 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
     )
 
     if response.status_code == 200:
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(dest_path.write_bytes, response.content)
+
+        def _write_secure_bytes(file_path: Path, content: bytes) -> None:
+            import os
+            import stat
+
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+            mode = stat.S_IRUSR | stat.S_IWUSR
+            fd = os.open(file_path, flags, mode)
+            try:
+                if os.name != "nt":
+                    os.fchmod(fd, mode)
+            except OSError:
+                pass
+            with os.fdopen(fd, "wb") as f:
+                f.write(content)
+
+        await asyncio.to_thread(_write_secure_bytes, dest_path, response.content)
         return True
 
     logger.error(f"Download failed ({response.status_code}): {response.text[:100]}")

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.6.0b6"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Basic `Path.write_bytes()` was used for exporting sensitive passport data and downloading Google Drive synchronization files. This relies on the system's default `umask`, potentially creating files with overly permissive settings that allow other users on the system to read sensitive data.
🎯 Impact: Local data exposure. Other users on the same machine could potentially read exported passports or the downloaded SQLite memory database.
🔧 Fix: Replaced `Path.write_bytes()` with a synchronous helper `_write_secure_bytes` executed via `asyncio.to_thread`. This helper explicitly creates the file with `os.open(..., os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)` and enforces permissions using `os.fchmod`, mitigating TOCTOU vulnerabilities and ensuring strict owner-only access.
✅ Verification: Ran `uv run pytest` and verified code formatting with `ruff`.

---
*PR created automatically by Jules for task [17714363895390487594](https://jules.google.com/task/17714363895390487594) started by @n24q02m*