### PR TITLE
fix: forward CF AI Gateway litellm envs into container

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -66,6 +66,8 @@ const CONTAINER_ENV_KEYS = [
   'PUBLIC_URL', 'CREDENTIAL_SECRET',
   'JINA_AI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_VERTEX_EXPRESS_API_KEY',
   'MCP_RELAY_PASSWORD', 'MCP_DCR_SERVER_SECRET',
+  // CF AI Gateway (llm-main) litellm routing
+  'OPENROUTER_API_BASE', 'OPENROUTER_API_KEY', 'JINA_AI_API_BASE',
 ] as const
 
 function pickContainerEnv(env: Env): Record<string, string> {

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -36,7 +36,7 @@
     "MCP_VECTORIZE_IDX": "${CF_VECTORIZE_ID}",
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
-    "LLM_MODELS": "vertex_express/gemini-3.5-flash",
+    "LLM_MODELS": "openrouter/minimax/minimax-m3",
     "EMBEDDING_DIMS": "768"
   },
   "observability": { "enabled": true }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -45,7 +45,7 @@
     "MCP_VECTORIZE_IDX": "mnemo-memory-vectors",
     "EMBEDDING_MODELS": "jina_ai/jina-embeddings-v5-text-small",
     "RERANK_MODELS": "jina_ai/jina-reranker-v3",
-    "LLM_MODELS": "vertex_express/gemini-3.5-flash",
+    "LLM_MODELS": "openrouter/minimax/minimax-m3",
     "EMBEDDING_DIMS": "768"
   },
   "routes": [{ "pattern": "<YOUR_WORKER_DOMAIN>", "custom_domain": true }],


### PR DESCRIPTION
The worker forwards CONTAINER_ENV_KEYS from the Worker environment into the container process, but did not include the new litellm routing variables used for CF AI Gateway (OPENROUTER_API_BASE, OPENROUTER_API_KEY, JINA_AI_API_BASE). This adds the three keys to CONTAINER_ENV_KEYS in src/worker.ts so they reach the container once configured as Worker vars/secrets.

Also updates the default LLM_MODELS in wrangler.deploy.template.jsonc and the self-host wrangler.jsonc example: the default LLM chain moves to OpenRouter (MiniMax M3) behind CF AI Gateway, replacing the previous vertex_express/gemini-3.5-flash default. EMBEDDING_MODELS and RERANK_MODELS are unchanged.