### PR TITLE
fix: prevent internal exception exposure to clients

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1280,9 +1280,10 @@ async def _handle_consolidate(
             "summary": summary.strip(),
             "note": "Review the summary and use add/delete to apply changes.",
         }
-    except Exception as e:
+    except Exception:
+        logger.exception("Consolidation failed")
         return {
-            "error": f"Consolidation failed: {e}",
+            "error": "Consolidation failed: internal error",
             "suggestion": "Check LLM provider configuration and network connectivity.",
         }
 
@@ -2153,10 +2154,10 @@ async def _handle_config_sync_now(
             "error": str(e),
             "suggestion": "Check if backend configuration is complete.",
         }
-    except Exception as e:
+    except Exception:
         logger.exception("sync_now failed")
         return {
-            "error": f"sync_now failed: {e}",
+            "error": "sync_now failed: internal error",
             "suggestion": "Check network connectivity and provider credentials.",
         }
 
@@ -2230,10 +2231,10 @@ async def _handle_config_import_passport(
             "error": str(e),
             "suggestion": "Ensure the specified backend is properly configured.",
         }
-    except Exception as e:
+    except Exception:
         logger.exception("import_passport: backend pull failed")
         return {
-            "error": f"backend pull failed: {e}",
+            "error": "backend pull failed: internal error",
             "suggestion": "Verify remote backend access and network connectivity.",
         }
 
@@ -2246,11 +2247,11 @@ async def _handle_config_import_passport(
 
     try:
         result = await apply_bundle(db, bundle, passphrase)
-    except Exception as e:
+    except Exception:
         logger.exception("import_passport: apply_bundle failed")
         return {
             "error": "Passphrase mismatch or tampered bundle",
-            "detail": f"{type(e).__name__}: {e}",
+            "detail": "internal error",
             "backend": target,
             "suggestion": "Verify the passphrase matches the one used to export the passport bundle and that the bundle has not been modified.",
         }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Exception Exposure

🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure. The `server.py` tool handlers (`_handle_consolidate`, `_handle_config_sync_now`, `_handle_config_import_passport`) were catching broad exceptions and echoing the raw string representation (`f"{e}"` or `f"{type(e).__name__}: {e}"`) directly back to the client in JSON responses. This exposes internal system details, stack traces, and underlying infrastructure logic to untrusted clients.
🎯 Impact: Attackers or unintended parties could glean information about file paths, network issues, package internals, or system states that could be leveraged for further attacks or footprinting.
🔧 Fix: Replaced the dynamic `{e}` interpolations in the JSON response with static generic messages (e.g., "internal error"). Ensured that the original exception context is securely captured on the server side using `logger.exception()`. Added an entry to `.jules/sentinel.md` documenting the learning.
✅ Verification: Ran `uv run ruff check .`, `uv run ty check`, and `uv run pytest tests/test_server.py tests/test_passport_actions.py` to ensure unit tests that asserted specific failure modes still passed and that the system remained robust.

---
*PR created automatically by Jules for task [12029555336332758032](https://jules.google.com/task/12029555336332758032) started by @n24q02m*