### PR TITLE
feat: per-sub custom endpoint (api_base) in relay for gateway routing

### DIFF
--- a/src/mnemo_mcp/credential_state.py
+++ b/src/mnemo_mcp/credential_state.py
@@ -43,6 +43,12 @@ CLOUD_KEYS = [
     "ANTHROPIC_API_KEY",
     "XAI_API_KEY",
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
+    # Per-sub custom endpoints (SSRF-vetted in mcp_core.llm dispatch). Listed
+    # here so credentials_for_current_request() keeps them through the
+    # os.environ filter and the per-sub config apply loop, same as the keys.
+    "EMBEDDING_API_BASE",
+    "RERANK_API_BASE",
+    "LLM_API_BASE",
 ]
 
 # All config keys that indicate a valid saved config (includes GDrive)

--- a/src/mnemo_mcp/relay_schema.py
+++ b/src/mnemo_mcp/relay_schema.py
@@ -47,6 +47,22 @@ def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
     }
 
 
+def _api_base_field(key: str, label: str, help_text: str) -> dict[str, Any]:
+    # Always-visible (not derived): the renderer only reveals a derived field
+    # when a model chip derives that exact provider ENV key, and no model
+    # derives *_API_BASE, so a derived endpoint field would stay hidden. The
+    # optional badge comes from required:false. Value is SSRF-vetted per-sub in
+    # mcp_core.llm dispatch before any request.
+    return {
+        "key": key,
+        "label": label,
+        "type": "url",
+        "placeholder": "https://gateway.example/…",
+        "helpText": help_text,
+        "required": False,
+    }
+
+
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "mnemo-mcp",
     "displayName": "Mnemo MCP",
@@ -65,6 +81,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": True,
             "placeholder": "add embedding model…",
         },
+        _api_base_field(
+            "EMBEDDING_API_BASE",
+            "Embedding endpoint",
+            "Custom endpoint / CF AI Gateway. Cohere: {gw}/cohere/v2/embed",
+        ),
         {
             "key": "RERANK_MODELS",
             "label": "Rerank models",
@@ -74,6 +95,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": True,
             "placeholder": "add rerank model…",
         },
+        _api_base_field(
+            "RERANK_API_BASE",
+            "Rerank endpoint",
+            "Custom endpoint / CF AI Gateway. Cohere: {gw}/cohere (litellm appends /v1/rerank)",
+        ),
         {
             "key": "LLM_MODELS",
             "label": "LLM models",
@@ -83,6 +109,11 @@ RELAY_SCHEMA: dict[str, Any] = {
             "hasLocal": False,
             "placeholder": "add LLM model…",
         },
+        _api_base_field(
+            "LLM_API_BASE",
+            "LLM endpoint",
+            "Custom endpoint / CF AI Gateway for graph/importance LLM calls.",
+        ),
         _key_field(
             "JINA_AI_API_KEY", "Jina AI API Key", "jina_...", "https://jina.ai/api-key"
         ),

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -468,3 +468,51 @@ class TestResetState:
             reset_state()
 
         assert get_state() == CredentialState.AWAITING_SETUP
+
+
+# ---------------------------------------------------------------------------
+# Per-sub custom endpoint (api_base) -- relay/gateway routing
+# ---------------------------------------------------------------------------
+
+
+class TestApiBaseCloudKeys:
+    def test_cloud_keys_includes_api_base(self):
+        # api_base env vars ride the same per-sub rails as provider keys:
+        # membership in CLOUD_KEYS makes credentials_for_current_request()
+        # keep them through the os.environ filter (stdio/single-user) and the
+        # per-sub config apply loop.
+        assert "EMBEDDING_API_BASE" in CLOUD_KEYS
+        assert "RERANK_API_BASE" in CLOUD_KEYS
+        assert "LLM_API_BASE" in CLOUD_KEYS
+
+    def test_per_sub_api_base_survives_filter(self, monkeypatch):
+        from mnemo_mcp.credential_state import credentials_for_current_request
+
+        monkeypatch.setenv("EMBEDDING_API_BASE", "https://gw-a.example/cohere/v2/embed")
+        assert (
+            credentials_for_current_request()["EMBEDDING_API_BASE"]
+            == "https://gw-a.example/cohere/v2/embed"
+        )
+
+
+class TestApiBaseSSRF:
+    async def test_embedder_loopback_api_base_blocked_in_multi_user(self, monkeypatch):
+        # Multi-user (PUBLIC_URL set): a per-sub custom endpoint pointing at
+        # loopback/private is rejected by the mcp-core SSRF vet before any
+        # network call. mnemo reads os.getenv(EMBEDDING_API_BASE) and passes it
+        # to mcp_core.llm.aembedding, which vets via _prep_api_base -- no local
+        # wrap needed.
+        import pytest
+        from mcp_core.http import SSRFBlockedError
+
+        from mnemo_mcp.embedder import CloudEmbeddingBackend
+
+        monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example.com")
+        monkeypatch.setenv("EMBEDDING_API_BASE", "http://127.0.0.1:11434")
+        # Stub the lazy litellm accessor so the test exercises the real vet in
+        # dispatch._prep_api_base without the multi-second litellm cold import.
+        # The vet runs before the (mocked) network leg, so the block still fires.
+        monkeypatch.setattr("mcp_core.llm.dispatch._get_litellm", MagicMock())
+        backend = CloudEmbeddingBackend("cohere/embed-multilingual-v3.0")
+        with pytest.raises(SSRFBlockedError):
+            await backend._call_provider(["hello"])

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -35,3 +35,33 @@ def test_vertex_express_key_field_present_and_derived():
     assert "GOOGLE_VERTEX_EXPRESS_API_KEY" in by_key
     assert by_key["GOOGLE_VERTEX_EXPRESS_API_KEY"].get("derived") is True
     assert "VERTEX_AI_API_KEY" not in by_key  # no dead-end field
+
+
+API_BASE_KEYS = ("EMBEDDING_API_BASE", "RERANK_API_BASE", "LLM_API_BASE")
+
+
+def test_api_base_fields_present_as_url():
+    by_key = {f["key"]: f for f in RELAY_SCHEMA["fields"]}
+    for key in API_BASE_KEYS:
+        assert key in by_key, f"{key} missing from relay schema"
+        assert by_key[key]["type"] == "url"
+        assert by_key[key]["required"] is False
+
+
+def test_api_base_fields_not_derived():
+    # api_base fields must stay always-visible: the renderer only reveals a
+    # ``derived`` field when a model chip derives that exact provider ENV key
+    # (data-provider-key match). No model derives *_API_BASE, so a derived
+    # api_base field would be hidden forever. required:false already carries
+    # the "Optional" badge, so visibility costs nothing.
+    by_key = {f["key"]: f for f in RELAY_SCHEMA["fields"]}
+    for key in API_BASE_KEYS:
+        assert not by_key[key].get("derived"), (
+            f"{key} must not be derived (would hide it)"
+        )
+
+
+def test_api_base_help_documents_cohere_gateway_path():
+    by_key = {f["key"]: f for f in RELAY_SCHEMA["fields"]}
+    assert "cohere/v2/embed" in by_key["EMBEDDING_API_BASE"]["helpText"]
+    assert "cohere" in by_key["RERANK_API_BASE"]["helpText"]


### PR DESCRIPTION
Adds per-sub custom endpoint fields (`EMBEDDING_API_BASE`, `RERANK_API_BASE`, `LLM_API_BASE`) to the relay setup form so each JWT-sub can route litellm through a custom endpoint / CF AI Gateway, instead of a server-wide env shared across subs.

## Changes
- `credential_state.py`: add the three `*_API_BASE` keys to `CLOUD_KEYS` so `credentials_for_current_request()` keeps them through the os.environ filter and per-sub config apply, same rails as the provider keys.
- `relay_schema.py`: add three `type: "url"`, `required: false` fields, one per task, placed next to the matching model-chain.

## Design notes
- **Fields are always-visible (not `derived`)**: the form renderer only reveals a `derived` field when a model chip derives that exact provider ENV key (`data-provider-key` match). No model derives `*_API_BASE`, so a derived endpoint field would stay hidden forever. `required: false` already renders the "Optional" badge, so always-visible costs nothing. Verified by rendering the schema through `mcp_core.auth.credential_form._render_field` (no `display:none`, `type="url"`).
- **SSRF: already vetted, no local wrap needed.** The embedder/reranker/llm read `os.getenv(*_API_BASE)` and pass `api_base=` to `mcp_core.llm.{aembedding,embedding,rerank,acompletion}`, all of which run `_prep_api_base` -> `vet_api_base` before any litellm call. In multi-user mode (`PUBLIC_URL` set) loopback + private are blocked unconditionally. Regression-guarded by a test driving the real embedder path with a loopback endpoint.
- Cohere gateway path documented in help text: embed `{gw}/cohere/v2/embed` (as-is), rerank `{gw}/cohere` (litellm appends `/v1/rerank`).

## Tests
`test_relay_schema.py` (fields present as url, not derived, help documents cohere path) + `test_credential_state.py` (CLOUD_KEYS membership, per-sub filter survival, SSRF loopback reject). Full suite green (local shell env-pollution failures in `test_config.py` are pre-existing and pass in a clean CI env).

mcp-core pin already at `>=1.20.0b2` (via #993); this PR is feature-only.