### PR TITLE
fix: bump mcp-core floor to 1.21.0 stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     # server_name ("mnemo-mcp") instead of the plugin slug ("mnemo")
     # this server actually saves credentials under, so `mnemo-mcp
     # config status` always reported "not configured".
-    "n24q02m-mcp-core[llm]>=1.20.0b2,<2",
+    "n24q02m-mcp-core[llm]>=1.21.0,<2",
     # Pin Pygments to fix ReDoS (CVE in <2.20.0)
     "Pygments>=2.20.0",
     "alembic>=1.18.5",

--- a/uv.lock
+++ b/uv.lock
@@ -528,11 +528,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.7"
+version = "3.32.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
 ]
 
 [[package]]
@@ -1090,7 +1090,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"] },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.20.0b2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.21.0,<2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -1196,7 +1196,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.20.0b2"
+version = "1.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1211,9 +1211,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/92/68abd1fc6491e83b4a91271b2690952dfe13bffb7c5cf27954ae3fe35bea/n24q02m_mcp_core-1.20.0b2.tar.gz", hash = "sha256:b2e85cf7eacb45457fba491bdd8927cc92947ff0184904ba9719ecd94fbd28a4", size = 345349, upload-time = "2026-07-17T06:24:34.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/30/590222f26ace6b3f4eb9d39f6338993a77a487056131e3b8e44cac1f3a01/n24q02m_mcp_core-1.21.0.tar.gz", hash = "sha256:0902edef3c11cae453b12054b5c86b01f2c44b340baa62ba20178913c5605e0c", size = 347475, upload-time = "2026-07-25T07:39:49.345Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/79/a4c91fa9a9778ae7b1b58ac51b196a4b35de2de33faf6dfee0e79a6a3f6b/n24q02m_mcp_core-1.20.0b2-py3-none-any.whl", hash = "sha256:67b5ec30bd4712cf9a29a5de397a4c9338846cb2e6cf9233b98f976f44b5919a", size = 189470, upload-time = "2026-07-17T06:24:33.11Z" },
+    { url = "https://files.pythonhosted.org/packages/61/09/0777b67ea7e8fdf96294342bf6aa3b5d76a368a67f46a870a7e4a3bf7966/n24q02m_mcp_core-1.21.0-py3-none-any.whl", hash = "sha256:9f78057826aa32a752bed5d7512bc78f0574b4b56a619f4b1b6cfa12d22cfb89", size = 190145, upload-time = "2026-07-25T07:39:47.979Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #997.
Closes #1012 — the tracking issue mcp-core CD opened for 1.21.0 itself, which this lands directly.

## The actual problem

#997 asked for 1.20.0. The pin was `n24q02m-mcp-core[llm]>=1.20.0b2,<2` — a **beta** floor — and the lockfile resolved accordingly:

```
name = "n24q02m-mcp-core"
version = "1.20.0b2"
```

So mnemo-mcp was not merely un-bumped, it was shipping against a prerelease of its core dependency. A `>=1.20.0b2` floor permits 1.20.0 stable but does not require it, which is why the issue stayed open while the lock quietly stayed on the beta.

## What this does

Raises the floor to `>=1.21.0,<2` and relocks. 1.21.0 is stable, published 2026-07-25, and is above the 1.20.0 the issue asked for, so it satisfies and supersedes the request in one move rather than landing 1.20.0 and taking a second bump immediately after.

## Changes in range, reviewed

Everything between 1.20.0b2 and 1.21.0 is `fix:` plus one additive `feat:` (`authorizeParams` on delegated OAuth upstream config). Nothing breaking. Two are worth naming:

- mcp-core #682 — an auth code is no longer minted when the credential save fails.
- Cache files are created with restrictive permissions instead of being `chmod`'ed after the write, closing the window between create and chmod.

## Verification

`filelock` moves 3.29.7 to 3.32.0 as a transitive consequence of relocking; nothing else in the lock changes.

The full suite passes against 1.21.0 **verified installed**, not merely locked:

```
$ uv run python -c "import importlib.metadata as m; print(m.version('n24q02m-mcp-core'))"
1.21.0
$ uv run pytest -q
1383 passed, 5 skipped, 78 deselected
```

Worth flagging, since it nearly produced a false pass here: `uv run --no-sync pytest` reports green while leaving the previous version installed. The first run of this branch passed 1383 tests against 1.20.0b2. The numbers above are from a run after `uv sync`, with the installed version printed.