### PR TITLE
fix: deprecate setup_relay alias, add logout CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ mnemo-mcp --http                # start the Streamable HTTP server
 
 mnemo-mcp auth google           # authorize Google Drive sync via OAuth
 mnemo-mcp auth google --client-id <ID> --client-secret <SECRET>   # bring-your-own OAuth client
+mnemo-mcp logout                # clear the local Google Drive sync token
 mnemo-mcp warmup                # pre-download the bundled local embedding + rerank model
 
 mnemo-mcp config status         # report whether stored config exists

--- a/src/mnemo_mcp/cli.py
+++ b/src/mnemo_mcp/cli.py
@@ -67,6 +67,18 @@ def _handle_auth(args: argparse.Namespace) -> int:
     return 0 if result.get("status") == "authenticated" else 1
 
 
+def _handle_logout(args: argparse.Namespace) -> int:
+    from mnemo_mcp.token_store import delete_token, load_token
+
+    if load_token("google_drive") is None:
+        print("Nothing to log out (no saved Google Drive token).")
+        return 0
+
+    delete_token("google_drive")
+    print("Logged out. Google Drive sync token cleared.")
+    return 0
+
+
 def _handle_warmup(args: argparse.Namespace) -> int:
     from mnemo_mcp.setup_tool import run_warmup
 
@@ -79,6 +91,7 @@ def _extras() -> dict:
     return {
         "auth": (_configure_auth, _handle_auth),
         "warmup": _handle_warmup,
+        "logout": _handle_logout,
     }
 
 

--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -169,9 +169,11 @@ backend if needed. Returns the updated `state` value.
 
 **Parameters:** None (uses request `ctx`)
 
-### `setup_relay` - Backward-compatible alias for `setup_start`
+### `setup_relay` - DEPRECATED, use `setup_start` instead
 
-Equivalent to `setup_start(key="force")`. Kept for older clients.
+Equivalent to `setup_start(key="force")`. Kept for one release cycle for
+older clients; the response carries a `_deprecation` field pointing at
+`setup_start`. Will be removed in a future release.
 
 **Parameters:** None
 

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2056,8 +2056,16 @@ async def _handle_config_setup_complete(
 
 
 async def _handle_config_setup_relay() -> dict[str, typing.Any]:
-    # Backward compat alias for setup_start.
-    return await _handle_config_setup_start(key="force")
+    """Deprecated alias for setup_start (removed in a future release)."""
+    result = await _handle_config_setup_start(key="force")
+    result["_deprecation"] = {
+        "message": (
+            "setup_relay is deprecated and will be removed in a future "
+            "release. Use setup_start instead."
+        ),
+        "use_instead": "setup_start",
+    }
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,40 @@ class TestAuthSubcommand:
         assert rc == 1
 
 
+class TestLogoutSubcommand:
+    """`mnemo-mcp logout` -- clears the local Google Drive sync token."""
+
+    def test_clears_saved_token(self, capsys):
+        from mnemo_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "logout"]),
+            patch(
+                "mnemo_mcp.token_store.load_token", return_value={"refresh_token": "x"}
+            ),
+            patch("mnemo_mcp.token_store.delete_token") as mock_delete,
+        ):
+            rc = cli.main()
+
+        mock_delete.assert_called_once_with("google_drive")
+        assert rc == 0
+        assert "cleared" in capsys.readouterr().out.lower()
+
+    def test_nothing_to_clear(self, capsys):
+        from mnemo_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["mnemo-mcp", "logout"]),
+            patch("mnemo_mcp.token_store.load_token", return_value=None),
+            patch("mnemo_mcp.token_store.delete_token") as mock_delete,
+        ):
+            rc = cli.main()
+
+        mock_delete.assert_not_called()
+        assert rc == 0
+        assert "nothing to log out" in capsys.readouterr().out.lower()
+
+
 class TestUnknownSubcommand:
     """build_cli's own unrecognized-subcommand handling -- rc 2, no server start."""
 

--- a/tests/test_server_setup_actions.py
+++ b/tests/test_server_setup_actions.py
@@ -229,6 +229,15 @@ class TestSetupRelay:
         assert result["status"] == "stdio_unsupported"
         assert "--http" in result["message"]
 
+    async def test_relay_alias_carries_deprecation_notice(self, ctx_with_db):
+        """setup_relay is deprecated in favor of setup_start (kept 1 cycle)."""
+        ctx, _ = ctx_with_db
+
+        result = await config(action="setup_relay", ctx=ctx)
+
+        assert result["_deprecation"]["use_instead"] == "setup_start"
+        assert "setup_start" in result["_deprecation"]["message"]
+
 
 # ---------------------------------------------------------------------------
 # _maybe_include_setup_hint


### PR DESCRIPTION
## Summary

Cross-server taxonomy parity work (WS6/WS5 of the S16 backlog spec):

- **Deprecate `config(action='setup_relay')`**: it is a hardcoded backward-compat alias for `setup_start` (`_handle_config_setup_relay` always called `_handle_config_setup_start(key="force")`), i.e. two tool actions doing the exact same job. Kept working for one release cycle; the response now carries a `_deprecation` field (`message` + `use_instead: "setup_start"`) so callers get a pointer instead of a silent duplicate surface. `setup_start` itself was already conformant with the other 6 servers' convention on `origin/main` — only the redundant alias needed handling.
- **`mnemo-mcp logout` CLI subcommand**: pairs with the existing `auth google` subcommand (clears the local Google Drive sync token), matching the `auth`+`logout` shape used elsewhere in the stack.
- BYOK (env var `GOOGLE_DRIVE_CLIENT_ID`/`_SECRET` + CLI flag, flag overrides env, via `resolve_bundled_client`) was already conformant on `origin/main` — no change needed there.

Docs updated: `src/mnemo_mcp/docs/config.md` (`setup_relay` section marked deprecated) + `README.md` (CLI subcommand list).

Note for the taxonomy tracking: this repo's `setup_sync` action is a distinct Google Drive docs-sync OAuth flow (Device Code), unrelated to the generic `setup_start` relay-trigger convention — not touched here (companion wet-mcp PR adds the missing `setup_start` there for the same reason, see n24q02m/wet-mcp#1545).

## Test plan

- [x] TDD: failing tests added first (`tests/test_server_setup_actions.py::TestSetupRelay::test_relay_alias_carries_deprecation_notice`, `tests/test_cli.py::TestLogoutSubcommand::*`), then implementation, then green.
- [x] Full suite: `uv run pytest` — 1368 passed, 5 skipped, 0 failures.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` all pass.
- [x] Pre-commit hooks pass (gitleaks, ruff, ty, full pytest, whitespace/EOF/CLAUDE.md sync).