### PR TITLE
feat: deprecate legacy memory composite tool in favor of granular tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - mnemo-mcp
 
 MCP Server cho AI memory. Python 3.13, uv, hatchling, src layout.
-Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher + config + help + config__open_relay.
+Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher (DEPRECATED -- use the granular tools instead) + config + help + config__open_relay.
 2-mode embedding: cloud chain (`EMBEDDING_MODELS`) > Local (Qwen3 ONNX khi chain rong). Per-task model chains (`EMBEDDING_MODELS`/`RERANK_MODELS`/`LLM_MODELS`, order = litellm fallback). LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]).
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - mnemo-mcp
 
 MCP Server cho AI memory. Python 3.13, uv, hatchling, src layout.
-Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher + config + help + config__open_relay.
+Hybrid search: FTS5 + sqlite-vec semantic. 15 tools: 11 specialized memory tools (add_memory, search_memory, list_memories, update_memory, delete_memory, export_memories, import_memories, memory_stats, restore_memory, archived_memories, consolidate_memories) + legacy `memory` dispatcher (DEPRECATED -- use the granular tools instead) + config + help + config__open_relay.
 2-mode embedding: cloud chain (`EMBEDDING_MODELS`) > Local (Qwen3 ONNX khi chain rong). Per-task model chains (`EMBEDDING_MODELS`/`RERANK_MODELS`/`LLM_MODELS`, order = litellm fallback). LLM/Embed/Rerank: litellm passthrough qua `mcp_core.llm` (mcp-core[llm]).
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ mnemo-mcp is packaged for [Smithery](https://smithery.ai/) -- install or run it 
 
 ## Tools
 
-15 MCP tools, 17 memory actions. The memory surface is exposed both as 11 specialized single-purpose tools and a legacy `memory` dispatcher (same actions), plus `config`, `help`, and `config__open_relay`:
+15 MCP tools, 17 memory actions. The memory surface is exposed both as 11 specialized single-purpose tools and a deprecated legacy `memory` dispatcher (same actions), plus `config`, `help`, and `config__open_relay`:
 
 | Tool | Actions | Description |
 |:-----|:--------|:------------|
 | `add_memory`, `search_memory`, `list_memories`, `update_memory`, `delete_memory`, `export_memories`, `import_memories`, `memory_stats`, `restore_memory`, `archived_memories`, `consolidate_memories` | (one action each) | Specialized single-purpose memory tools -- the recommended surface |
-| `memory` (legacy dispatcher) | `add`, `capture`, `search`, `list`, `update`, `delete`, `export`, `import`, `stats`, `restore`, `archived`, `archive_now`, `consolidate`, `compress`, `entity_search`, `entity_graph`, `history` | Core CRUD + typed capture (6 context_types) + hybrid search (RRF + rerank + temporal decay) + import/export + soft-archive + restore + on-demand archive sweep + LLM consolidation + LLM compression + temporal KG (entity search / graph / history) |
+| `memory` (legacy dispatcher, **DEPRECATED** -- use the granular tools above instead; will be removed in a future release) | `add`, `capture`, `search`, `list`, `update`, `delete`, `export`, `import`, `stats`, `restore`, `archived`, `archive_now`, `consolidate`, `compress`, `entity_search`, `entity_graph`, `history` | Core CRUD + typed capture (6 context_types) + hybrid search (RRF + rerank + temporal decay) + import/export + soft-archive + restore + on-demand archive sweep + LLM consolidation + LLM compression + temporal KG (entity search / graph / history) |
 | `config` | `status`, `sync`, `set`, `warmup`, `setup_sync`, `setup_status`, `setup_start`, `setup_skip`, `setup_reset`, `setup_complete`, `setup_relay`, `sync_now`, `export_passport`, `import_passport` | Server status, trigger sync, update settings, pre-download embedding model, authenticate sync provider, manage HTTP setup form lifecycle, passport export/import |
 | `help` | `topic="memory"` or `topic="config"` | Full documentation for any tool |
 | `config__open_relay` | (HTTP relay mode) | Open the zero-config relay setup form (registered via mcp-core) |

--- a/src/mnemo_mcp/docs/memory.md
+++ b/src/mnemo_mcp/docs/memory.md
@@ -1,5 +1,8 @@
 # Memory Tool - Full Documentation
 
+> **[DEPRECATED — use the granular tools (add_memory, search_memory, ...) instead; this composite tool will be removed in a future release]**
+> This composite `memory` dispatcher is kept for backward compatibility only. Prefer the specialized single-purpose tools -- `add_memory`, `search_memory`, `list_memories`, `update_memory`, `delete_memory`, `export_memories`, `import_memories`, `memory_stats`, `restore_memory`, `archived_memories`, `consolidate_memories` -- which map 1:1 to the actions documented below. Actions with no granular equivalent yet (`capture`, `archive_now`, `as_of`, `compress`, `entity_search`, `entity_graph`, `history`) remain available only through this tool for now.
+
 ## Overview
 
 The `memory` tool manages persistent AI memories with hybrid search (text + semantic).

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -392,6 +392,44 @@ async def _maybe_include_setup_hint(result: dict) -> dict:
     return result
 
 
+# W6.4: `memory` deprecation -- map each composite-tool action to its
+# granular single-purpose tool replacement, where one exists. Actions with
+# no entry (capture/archive_now/as_of/compress/entity_search/entity_graph/
+# history) are Phase 3 / typed-capture features not yet split out; callers
+# keep using the composite tool for those until a granular equivalent ships.
+_GRANULAR_TOOL_FOR_ACTION: dict[str, str] = {
+    "add": "add_memory",
+    "search": "search_memory",
+    "list": "list_memories",
+    "update": "update_memory",
+    "delete": "delete_memory",
+    "export": "export_memories",
+    "import": "import_memories",
+    "stats": "memory_stats",
+    "restore": "restore_memory",
+    "archived": "archived_memories",
+    "consolidate": "consolidate_memories",
+}
+
+
+def _deprecation_notice(action: str | None) -> dict[str, str | None]:
+    """Build the `_deprecation` field attached to every `memory()` response."""
+    granular_tool = _GRANULAR_TOOL_FOR_ACTION.get(action or "")
+    if granular_tool:
+        message = (
+            "The 'memory' composite tool is deprecated and will be removed "
+            f"in a future release. Use '{granular_tool}' instead of "
+            f"action={action!r}."
+        )
+    else:
+        message = (
+            "The 'memory' composite tool is deprecated and will be removed "
+            f"in a future release. No granular tool exists yet for "
+            f"action={action!r}."
+        )
+    return {"message": message, "use_instead": granular_tool}
+
+
 def _format_memory(mem: dict) -> dict:
     """Format a raw memory dict for tool output.
 
@@ -1430,6 +1468,8 @@ async def consolidate_memories(
 
 @mcp.tool(
     description=(
+        "[DEPRECATED — use the granular tools (add_memory, search_memory, ...) "
+        "instead; this composite tool will be removed in a future release]\n\n"
         "Legacy dispatcher for backward compatibility. Use specialized tools (add_memory, search_memory, etc.) instead.\n\nPersistent memory store. Actions: add|search|list|update|delete|export|import|stats|restore|archived|consolidate.\n"
         "\n"
         "ACTION GUIDE — when to use each:\n"
@@ -1511,7 +1551,7 @@ async def memory(
         limit = max(1, min(limit, 100))
 
     if as_of is not None and action != "as_of":
-        return {
+        result: dict[str, typing.Any] = {
             "error": (
                 f"as_of is only supported with action='as_of' (got action={action!r}). "
                 "Point-in-time filtering for search/list is not implemented; "
@@ -1519,12 +1559,14 @@ async def memory(
             ),
             "suggestion": "Use action='as_of' with the as_of parameter, or drop as_of for current-state results.",
         }
+        result["_deprecation"] = _deprecation_notice(action)
+        return result
 
     match action:
         case "add":
-            return await _handle_add(ctx, content, category, tags)
+            result = await _handle_add(ctx, content, category, tags)
         case "capture":
-            return await _handle_capture(
+            result = await _handle_capture(
                 ctx,
                 text or content,
                 context_type=context_type,
@@ -1539,7 +1581,7 @@ async def memory(
             # the capture branch above; here we treat it as a search filter
             # only when caller did not leave it at the conversation default.
             ctype_filter = context_type if context_type != "conversation" else None
-            return await _handle_search(
+            result = await _handle_search(
                 ctx,
                 query,
                 category,
@@ -1552,38 +1594,38 @@ async def memory(
                 include_archived=include_archived,
             )
         case "list":
-            return await _handle_list(ctx, category, limit)
+            result = await _handle_list(ctx, category, limit)
         case "as_of":
-            return await _handle_as_of(ctx, as_of, limit)
+            result = await _handle_as_of(ctx, as_of, limit)
         case "update":
-            return await _handle_update(
+            result = await _handle_update(
                 ctx, memory_id, content, category, tags, source, importance
             )
         case "delete":
-            return await _handle_delete(ctx, memory_id)
+            result = await _handle_delete(ctx, memory_id)
         case "export":
-            return await _handle_export(ctx)
+            result = await _handle_export(ctx)
         case "import":
-            return await _handle_import(ctx, data, mode)
+            result = await _handle_import(ctx, data, mode)
         case "stats":
-            return await _handle_stats(ctx)
+            result = await _handle_stats(ctx)
         case "restore":
-            return await _handle_restore(ctx, memory_id)
+            result = await _handle_restore(ctx, memory_id)
         case "archived":
-            return await _handle_archived(ctx, limit)
+            result = await _handle_archived(ctx, limit)
         case "archive_now":
-            return await _handle_archive_now(ctx)
+            result = await _handle_archive_now(ctx)
         case "consolidate":
-            return await _handle_consolidate(ctx, category)
+            result = await _handle_consolidate(ctx, category)
         case "compress":
-            return await _handle_memory_compress(ctx, memory_id)
+            result = await _handle_memory_compress(ctx, memory_id)
         case "entity_search":
             ent_type = context_type if context_type != "conversation" else None
-            return await _handle_entity_search(
+            result = await _handle_entity_search(
                 ctx, name=name or query, entity_type=ent_type, limit=limit
             )
         case "entity_graph":
-            return await _handle_entity_graph(
+            result = await _handle_entity_graph(
                 ctx,
                 entity_id=entity_id,
                 name=name or query,
@@ -1591,7 +1633,7 @@ async def memory(
                 limit=limit,
             )
         case "history":
-            return await _handle_history(ctx, entity_id=entity_id or memory_id)
+            result = await _handle_history(ctx, entity_id=entity_id or memory_id)
         case _:
             valid_actions = [
                 "add",
@@ -1629,7 +1671,10 @@ async def memory(
                 resp["suggestion"] = (
                     f"Available actions are: {', '.join(valid_actions)}."
                 )
-            return resp
+            result = resp
+
+    result["_deprecation"] = _deprecation_notice(action)
+    return result
 
 
 @mcp.tool(

--- a/tests/test_memory_deprecation.py
+++ b/tests/test_memory_deprecation.py
@@ -1,0 +1,142 @@
+"""Tests for the `memory` composite tool's deprecation warning.
+
+W6.4: `memory` stays fully functional (no behavior change) but now surfaces
+a deprecation notice pointing callers at the granular tools -- in the tool
+description (static, seen at `tools/list` time) and in a `_deprecation`
+field added to every response (seen at call time, action-aware).
+"""
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.server import add_memory, mcp, memory, search_memory
+
+_DEPRECATION_TAG = (
+    "[DEPRECATED — use the granular tools (add_memory, search_memory, ...) "
+    "instead; this composite tool will be removed in a future release]"
+)
+
+
+@pytest.fixture
+def ctx_with_db(tmp_path: Path) -> Generator[tuple[MagicMock, MemoryDB]]:
+    """Mock MCP Context with fresh DB (mirrors tests/test_server.py)."""
+    db = MemoryDB(tmp_path / "deprecation_test.db", embedding_dims=0)
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {
+        "db": db,
+        "embedding_model": None,
+        "embedding_dims": 0,
+    }
+    yield ctx, db
+    db.close()
+
+
+class TestMemoryToolDescriptionDeprecated:
+    """(a) The `memory` tool description leads with a `[DEPRECATED` tag."""
+
+    async def test_description_starts_with_deprecated_tag(self):
+        tools = await mcp.list_tools()
+        memory_tool = next(t for t in tools if t.name == "memory")
+        assert memory_tool.description is not None
+        assert memory_tool.description.startswith(_DEPRECATION_TAG)
+
+    async def test_description_still_documents_actions(self):
+        # Existing action-guide content must survive -- only prepended to,
+        # not replaced.
+        tools = await mcp.list_tools()
+        memory_tool = next(t for t in tools if t.name == "memory")
+        assert memory_tool.description is not None
+        assert "ACTION GUIDE" in memory_tool.description
+        assert "action='add'" in memory_tool.description
+
+
+class TestMemoryResponseDeprecationField:
+    """(b) Representative actions (add/search/as_of) get `_deprecation`."""
+
+    async def test_add_response_suggests_add_memory(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(action="add", content="test memory", ctx=ctx)
+        assert "_deprecation" in result
+        assert result["_deprecation"]["use_instead"] == "add_memory"
+        assert "add_memory" in result["_deprecation"]["message"]
+
+    async def test_search_response_suggests_search_memory(self, ctx_with_db):
+        ctx, db = ctx_with_db
+        db.add("Python is great for AI and machine learning")
+        result = await memory(action="search", query="Python AI", ctx=ctx)
+        assert result["_deprecation"]["use_instead"] == "search_memory"
+        assert "search_memory" in result["_deprecation"]["message"]
+
+    async def test_as_of_response_has_no_granular_equivalent(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(action="as_of", as_of="2026-01-01T00:00:00", ctx=ctx)
+        assert "_deprecation" in result
+        assert result["_deprecation"]["use_instead"] is None
+        assert "as_of" in result["_deprecation"]["message"]
+
+    async def test_as_of_guard_error_path_also_has_deprecation(self, ctx_with_db):
+        """The early-return guard (as_of + non-as_of action) is also a
+        `memory()` response and must carry the same field."""
+        ctx, _ = ctx_with_db
+        result = await memory(
+            action="search", query="x", as_of="2026-01-01T00:00:00", ctx=ctx
+        )
+        assert "error" in result
+        assert "_deprecation" in result
+        assert result["_deprecation"]["use_instead"] == "search_memory"
+
+    async def test_unknown_action_response_has_deprecation(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(action="invalid", ctx=ctx)
+        assert "error" in result
+        assert "_deprecation" in result
+        assert result["_deprecation"]["use_instead"] is None
+
+    async def test_none_action_response_has_deprecation(self):
+        result = await memory(action=None)
+        assert "error" in result
+        assert "_deprecation" in result
+
+
+class TestMemoryDeprecationBehaviorUnchanged:
+    """(c) Regression: only a new field is added; nothing else changes."""
+
+    async def test_add_existing_fields_unchanged(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(action="add", content="test memory", ctx=ctx)
+        assert result["status"] == "saved"
+        assert result["id"]
+        assert result["semantic"] is False
+        assert set(result) == {"id", "status", "category", "semantic", "_deprecation"}
+
+    async def test_add_no_content_error_path_unchanged(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(action="add", ctx=ctx)
+        assert "error" in result
+        assert "suggestion" in result
+        assert "_deprecation" in result
+
+    async def test_unknown_action_valid_actions_list_unchanged(self, ctx_with_db):
+        ctx, _ = ctx_with_db
+        result = await memory(action="invalid", ctx=ctx)
+        assert "valid_actions" in result
+        assert "add" in result["valid_actions"]
+        assert "Available actions are:" in result["suggestion"]
+
+    async def test_granular_add_memory_tool_unaffected(self, ctx_with_db):
+        """The specialized tools share `_handle_*` with `memory()` but must
+        NOT pick up the deprecation field -- only the composite dispatcher
+        is deprecated, not its handlers."""
+        ctx, _ = ctx_with_db
+        result = await add_memory(content="direct call", ctx=ctx)
+        assert "_deprecation" not in result
+
+    async def test_granular_search_memory_tool_unaffected(self, ctx_with_db):
+        ctx, db = ctx_with_db
+        db.add("direct search target")
+        result = await search_memory(query="direct search", ctx=ctx)
+        assert "_deprecation" not in result

--- a/tests/test_memory_deprecation.py
+++ b/tests/test_memory_deprecation.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from mnemo_mcp.db import MemoryDB
-from mnemo_mcp.server import add_memory, mcp, memory, search_memory
+from mnemo_mcp.server import add_memory, help, mcp, memory, search_memory
 
 _DEPRECATION_TAG = (
     "[DEPRECATED — use the granular tools (add_memory, search_memory, ...) "
@@ -52,6 +52,14 @@ class TestMemoryToolDescriptionDeprecated:
         assert memory_tool.description is not None
         assert "ACTION GUIDE" in memory_tool.description
         assert "action='add'" in memory_tool.description
+
+    async def test_live_help_doc_also_carries_deprecated_tag(self):
+        # The `help(topic="memory")` doc is live tool surface too (an LLM
+        # client can read it instead of/alongside the tool description), so
+        # it must carry the same deprecation notice.
+        doc = await help(topic="memory")
+        assert _DEPRECATION_TAG in doc
+        assert "add_memory" in doc
 
 
 class TestMemoryResponseDeprecationField:


### PR DESCRIPTION
## Summary
- `memory` composite dispatcher duplicated the 11 granular single-purpose tools (add_memory, search_memory, ...), causing tool-choice noise for LLM clients (N+2 tool inversion, per 2026-07-16 ux-audit).
- This PR marks `memory` deprecated for one release cycle without removing it: tool description now leads with `[DEPRECATED — use the granular tools (add_memory, search_memory, ...) instead; this composite tool will be removed in a future release]`, and every `memory()` response gets a `_deprecation` field naming the granular-tool replacement for the action just called (or noting none exists yet for Phase 3 actions: capture/archive_now/as_of/compress/entity_search/entity_graph/history).
- Behavior is unchanged otherwise — same return shapes, same error handling, only a new field added.
- README.md / AGENTS.md / CLAUDE.md tool tables updated to mark `memory` deprecated and point at the granular tools.

## Test plan
- [x] New `tests/test_memory_deprecation.py` (13 tests, 3 groups per spec): (a) description carries the `[DEPRECATED` tag, (b) representative actions (add/search/as_of + guard/unknown/None-action paths) get `_deprecation` with the correct granular-tool suggestion, (c) regression — existing response fields unchanged, granular tools (add_memory/search_memory) themselves unaffected.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` all pass.
- [x] Full `uv run pytest` (1362 tests, default marker) passes.
- [x] Local pre-commit hooks (gitleaks, ruff, ty, pytest, CLAUDE.md/AGENTS.md sync guard) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BDQppEphd9i2hfu1x35Ns