### PR TITLE
fix: bump mcp-core to 1.20.0b2 for plugin-name and CLI fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,12 @@ dependencies = [
     "qwen3-embed>=1.12.1",
     # 1.19.0 ships mcp_core.cli's argument-spec extra subcommand
     # support ((configure, handler) tuples) this repo's cli.py auth
-    # subcommand consumes.
-    "n24q02m-mcp-core[llm]>=1.19.0,<2",
+    # subcommand consumes. 1.20.0b2 fixes build_cli's `config`/`doctor`
+    # PerPluginStore key (#666): it defaulted to the display
+    # server_name ("mnemo-mcp") instead of the plugin slug ("mnemo")
+    # this server actually saves credentials under, so `mnemo-mcp
+    # config status` always reported "not configured".
+    "n24q02m-mcp-core[llm]>=1.20.0b2,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1045,7 +1045,7 @@ wheels = [
 
 [[package]]
 name = "mnemo-mcp"
-version = "2.6.0"
+version = "2.7.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1090,7 +1090,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.20.0b2,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1196,7 +1196,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.19.0"
+version = "1.20.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1211,9 +1211,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/82/5cf9177a7188dbf074a30ad057b9f7aeca8c546d34587311315215f92a9c/n24q02m_mcp_core-1.19.0.tar.gz", hash = "sha256:2109af5f1bd8a9387c135d7477b3deadfdcc3adbcfce354c7d4e3d49068d757a", size = 320002, upload-time = "2026-07-14T12:27:39.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/92/68abd1fc6491e83b4a91271b2690952dfe13bffb7c5cf27954ae3fe35bea/n24q02m_mcp_core-1.20.0b2.tar.gz", hash = "sha256:b2e85cf7eacb45457fba491bdd8927cc92947ff0184904ba9719ecd94fbd28a4", size = 345349, upload-time = "2026-07-17T06:24:34.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/c6/d755370d27c6963dfa14e924b35c5ccfb2830361ed4d989813fbb4bc94ec/n24q02m_mcp_core-1.19.0-py3-none-any.whl", hash = "sha256:b91bae678620470f084ba91d9d4767ef05843d42316a3c9d5c4fb25325210be8", size = 178192, upload-time = "2026-07-14T12:27:38.065Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/79/a4c91fa9a9778ae7b1b58ac51b196a4b35de2de33faf6dfee0e79a6a3f6b/n24q02m_mcp_core-1.20.0b2-py3-none-any.whl", hash = "sha256:67b5ec30bd4712cf9a29a5de397a4c9338846cb2e6cf9233b98f976f44b5919a", size = 189470, upload-time = "2026-07-17T06:24:33.11Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump `n24q02m-mcp-core[llm]` floor from `>=1.19.0,<2` to `>=1.20.0b2,<2`.
- Picks up mcp-core#666: `build_cli`'s `config`/`doctor` credential-store key defaulted to the display `server_name` (`mnemo-mcp`) instead of the plugin slug (`mnemo`) this server actually saves credentials under, so `mnemo-mcp config status` / `mnemo-mcp doctor` always reported "not configured" even with a valid saved config.

## Test plan
- [x] `uv lock` resolves `n24q02m-mcp-core` 1.19.0 -> 1.20.0b2 from PyPI (no local path source).
- [x] Reproduced the bug pre-bump: saved a cred via `PerPluginStore("mnemo")`, `mnemo-mcp config status` (mcp-core 1.19.0) reported `mnemo-mcp: not configured`.
- [x] Verified the fix post-bump: same saved cred, `mnemo-mcp config status` (mcp-core 1.20.0b2) reports `mnemo-mcp: configured (source: file)`.
- [x] Full `uv run pytest` suite: 1368 passed, 5 skipped, 0 failed.