### PR TITLE
fix: record rejected palette submissions in the palette ledger

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,13 @@
 **Learning:** `mnemo-mcp` ships a Python MCP server and a Cloudflare Worker. It has no frontend, no templates and no user-facing UI, so the Palette remit does not apply to it in the usual sense. This was concluded twice in one week and each conclusion was filed as a pull request containing an empty commit (#1003, #1007), which cost two review cycles and produced no change.
 
 **Action:** The reviewable surface here is the text the tools themselves return: the `error`, `suggestion` and `note` strings in `src/mnemo_mcp/server.py` and the tool docs under `src/mnemo_mcp/docs/`. Those are what a caller actually reads, and the entries above are all improvements to exactly that surface. Direct Palette work there. A conclusion that there is nothing to change belongs in this file as an entry; it does not need a pull request to be recorded.
+
+## Rejected
+
+### 2026-07-25 - Empty-commit pull requests that announce a skip (#1003, #1007)
+Both PRs changed no files (`+0/-0`) and existed only to state that this repo has no frontend. The conclusion was right; the delivery was not. An empty PR consumes a review cycle, runs the full check matrix, and leaves a branch behind to prune, all to communicate one sentence that belongs in this file. #1003 additionally used a `chore:` prefix, which this repo does not accept, and carried four commits restating the same empty change.
+
+Record a skip as an entry here. Do not open a PR to report that no change is needed.
+
+### 2026-07-25 - Reframing backend work as UX to satisfy the remit
+Noted because #1007 flagged the temptation itself: when no UI exists, editing API internals and labelling the result a UX improvement is worse than skipping. The honest surface is the response text a caller reads, described in the entry above. If that surface has nothing wrong with it, the correct outcome is no change.


### PR DESCRIPTION
Follow-on to #1011, which added `## Rejected` sections to `.jules/bolt.md` and `.jules/sentinel.md` but left `.jules/palette.md` without one. This adds it, so all three ledgers record what was turned down this round and why.

Contents: the two empty-commit pull requests (#1003, #1007) that changed no files and existed only to announce that this repo has no frontend, and the related temptation — which #1007 named itself — of relabelling backend edits as UX work when there is no UI to work on.

## A limit worth stating plainly

This entry cannot prevent a repeat. The other ledger entries encode "when you do X, do it this way", which is actionable at the point a change is being written. This one encodes "there is nothing here for you", and a ledger has no way to enforce an instruction whose content is to produce nothing — the agent has already been dispatched by the time it reads this.

So the entry is written to redirect rather than to forbid: it names the response text in `src/mnemo_mcp/server.py` and the docs under `src/mnemo_mcp/docs/` as the surface that does read like UX work on a server, which is what the existing entries in the file are all improvements to. That is the best a ledger can do here.

Closing this class off properly needs something outside the ledger — either scoping the Palette task away from this repo at the dispatcher, or a governance job that auto-closes zero-file PRs. This repo currently has neither: there is no `.jules.yaml` and the workflows are `ci.yml`, `cd.yml` and `opencode.yml` only. Flagging it rather than deciding it.

Markdown only; no code or dependency changes.