### PR TITLE
feat: derive a stable subject from the workspace username

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,24 @@ This plugin implements **TC-Local** (machine-bound, single trust principal). The
 | HTTP self-host | Same as stdio | Same | Only you (admin = user) |
 | HTTP multi-user remote (`PUBLIC_URL`) | Per-JWT-sub credential store | AES-GCM | Only the authenticated user (per-`sub` isolation) |
 
+### Workspace username (HTTP setup form)
+
+The browser setup form has an optional **workspace username** field. Entering the
+same username always lands you in the same per-`sub` bucket, so your credentials
+and memories stay reachable across a re-authorization and across devices, instead
+of being tied to the one-off subject minted for each `/authorize` round-trip.
+Leaving it blank keeps the previous per-authorize behaviour.
+
+Trust boundary: when the form is gated by a *shared* `MCP_RELAY_PASSWORD`, the
+username is a partition key, not a secret -- anyone who knows that password can
+type any username and reach that bucket. That is fine for a trusted group; an
+untrusted multi-tenant deployment needs a per-user secret or delegated OAuth
+instead.
+
+**One-time migration:** existing users must re-enter their credentials once after
+this change. Nothing is deleted; credentials stored under the old random subject
+are simply no longer addressed.
+
 ## License
 
 MIT -- See [LICENSE](LICENSE).

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -2510,6 +2510,7 @@ async def run_http(port: int = 0) -> None:
         # "Waiting for authorization..." forever. Accepts legacy 1-arg core.
         setup_complete_hook=wire_gdrive_callbacks,
         auth_scope=_per_request_sub_scope if public_url else None,
+        stable_sub_enabled=True,
     )
 
 


### PR DESCRIPTION
Part of n24q02m/mcp-core#676. Enables the existing core-py stable-sub mechanism so credentials entered in a later authorize round-trip reach the same per-sub bucket, instead of the one-off subject minted per /authorize.

The browser setup form now shows an optional workspace-username field. Same username -> same per-sub bucket across re-auth and devices; blank keeps the previous random-subject behaviour.

WARNING -- one-time credential re-entry required: enabling this changes how the subject is computed, so credentials already stored under a random subject are no longer addressed (not deleted). Every existing user must re-enter credentials once at their next setup.

Trust boundary: with a SHARED relay password the username is a partition key, NOT a secret -- anyone who knows the password can submit any username and reach that bucket. Suitable for a trusted group; untrusted multi-tenant needs per-user secrets or delegated OAuth.

Gate run locally: ruff check + ruff format --check + pytest, all green.