### PR TITLE
fix: recover from unsupported embedding dimension instead of silent semantic degrade

### DIFF
--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -54,9 +54,46 @@ _RETRYABLE_PATTERNS = (
 )
 
 
+# Patterns marking a PERMANENT client-side error (invalid request, unsupported
+# capability, auth). litellm frequently re-wraps these as APIConnectionError --
+# whose class name contains "connection" and whose status_code is a hardcoded
+# 500 -- so classification MUST look at the message semantics, not the exception
+# class or status code. Retrying a permanent error re-sends the same doomed
+# request and (worse) would block capability fallbacks such as dropping an
+# unsupported `dimensions` argument.
+_PERMANENT_PATTERNS = (
+    "not a valid",
+    "not support",
+    "unsupported",
+    "invalid request",
+    "invalid_request",
+    "invalid api key",
+    "output_dimension",
+    "unauthorized",
+    "forbidden",
+    "authentication",
+    "no such model",
+    "model not found",
+    "does not exist",
+    "401",
+    "403",
+    "404",
+    "422",
+)
+
+
 def _is_retryable(exc: Exception) -> bool:
-    """Check if an exception is transient and worth retrying."""
+    """Return True only for TRANSIENT errors worth retrying.
+
+    Classifies on error semantics, NOT the exception class name or a synthetic
+    status_code: litellm wraps a provider's permanent 4xx (e.g. a 422 "invalid
+    output_dimension") as ``APIConnectionError`` whose repr contains "connection"
+    and whose ``status_code`` is a hardcoded 500 -- matching either would wrongly
+    retry a request that can never succeed and skip the dimensions fallback.
+    """
     msg = str(exc).lower()
+    if any(p in msg for p in _PERMANENT_PATTERNS):
+        return False
     return any(p in msg for p in _RETRYABLE_PATTERNS)
 
 
@@ -274,16 +311,16 @@ class CloudEmbeddingBackend:
                     embeddings = [e[:dimensions] for e in embeddings]
                 return embeddings
             except Exception as e:
-                # If the provider rejects `dimensions`, retry without it
-                # and truncate locally instead.
-                if (
-                    use_dimensions
-                    and not _is_retryable(e)
-                    and _is_unsupported_param(e, "dimensions")
-                ):
-                    logger.debug(
-                        f"Provider does not support dimensions param, "
-                        f"will truncate locally: {e}"
+                # A dimensions rejection is PERMANENT -- retrying with the same
+                # dims can never succeed. Recover (drop `dimensions`, truncate
+                # locally) BEFORE the retryability check: litellm may wrap the
+                # provider's 422 as an APIConnectionError, so retry
+                # classification must not gate this capability fallback.
+                if use_dimensions and _is_unsupported_param(e, "dimensions"):
+                    logger.warning(
+                        f"Provider {self.model} rejected dimensions="
+                        f"{use_dimensions}; retrying without it and truncating "
+                        f"locally: {e}"
                     )
                     use_dimensions = None
                     continue

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -481,8 +481,25 @@ async def _embed(
             return await backend.embed_single_query(text, dims)
         return await backend.embed_single(text, dims)
     except Exception as e:
-        logger.debug(f"Embedding failed: {e}")
-        return None
+        from mnemo_mcp.embedder import _is_retryable
+
+        if _is_retryable(e):
+            # Transient (rate-limit / network; the backend already exhausted
+            # its retries). Degrade THIS call to FTS5 -- the next may succeed.
+            logger.warning(
+                f"Embedding transiently unavailable ({model}); "
+                f"degrading to FTS5 for this call: {e}"
+            )
+            return None
+        # Permanent config/capability error (bad key, unknown model, dims the
+        # backend could not work around): every embed will fail. Surface it
+        # loudly instead of silently returning None and hiding a broken
+        # semantic search behind a FTS5 fallback.
+        logger.error(
+            f"Embedding permanently failing ({model}): {e}. "
+            "Check EMBEDDING_MODELS / EMBEDDING_DIMS / API key."
+        )
+        raise
 
 
 async def _handle_add(

--- a/tests/test_embedder_silent_dims.py
+++ b/tests/test_embedder_silent_dims.py
@@ -1,0 +1,120 @@
+"""Regression tests for the silent semantic-degrade bug.
+
+When a cloud provider rejects the requested output ``dimensions`` (e.g.
+``cohere/embed-v4.0`` at mnemo's default 768; cohere-v4 supports only
+{256, 512, 1024, 1536}), litellm wraps the provider's HTTP 422 as an
+``APIConnectionError`` whose class name contains "connection" and whose
+``status_code`` is a synthetic 500. The old ``_is_retryable`` matched the
+"connection" substring, so the dimensions-fallback was bypassed and the call
+was retried 3x with the SAME rejected dims, then gave up -> ``_embed`` returned
+None -> semantic search silently degraded to FTS5 with no error surfaced.
+
+These tests reproduce that exact shape (litellm exceptions, dims-aware mock)
+and lock in the fix: unsupported-dimensions recover via retry-without-dims +
+local truncate, and permanent client errors are never retried.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from litellm.exceptions import APIConnectionError, RateLimitError
+
+from mnemo_mcp.embedder import MAX_RETRIES, CloudEmbeddingBackend, _is_retryable
+
+# The exact provider body cohere returns for an unsupported output_dimension,
+# as litellm surfaces it after wrapping the 422 in APIConnectionError.
+_COHERE_422_BODY = (
+    'CohereException - {"message": "768 is not a valid output_dimension, '
+    'use one of 256, 512, 1024, 1536"}'
+)
+
+
+def _wrapped_422() -> APIConnectionError:
+    """A litellm APIConnectionError wrapping cohere's 422 dims rejection."""
+    return APIConnectionError(
+        message=_COHERE_422_BODY, llm_provider="cohere", model="embed-v4.0"
+    )
+
+
+class TestIsRetryableClassification:
+    """`_is_retryable` must classify on error semantics, not class name."""
+
+    def test_wrapped_422_unsupported_dimension_is_not_retryable(self):
+        exc = _wrapped_422()
+        # Guard: this really is the tricky shape (class name -> "connection",
+        # synthetic 500) that fooled the old substring matcher.
+        assert "connection" in str(exc).lower()
+        assert getattr(exc, "status_code", None) == 500
+
+        assert _is_retryable(exc) is False
+
+    def test_genuine_connection_error_is_retryable(self):
+        exc = APIConnectionError(
+            message="Connection error.", llm_provider="cohere", model="embed-v4.0"
+        )
+        assert _is_retryable(exc) is True
+
+    def test_rate_limit_is_retryable(self):
+        exc = RateLimitError(
+            message="rate limit exceeded", llm_provider="cohere", model="embed-v4.0"
+        )
+        assert _is_retryable(exc) is True
+
+    def test_invalid_api_key_is_not_retryable(self):
+        exc = APIConnectionError(
+            message="AuthenticationError - invalid api key",
+            llm_provider="cohere",
+            model="embed-v4.0",
+        )
+        assert _is_retryable(exc) is False
+
+
+@pytest.mark.asyncio
+class TestWrappedDimsRejectionRecovery:
+    """The litellm-wrapped 422 must trigger the retry-without-dims fallback."""
+
+    async def test_wrapped_422_triggers_dims_fallback_and_truncates(self):
+        # Dims-aware fake: the provider REJECTS every dims-bearing call (as
+        # cohere-v4 does at 768) and only succeeds when dims are dropped.
+        # A non-dims-aware mock would let the buggy retry "recover" by luck and
+        # hide the defect.
+        native_dim = 1536
+
+        async def fake_call(texts, dimensions=None):
+            if dimensions is not None:
+                raise _wrapped_422()
+            return [[0.1] * native_dim for _ in texts]
+
+        backend = CloudEmbeddingBackend(model="cohere/embed-v4.0")
+        with patch.object(
+            backend, "_call_provider", new=AsyncMock(side_effect=fake_call)
+        ) as mock_call:
+            result = await backend._embed_batch_inner(["hello"], dimensions=768)
+
+        # Recovered: valid vector truncated locally to the requested 768.
+        assert len(result[0]) == 768
+        assert result[0] == [0.1] * 768
+        # Exactly two provider calls: dims=768 (rejected) then dims=None (ok).
+        assert mock_call.call_count == 2
+        assert mock_call.call_args_list[0].args[1] == 768
+        assert mock_call.call_args_list[1].args[1] is None
+
+    async def test_wrapped_422_is_not_retried_with_same_dims(self):
+        # If the fallback did NOT fire, the buggy code would retry MAX_RETRIES
+        # times with the same rejected dims. Assert it does NOT.
+        async def always_reject(texts, dimensions=None):
+            raise _wrapped_422()
+
+        backend = CloudEmbeddingBackend(model="cohere/embed-v4.0")
+        with patch.object(
+            backend, "_call_provider", new=AsyncMock(side_effect=always_reject)
+        ) as mock_call:
+            with pytest.raises(APIConnectionError):
+                await backend._embed_batch_inner(["hello"], dimensions=768)
+
+        # 1 dims=768 attempt (rejected) + 1 dims=None fallback attempt (also
+        # rejected) = 2. NOT MAX_RETRIES retries of the same bad dims.
+        assert mock_call.call_count == 2
+        assert mock_call.call_count < MAX_RETRIES + 1
+        assert mock_call.call_args_list[0].args[1] == 768
+        assert mock_call.call_args_list[1].args[1] is None

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -57,14 +57,31 @@ class TestEmbed:
             result = await _embed("test text", "some-model", 768)
             assert result is None
 
-    async def test_embed_exception_returns_none(self):
-        """Returns None when embedding raises an exception."""
+    async def test_embed_transient_exception_returns_none(self):
+        """A transient embedding error degrades this call to None (FTS5-only)."""
+        from litellm.exceptions import RateLimitError
+
         mock_backend = MagicMock()
-        mock_backend.embed_single = AsyncMock(side_effect=Exception("API error"))
+        mock_backend.embed_single = AsyncMock(
+            side_effect=RateLimitError(
+                message="rate limit exceeded", llm_provider="cohere", model="m"
+            )
+        )
 
         with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
             result = await _embed("test text", "some-model", 768)
             assert result is None
+
+    async def test_embed_permanent_exception_raises(self):
+        """A permanent embedding error is surfaced loudly, not swallowed to None."""
+        mock_backend = MagicMock()
+        mock_backend.embed_single = AsyncMock(
+            side_effect=Exception("model does not exist")
+        )
+
+        with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
+            with pytest.raises(Exception, match="does not exist"):
+                await _embed("test text", "some-model", 768)
 
     async def test_embed_with_qwen3_query(self):
         """Uses query_embed for Qwen3 backend with is_query=True."""

--- a/tests/test_server_embed.py
+++ b/tests/test_server_embed.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from litellm.exceptions import APIConnectionError, RateLimitError
 
 from mnemo_mcp.embedder import Qwen3EmbedBackend
 from mnemo_mcp.server import _embed
@@ -51,11 +52,34 @@ async def test_embed_with_qwen3_backend_doc():
 
 
 @pytest.mark.asyncio
-async def test_embed_backend_exception():
-    """Test _embed handles backend exceptions gracefully."""
+async def test_embed_transient_error_degrades_to_none():
+    """A transient backend error (rate-limit/network) degrades this call to FTS5.
+
+    The next call may succeed, so returning None (FTS5-only for this call) is the
+    correct graceful degradation.
+    """
     mock_backend = AsyncMock()
-    mock_backend.embed_single.side_effect = Exception("Embed error")
+    mock_backend.embed_single.side_effect = RateLimitError(
+        message="rate limit exceeded", llm_provider="cohere", model="embed-v4.0"
+    )
 
     with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
         result = await _embed("text", "model", 768)
         assert result is None
+
+
+@pytest.mark.asyncio
+async def test_embed_permanent_error_raises_loudly():
+    """A permanent backend error (bad key, unusable model/dims) must NOT be
+    silently swallowed into None -- every embed would fail, so surface it loudly.
+    """
+    mock_backend = AsyncMock()
+    mock_backend.embed_single.side_effect = APIConnectionError(
+        message="AuthenticationError - invalid api key",
+        llm_provider="cohere",
+        model="embed-v4.0",
+    )
+
+    with patch("mnemo_mcp.embedder.get_backend", return_value=mock_backend):
+        with pytest.raises(APIConnectionError):
+            await _embed("text", "model", 768)


### PR DESCRIPTION
## Problem

When a configured cloud embedding provider rejects the requested output
dimension, mnemo silently degraded to FTS5-only search with **no error
surfaced** — the user saw `semantic: false` but no signal that their embedding
was broken.

Concrete case: `cohere/embed-v4.0` at mnemo's default `EMBEDDING_DIMS=768`.
cohere-v4 supports only `{256, 512, 1024, 1536}`, so every embed returned
HTTP 422 (`768 is not a valid output_dimension`).

### Root cause

1. litellm wraps the provider's 422 as an `APIConnectionError` whose class name
   contains "connection" and whose `status_code` is a hardcoded `500`. The old
   `_is_retryable` matched the "connection" substring in `str(exc)`, so it
   returned `True` for a permanent client error.
2. `_embed_batch_inner` gated its "provider rejects dimensions → retry without
   dims + truncate locally" fallback behind `not _is_retryable(e)`. With
   `_is_retryable` wrongly `True`, the fallback was **bypassed**; the request was
   retried 3× with the same rejected dims, then gave up.
3. `server._embed` swallowed the resulting exception into `None`
   (`logger.debug` + `return None`) → `semantic: false`, no signal.

## Fix

- **`_is_retryable` classifies on error semantics**, not the exception class
  name or the synthetic `status_code`. Permanent client errors (invalid param,
  auth, not-found) are never retryable.
- **The dimensions fallback fires whenever the provider rejects the dims param**,
  before the retryability check — a dims rejection is permanent and litellm may
  wrap it as a connection error. Net effect: cohere-v4 @ 768 → retry without dims
  → native 1536 → truncate locally to 768 → semantic works.
- **Permanent embedding failures surface loudly** (`server._embed` re-raises)
  instead of returning `None` and hiding a broken semantic search. Transient
  failures (rate-limit / network, retries exhausted) still degrade gracefully for
  the single call.

`check_available()` is intentionally left probing without dims: once the fallback
works, a dims-bearing embed succeeds via local truncation, so the no-dims probe
correctly reports the model as available. Probing with dims through the raw
(non-fallback) path would wrongly reject a model that works.

## Tests

- `tests/test_embedder_silent_dims.py` (new):
  - `_is_retryable` returns `False` for a litellm-wrapped 422 unsupported-dimension
    (asserts on message/status, not class name) and `True` for a genuine
    connection error / rate-limit.
  - The wrapped 422 triggers the retry-without-dims fallback and truncates to the
    requested dims (dims-aware mock: the provider rejects every dims-bearing call,
    reproducing the retry-with-same-dims failure).
  - The wrapped 422 is not retried 3× with the same rejected dims.
- `tests/test_server_embed.py`, `tests/test_server_coverage.py`: `_embed` raises
  loudly on a permanent error and returns `None` (graceful FTS5) on a transient one.

Full suite green (1382 passed). Verified end-to-end against a live
`cohere/embed-v4.0` endpoint: `add_memory` + `search_memory` now report
`semantic: true` via the fallback/truncate path — no silent degradation.