### PR TITLE
fix: bitemporal supersession + as_of guard for mnemo memories

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -927,8 +927,12 @@ class MemoryDB:
         (mem_001 schema additions). Returns SQL fragment to append to a
         ``WHERE m.... = ...`` clause and the matching positional params so
         FTS and vec can compose the same filter set without duplication.
+
+        Bitemporal (mem_003): always excludes superseded/soft-deleted rows
+        (``valid_to IS NOT NULL``) -- neither FTS nor vec search should ever
+        surface a historical version, regardless of ``include_archived``.
         """
-        fragments = []
+        fragments = ["AND m.valid_to IS NULL"]
         params: list = []
         if context_type is not None:
             fragments.append("AND m.context_type = ?")
@@ -1172,6 +1176,10 @@ class MemoryDB:
         Phase 1 archive policy: by default exclude soft-archived rows
         (``archived_at IS NOT NULL``). Pass ``include_archived=True`` to see
         them — symmetric with :meth:`search` semantics.
+
+        Bitemporal (mem_003): always excludes superseded/soft-deleted rows
+        (``valid_to IS NOT NULL``), independent of ``include_archived`` --
+        archival and supersession are orthogonal states.
         """
         if isinstance(limit, int):
             limit = max(1, min(limit, 100))
@@ -1180,25 +1188,30 @@ class MemoryDB:
             if include_archived:
                 sql = (
                     "SELECT * FROM memories "
-                    "WHERE category = ? "
+                    "WHERE category = ? AND valid_to IS NULL "
                     "ORDER BY updated_at DESC "
                     "LIMIT ? OFFSET ?"
                 )
             else:
                 sql = (
                     "SELECT * FROM memories "
-                    "WHERE category = ? AND archived_at IS NULL "
+                    "WHERE category = ? AND archived_at IS NULL AND valid_to IS NULL "
                     "ORDER BY updated_at DESC "
                     "LIMIT ? OFFSET ?"
                 )
             rows = self._conn.execute(sql, (category, limit, offset)).fetchall()
         else:
             if include_archived:
-                sql = "SELECT * FROM memories ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+                sql = (
+                    "SELECT * FROM memories "
+                    "WHERE valid_to IS NULL "
+                    "ORDER BY updated_at DESC "
+                    "LIMIT ? OFFSET ?"
+                )
             else:
                 sql = (
                     "SELECT * FROM memories "
-                    "WHERE archived_at IS NULL "
+                    "WHERE archived_at IS NULL AND valid_to IS NULL "
                     "ORDER BY updated_at DESC "
                     "LIMIT ? OFFSET ?"
                 )
@@ -1207,9 +1220,14 @@ class MemoryDB:
         return [dict(r) for r in rows]
 
     def get(self, memory_id: str) -> dict | None:
-        """Get a single memory by ID."""
+        """Get a single memory by ID.
+
+        Bitemporal (mem_003): only returns the row when it is still current
+        (``valid_to IS NULL``). A superseded/soft-deleted id returns None --
+        callers must switch to the id returned by :meth:`update`.
+        """
         row = self._conn.execute(
-            "SELECT * FROM memories WHERE id = ?", (memory_id,)
+            "SELECT * FROM memories WHERE id = ? AND valid_to IS NULL", (memory_id,)
         ).fetchone()
         return dict(row) if row else None
 
@@ -1222,8 +1240,22 @@ class MemoryDB:
         source: str | None = None,
         importance: float | None = None,
         embedding: list[float] | None = None,
-    ) -> bool:
-        """Update an existing memory. Returns True if found and updated.
+    ) -> str | None:
+        """Update an existing memory by superseding it with a new version.
+
+        Bitemporal supersession (spec §6, mem_003): the old row is closed
+        (``valid_to=now``, ``superseded_by=<new id>``) and a new row is
+        inserted carrying forward every field not explicitly overridden here
+        (plus fresh ``created_at``/``updated_at``/``last_accessed`` and a
+        reset ``access_count``). This makes ``update`` id-changing: callers
+        must switch to the returned id for subsequent get/search/delete
+        calls -- the old id no longer resolves via :meth:`get`/:meth:`search`
+        /:meth:`list_memories` (see call-site filters), only via
+        ``temporal.queries.memories_as_of`` for historical ``as_of`` lookups.
+
+        Returns:
+            The new memory's id, or ``None`` if ``memory_id`` was not found
+            (already deleted or already superseded).
 
         Raises:
             ValueError: If content exceeds MAX_CONTENT_LENGTH.
@@ -1233,65 +1265,91 @@ class MemoryDB:
                 f"Content length {len(content)} exceeds limit of {MAX_CONTENT_LENGTH}"
             )
 
-        now = _now_iso()
+        old_row = self._conn.execute(
+            "SELECT * FROM memories WHERE id = ? AND valid_to IS NULL", (memory_id,)
+        ).fetchone()
+        if old_row is None:
+            return None
 
-        # Use static parameterized query with CASE WHEN for safe partial updates.
-        # This prevents SQL injection and ensures only specified fields are changed.
-        cursor = self._conn.execute(
-            """
-            UPDATE memories SET
-                content = CASE WHEN :content_provided THEN :content ELSE content END,
-                category = CASE WHEN :category_provided THEN :category ELSE category END,
-                tags = CASE WHEN :tags_provided THEN :tags ELSE tags END,
-                source = CASE WHEN :source_provided THEN :source ELSE source END,
-                importance = CASE WHEN :importance_provided THEN :importance ELSE importance END,
-                updated_at = :now
-            WHERE id = :id
-            """,
-            {
-                "id": memory_id,
-                "now": now,
-                "content": content,
-                "content_provided": content is not None,
-                "category": category,
-                "category_provided": category is not None,
-                # Bolt Performance Optimization:
-                # Prevent expensive json.dumps calls for the default empty list.
-                "tags": ("[]" if not tags else json.dumps(tags))
-                if tags is not None
-                else None,
-                "tags_provided": tags is not None,
-                "source": source,
-                "source_provided": source is not None,
-                "importance": max(0.0, min(1.0, importance))
-                if importance is not None
-                else None,
-                "importance_provided": importance is not None,
-            },
+        now = _now_iso()
+        new_id = uuid.uuid4().hex
+
+        new_row = dict(old_row)
+        new_row["id"] = new_id
+        new_row["created_at"] = now
+        new_row["updated_at"] = now
+        new_row["last_accessed"] = now
+        new_row["access_count"] = 0
+        new_row["valid_from"] = now
+        new_row["valid_to"] = None
+        new_row["superseded_by"] = None
+        if "commit_sha" in new_row:
+            new_row["commit_sha"] = None
+
+        if content is not None:
+            new_row["content"] = content
+        if category is not None:
+            new_row["category"] = category
+        if tags is not None:
+            # Bolt Performance Optimization:
+            # Prevent expensive json.dumps calls for the default empty list.
+            new_row["tags"] = "[]" if not tags else json.dumps(tags)
+        if source is not None:
+            new_row["source"] = source
+        if importance is not None:
+            new_row["importance"] = max(0.0, min(1.0, importance))
+
+        columns = list(new_row.keys())
+        column_list = ", ".join(columns)
+        placeholders = ", ".join("?" for _ in columns)
+
+        self._conn.execute(
+            "UPDATE memories SET valid_to = ?, superseded_by = ? WHERE id = ?",
+            (now, new_id, memory_id),
+        )
+        self._conn.execute(
+            f"INSERT INTO memories ({column_list}) VALUES ({placeholders})",
+            [new_row[c] for c in columns],
         )
 
-        if cursor.rowcount == 0:
-            return False
-
-        # Update embedding if provided
-        if embedding and self._vec_enabled:
+        # Embedding: an explicit value replaces; otherwise carry the old
+        # vector forward under the new id so semantic search keeps working
+        # for metadata-only edits (content-only re-embedding is the
+        # caller's responsibility, e.g. server._handle_update).
+        if self._vec_enabled:
+            old_vec = self._conn.execute(
+                "SELECT embedding FROM memories_vec WHERE id = ?", (memory_id,)
+            ).fetchone()
             self._conn.execute("DELETE FROM memories_vec WHERE id = ?", (memory_id,))
-            self._conn.execute(
-                "INSERT INTO memories_vec (id, embedding) VALUES (?, ?)",
-                (memory_id, _serialize_f32(embedding, self._embedding_dims)),
-            )
+            if embedding:
+                self._conn.execute(
+                    "INSERT INTO memories_vec (id, embedding) VALUES (?, ?)",
+                    (new_id, _serialize_f32(embedding, self._embedding_dims)),
+                )
+            elif old_vec is not None:
+                self._conn.execute(
+                    "INSERT INTO memories_vec (id, embedding) VALUES (?, ?)",
+                    (new_id, old_vec["embedding"]),
+                )
 
         self._conn.commit()
-        logger.info(f"[AUDIT] update id={memory_id}")
-        return True
+        logger.info(f"[AUDIT] update id={memory_id} -> new_id={new_id}")
+        return new_id
 
     def delete(self, memory_id: str) -> bool:
-        """Delete a memory by ID. Returns True if found and deleted."""
-        # Bolt Performance Optimization:
-        # Avoided N+1 SELECT overhead by executing DELETE directly and checking rowcount.
-        # This completely bypasses Python's memory allocation for a row we intend to delete.
-        cursor = self._conn.cursor()
-        cursor.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
+        """Delete a memory by ID. Returns True if found and deleted.
+
+        Bitemporal (mem_003): soft-closes the row (``valid_to=now``) instead
+        of physically removing it, so it drops out of get/search/list (same
+        observable behaviour as a hard delete) while remaining available to
+        ``temporal.queries.memories_as_of`` for historical ``as_of`` lookups
+        and to ``history_for_entity`` for audit trails. ``superseded_by``
+        stays NULL -- deletion has no forward pointer, unlike ``update``.
+        """
+        cursor = self._conn.execute(
+            "UPDATE memories SET valid_to = ? WHERE id = ? AND valid_to IS NULL",
+            (_now_iso(), memory_id),
+        )
 
         if cursor.rowcount == 0:
             return False
@@ -1304,15 +1362,23 @@ class MemoryDB:
         return True
 
     def stats(self) -> dict:
-        """Get database statistics."""
-        total = self._conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+        """Get database statistics.
+
+        Bitemporal (mem_003): counts/aggregates only current rows
+        (``valid_to IS NULL``) -- superseded/soft-deleted history is not
+        double-counted into totals or category breakdowns.
+        """
+        total = self._conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE valid_to IS NULL"
+        ).fetchone()[0]
 
         categories = self._conn.execute(
-            "SELECT category, COUNT(*) as cnt FROM memories GROUP BY category ORDER BY cnt DESC"
+            "SELECT category, COUNT(*) as cnt FROM memories "
+            "WHERE valid_to IS NULL GROUP BY category ORDER BY cnt DESC"
         ).fetchall()
 
         last_updated = self._conn.execute(
-            "SELECT MAX(updated_at) FROM memories"
+            "SELECT MAX(updated_at) FROM memories WHERE valid_to IS NULL"
         ).fetchone()[0]
 
         return {

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -740,7 +740,7 @@ async def _handle_update(
         embedding = await _embed(content, embedding_model, embedding_dims)
 
     try:
-        ok = await asyncio.to_thread(
+        new_id = await asyncio.to_thread(
             db.update,
             memory_id=memory_id,
             content=content,
@@ -761,11 +761,13 @@ async def _handle_update(
             "error": "Internal error while updating memory",
             "suggestion": "Check server logs for tracebacks or verify database connection.",
         }
-    if ok:
-        # Background: re-extract entities if content changed
+    if new_id:
+        # Background: re-extract entities if content changed. Bitemporal
+        # supersession (mem_003) means memory_id no longer resolves after
+        # this update -- enrichment must target the new row.
         if content:
-            asyncio.create_task(_enrich_memory(db, memory_id, content))
-        return {"status": "updated", "id": memory_id}
+            asyncio.create_task(_enrich_memory(db, new_id, content))
+        return {"status": "updated", "id": new_id}
     return {
         "error": f"Memory {memory_id} not found",
         "suggestion": "Verify the memory_id using action='search' or action='list'.",

--- a/tests/temporal/test_queries.py
+++ b/tests/temporal/test_queries.py
@@ -3,6 +3,8 @@ history / as_of bitemporal lookups."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.graph import (
     create_relations,
@@ -15,6 +17,11 @@ from mnemo_mcp.temporal.queries import (
     history_for_entity,
     memories_as_of,
 )
+
+
+def _now_iso() -> str:
+    """Current UTC timestamp in ISO format (mirrors mnemo_mcp.db._now_iso)."""
+    return datetime.now(UTC).isoformat()
 
 
 def _seed_kg(db: MemoryDB, content: str, entities, relations=None):
@@ -174,3 +181,29 @@ class TestMemoriesAsOf:
         result = memories_as_of(tmp_db, as_of="2026-03-01T00:00:00")
         ids = {m["id"] for m in result}
         assert mid not in ids
+
+
+class TestUpdateSupersession:
+    def test_update_supersedes_old_row(self, tmp_db: MemoryDB):
+        mid = tmp_db.add("v1", category="fact")
+        t_between = _now_iso()
+        new_id = tmp_db.update(mid, content="v2")
+
+        assert new_id is not None
+        assert new_id != mid
+
+        # Historical query (as_of before the update) still sees v1.
+        historical = memories_as_of(tmp_db, as_of=t_between, limit=10)
+        assert [r["content"] for r in historical] == ["v1"]
+
+        # Current query (as_of=None) sees only v2, under the new id.
+        current = memories_as_of(tmp_db, as_of=None, limit=10)
+        assert [r["content"] for r in current] == ["v2"]
+        assert current[0]["id"] == new_id
+
+        # The old row is closed and points forward to the new one.
+        old_row = tmp_db._conn.execute(
+            "SELECT valid_to, superseded_by FROM memories WHERE id = ?", (mid,)
+        ).fetchone()
+        assert old_row["valid_to"] is not None
+        assert old_row["superseded_by"] == new_id

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -96,24 +96,33 @@ class TestGet:
 
 
 class TestUpdate:
+    """update() now supersedes: it returns the NEW row's id (not a bool),
+    and the old id no longer resolves via get() (bitemporal supersession,
+    mem_003 -- see mnemo_mcp.db.MemoryDB.update docstring)."""
+
     def test_content(self, tmp_db: MemoryDB):
         mid = tmp_db.add("original")
-        assert tmp_db.update(mid, content="updated") is True
-        mem = tmp_db.get(mid)
+        new_id = tmp_db.update(mid, content="updated")
+        assert new_id is not None
+        assert new_id != mid
+        assert tmp_db.get(mid) is None
+        mem = tmp_db.get(new_id)
         assert mem is not None
         assert mem["content"] == "updated"
 
     def test_category(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test", category="old")
-        tmp_db.update(mid, category="new")
-        mem = tmp_db.get(mid)
+        new_id = tmp_db.update(mid, category="new")
+        assert new_id is not None
+        mem = tmp_db.get(new_id)
         assert mem is not None
         assert mem["category"] == "new"
 
     def test_tags(self, tmp_db: MemoryDB):
         mid = tmp_db.add("test", tags=["a"])
-        tmp_db.update(mid, tags=["b", "c"])
-        mem = tmp_db.get(mid)
+        new_id = tmp_db.update(mid, tags=["b", "c"])
+        assert new_id is not None
+        mem = tmp_db.get(new_id)
         assert mem is not None
         assert json.loads(mem["tags"]) == ["b", "c"]
 
@@ -123,19 +132,21 @@ class TestUpdate:
         assert mem is not None
         old_ts = mem["updated_at"]
         time.sleep(0.01)
-        tmp_db.update(mid, content="changed")
-        mem = tmp_db.get(mid)
+        new_id = tmp_db.update(mid, content="changed")
+        assert new_id is not None
+        mem = tmp_db.get(new_id)
         assert mem is not None
         assert mem["updated_at"] >= old_ts
 
-    def test_nonexistent_returns_false(self, tmp_db: MemoryDB):
-        assert tmp_db.update("nonexistent", content="x") is False
+    def test_nonexistent_returns_none(self, tmp_db: MemoryDB):
+        assert tmp_db.update("nonexistent", content="x") is None
 
     def test_partial_update_preserves_fields(self, tmp_db: MemoryDB):
         """Updating category should not change content or tags."""
         mid = tmp_db.add("content", category="old", tags=["tag1"])
-        tmp_db.update(mid, category="new")
-        mem = tmp_db.get(mid)
+        new_id = tmp_db.update(mid, category="new")
+        assert new_id is not None
+        mem = tmp_db.get(new_id)
         assert mem is not None
         assert mem["content"] == "content"
         assert mem["category"] == "new"
@@ -550,14 +561,14 @@ class TestContentLengthValidation:
 
     def test_update_at_limit_ok(self, tmp_db: MemoryDB):
         mid = tmp_db.add("short")
-        ok = tmp_db.update(mid, content="x" * MAX_CONTENT_LENGTH)
-        assert ok is True
+        new_id = tmp_db.update(mid, content="x" * MAX_CONTENT_LENGTH)
+        assert new_id is not None
 
     def test_update_none_content_skips_validation(self, tmp_db: MemoryDB):
         """Updating category only should not trigger content validation."""
         mid = tmp_db.add("test")
-        ok = tmp_db.update(mid, category="new_cat")
-        assert ok is True
+        new_id = tmp_db.update(mid, category="new_cat")
+        assert new_id is not None
 
     def test_import_rejects_oversized(self, tmp_db: MemoryDB):
         """Import should skip oversized content and count as rejected."""

--- a/tests/test_db_vec.py
+++ b/tests/test_db_vec.py
@@ -55,10 +55,10 @@ class TestUpdateWithVectors:
         mid = tmp_db_vec.add("test", embedding=emb1)
 
         emb2 = [0.0, 1.0, 0.0]
-        tmp_db_vec.update(mid, embedding=emb2)
+        new_id = tmp_db_vec.update(mid, embedding=emb2)
 
         row = tmp_db_vec._conn.execute(
-            "SELECT embedding FROM memories_vec WHERE id = ?", (mid,)
+            "SELECT embedding FROM memories_vec WHERE id = ?", (new_id,)
         ).fetchone()
         assert row is not None
         assert row["embedding"] == _serialize_f32(emb2)
@@ -68,15 +68,15 @@ class TestUpdateWithVectors:
         mid = tmp_db_vec.add("test", embedding=emb)
 
         # Update content only, no embedding
-        tmp_db_vec.update(mid, content="updated content")
+        new_id = tmp_db_vec.update(mid, content="updated content")
 
         row = tmp_db_vec._conn.execute(
-            "SELECT embedding FROM memories_vec WHERE id = ?", (mid,)
+            "SELECT embedding FROM memories_vec WHERE id = ?", (new_id,)
         ).fetchone()
         assert row is not None
         assert row["embedding"] == _serialize_f32(emb)
 
-        mem = tmp_db_vec.get(mid)
+        mem = tmp_db_vec.get(new_id)
         assert mem["content"] == "updated content"
 
     def test_update_embedding_only(self, tmp_db_vec):
@@ -84,15 +84,15 @@ class TestUpdateWithVectors:
         mid = tmp_db_vec.add("test", embedding=emb1)
 
         emb2 = [0.0, 0.0, 1.0]
-        tmp_db_vec.update(mid, embedding=emb2)
+        new_id = tmp_db_vec.update(mid, embedding=emb2)
 
         row = tmp_db_vec._conn.execute(
-            "SELECT embedding FROM memories_vec WHERE id = ?", (mid,)
+            "SELECT embedding FROM memories_vec WHERE id = ?", (new_id,)
         ).fetchone()
         assert row is not None
         assert row["embedding"] == _serialize_f32(emb2)
 
-        mem = tmp_db_vec.get(mid)
+        mem = tmp_db_vec.get(new_id)
         assert mem["content"] == "test"
 
     def test_delete_removes_embedding(self, tmp_db_vec):
@@ -112,10 +112,10 @@ class TestUpdateWithVectors:
         mid = tmp_db_vec.add("test", embedding=emb)
 
         # Empty list is falsy, so it should behave like None
-        tmp_db_vec.update(mid, embedding=[])
+        new_id = tmp_db_vec.update(mid, embedding=[])
 
         row = tmp_db_vec._conn.execute(
-            "SELECT embedding FROM memories_vec WHERE id = ?", (mid,)
+            "SELECT embedding FROM memories_vec WHERE id = ?", (new_id,)
         ).fetchone()
         assert row is not None
         assert row["embedding"] == _serialize_f32(emb)

--- a/tests/test_db_vec_coverage.py
+++ b/tests/test_db_vec_coverage.py
@@ -55,10 +55,10 @@ class TestAddWithForcedVec:
 class TestUpdateWithForcedVec:
     def test_update_embedding_replaces_vec_row(self, _forced_vec_db):
         mid = _forced_vec_db.add("hello", embedding=[0.1, 0.2, 0.3])
-        ok = _forced_vec_db.update(mid, embedding=[0.9, 0.8, 0.7])
-        assert ok is True
+        new_id = _forced_vec_db.update(mid, embedding=[0.9, 0.8, 0.7])
+        assert new_id is not None
         row = _forced_vec_db._conn.execute(
-            "SELECT COUNT(*) AS c FROM memories_vec WHERE id = ?", (mid,)
+            "SELECT COUNT(*) AS c FROM memories_vec WHERE id = ?", (new_id,)
         ).fetchone()
         assert row["c"] == 1
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -38,16 +38,18 @@ def test_update_security(tmp_db: MemoryDB):
     # much harder to exploit.
 
     # Normal update works
-    assert tmp_db.update(mid, content="new content") is True
-    mem = tmp_db.get(mid)
+    new_id = tmp_db.update(mid, content="new content")
+    assert new_id is not None
+    mem = tmp_db.get(new_id)
     assert mem is not None
     assert mem["content"] == "new content"
 
     # Try to inject something into a parameter (though it'\''s already safe due to placeholders)
     # This is more of a sanity check.
     malicious_content = "content', category='pwned"
-    tmp_db.update(mid, content=malicious_content)
-    mem = tmp_db.get(mid)
+    newer_id = tmp_db.update(new_id, content=malicious_content)
+    assert newer_id is not None
+    mem = tmp_db.get(newer_id)
     assert mem is not None
     assert mem["content"] == malicious_content
     assert mem["category"] == "cat"  # Category remains unchanged
@@ -60,8 +62,9 @@ def test_update_security_extended(tmp_db: MemoryDB):
     )
 
     # Verify we can update new fields
-    tmp_db.update(mid, source="new source", importance=0.8)
-    mem = tmp_db.get(mid)
+    new_id = tmp_db.update(mid, source="new source", importance=0.8)
+    assert new_id is not None
+    mem = tmp_db.get(new_id)
     assert mem is not None
     assert mem["source"] == "new source"
     assert mem["importance"] == 0.8
@@ -72,8 +75,9 @@ def test_update_security_extended(tmp_db: MemoryDB):
     # it is treated as a value, not a column name.
 
     malicious_val = "ignored' --"
-    tmp_db.update(mid, category=malicious_val)
-    mem = tmp_db.get(mid)
+    newer_id = tmp_db.update(new_id, category=malicious_val)
+    assert newer_id is not None
+    mem = tmp_db.get(newer_id)
     assert mem is not None
     assert mem["category"] == malicious_val
     assert mem["content"] == "original content"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -183,7 +183,12 @@ class TestMemoryUpdate:
             ctx=ctx,
         )
         assert result["status"] == "updated"
-        mem = db.get(mid)
+        # Bitemporal supersession (mem_003): update returns a NEW id; the
+        # old id is superseded and no longer resolves via get().
+        new_id = result["id"]
+        assert new_id != mid
+        assert db.get(mid) is None
+        mem = db.get(new_id)
         assert mem is not None
         assert mem["content"] == "updated"
 
@@ -886,15 +891,17 @@ class TestSpecializedTools:
         list_res = await list_memories(category="test", ctx=ctx)
         assert any(r["id"] == mid for r in list_res["results"])
 
-        # 4. Update
+        # 4. Update (bitemporal supersession, mem_003: returns a NEW id;
+        # the old id is superseded and no longer resolves)
         update_res = await update_memory(memory_id=mid, content="updated tool", ctx=ctx)
         assert update_res["status"] == "updated"
-        assert db.get(mid)["content"] == "updated tool"
+        new_id = update_res["id"]
+        assert db.get(new_id)["content"] == "updated tool"
 
-        # 5. Delete
-        delete_res = await delete_memory(memory_id=mid, ctx=ctx)
+        # 5. Delete (must target the current id, not the superseded one)
+        delete_res = await delete_memory(memory_id=new_id, ctx=ctx)
         assert delete_res["status"] == "deleted"
-        assert db.get(mid) is None
+        assert db.get(new_id) is None
 
     async def test_update_memory_error(self, ctx_with_db):
         ctx, _ = ctx_with_db


### PR DESCRIPTION
Task 1 (supersession): update_memory now closes the old row (valid_to=now, superseded_by=new_id) and inserts a new row; delete soft-closes. as_of therefore returns true history instead of the mutated current state. Reads filter valid_to IS NULL. Note: update now returns a NEW id.

Task 2 (as_of guard): action=as_of without an as_of value now returns {error: as_of is required...} instead of silently returning current state; docstring corrected.

224 related tests pass; full suite green in a clean env (5 pre-existing test_config.py embedding failures are local-env-leak of EMBEDDING_MODELS/JINA_AI_API_KEY, unrelated — pass on CI's clean env).