### PR TITLE
feat: add bot PR governance workflow

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -1,0 +1,101 @@
+name: Bot PR Governance
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  governance:
+    name: Bot PR Rate Limit & Duplicate Check
+    runs-on: ubuntu-latest
+    # Only govern branches pushed to this repository. A pull request from a
+    # fork is an outside contribution: its branch name is not ours to read as
+    # a bot signature, and closing it on that heuristic would be wrong. The
+    # token is read-only for fork pull_request runs anyway, so the close and
+    # label calls below could not succeed.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Detect and govern bot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.head_ref }}
+          ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          # Detect if this is a bot-created PR by branch name pattern.
+          # Two signals:
+          #   1. Explicit bot-tool prefixes (Bolt, Palette, Jules, fix/web-scraper)
+          #   2. Any branch ending with a long numeric task/trace ID (-[0-9]{14,})
+          IS_BOT_PR=false
+          if echo "$BRANCH" | grep -qE \
+              '^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])'; then
+            IS_BOT_PR=true
+          elif echo "$BRANCH" | grep -qE -- \
+              '-[0-9]{14,}$'; then
+            IS_BOT_PR=true
+          fi
+
+          if [ "$IS_BOT_PR" = "false" ]; then
+            echo "Not a bot PR ($BRANCH), skipping governance checks."
+            exit 0
+          fi
+
+          echo "Bot PR detected on branch: $BRANCH"
+          gh pr edit "$PR_NUMBER" --add-label "bot-generated" --repo "$REPO" || true
+
+          # --- Rate limit: max 5 bot PRs/actor/day ---
+          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+                  date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
+          COUNT=$(gh pr list --repo "$REPO" --state open \
+                   --json createdAt,headRefName,author \
+                   --jq "[.[] |
+                          select(.author.login == \"$ACTOR\") |
+                          select(.createdAt > \"$SINCE\") |
+                          select(.headRefName | test(
+                            \"^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])\" +
+                            \"|-[0-9]{14,}$\"
+                          ))] | length" 2>/dev/null || echo 0)
+
+          echo "Bot PRs by $ACTOR in last 24h: $COUNT"
+
+          if [ "${COUNT:-0}" -gt 5 ]; then
+            gh pr close "$PR_NUMBER" --repo "$REPO" \
+              --comment "**Bot rate limit exceeded**: $COUNT PRs created in the last 24 hours (limit: 5/day). This PR has been automatically closed to reduce PR backlog and CI resource waste. Please consolidate related fixes."
+            echo "PR #$PR_NUMBER closed: rate limit exceeded ($COUNT/5 today)"
+            exit 0
+          fi
+
+          # --- Duplicate detection by title keyword ---
+          KEYWORD=$(echo "$PR_TITLE" | sed 's/[^a-zA-Z0-9 _-]//g' | \
+                    tr '[:upper:]' '[:lower:]' | cut -c1-50 | xargs)
+          if [ -z "$KEYWORD" ]; then
+            echo "No keyword extracted, skipping duplicate check."
+            exit 0
+          fi
+
+          DUPES=$(gh pr list --repo "$REPO" --state open --search "$KEYWORD" \
+                   --json number \
+                   --jq "[.[] | select(.number != $PR_NUMBER)] | length" \
+                   2>/dev/null || echo 0)
+
+          echo "Similar open PRs for '$KEYWORD': $DUPES"
+          if [ "${DUPES:-0}" -ge 1 ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" \
+              --add-label "possible-duplicate" || true
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "**Possible duplicate**: found ${DUPES} open PR(s) with similar title ('${KEYWORD}'). Check before merging: \`gh pr list --search '${KEYWORD}' --state open\`"
+          fi


### PR DESCRIPTION
Rate-limits bot pull requests to 5 per actor per day and flags likely duplicates by title keyword. Ported from the workflow already running on Aiora.

## Why

Three of the pairs cleared today were one idea filed twice within days:

| Idea | Filed as |
|---|---|
| Skip palette, repo has no frontend | #1003, #1007 |
| `upsert_sync_state` atomic upsert | #1000, #1004 |
| Exception detail leakage | #999, #1002 (plus #1005, which shipped) |

Six pull requests, three ideas, six full check-matrix runs, six review cycles. #1011 and #1014 added `## Rejected` sections to all three ledgers so the reasoning is on record — but a ledger entry only reaches a bot that reads it before acting, and nothing in the repo stops the second submission from being opened. This is the part the ledger cannot do.

## Changes from the Aiora original

**`runs-on: ubuntu-latest`.** Aiora is private and uses the self-hosted arm64 runner. This repo is public, where self-hosted runners must not be used.

**The job is skipped for fork pull requests** — `if: github.event.pull_request.head.repo.full_name == github.repository`. This is a second deviation and deliberate: Aiora is private and never sees a fork, this repo is public and will. An outside contributor's branch name is not ours to read as a bot signature, and auto-closing on that heuristic would be a bad first experience for a genuine contribution. Fork `pull_request` runs also receive a read-only token, so the label and close calls would fail regardless — better to skip cleanly than fail noisily.

## Detection checked against real data

The two rules are `^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])` and `-[0-9]{14,}$`. Run over the last 300 pull requests on this repo:

- **158 matched** — 120 by trailing task id, 38 by tool prefix
- **0 `renovate/*` branches matched**
- **0 human branches matched**

The only two branches containing bot-ish words that did not match are `fix/palette-ledger-rejected` (my own branch from #1014, which merely has the word "palette" in it) and `renovate/docker-setup-buildx-action-digest` — both correctly left alone. Verified in bash with the exact `grep -qE` invocations from the workflow, not just an equivalent regex.

## Also matched to repo convention

Added the `harden-runner` step every other job in `ci.yml` and `cd.yml` opens with, pinned to the same SHA (`bf7454d0`, v2.20.0). The workflow calls no other actions.

## Note

The rate limit counts the current pull request, so `-gt 5` permits five open bot pull requests per actor per day and closes the sixth. The duplicate check only labels and comments; it never closes.