### PR TITLE
fix: drop code_quality from the main ruleset

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -40,12 +40,6 @@
       "type": "update"
     },
     {
-      "type": "code_quality",
-      "parameters": {
-        "severity": "errors"
-      }
-    },
-    {
       "type": "code_scanning",
       "parameters": {
         "code_scanning_tools": [


### PR DESCRIPTION
Brings `.github/rulesets/main.json` in line with the live ruleset (id 12738655), from which `code_quality` has been removed.

## What the rule was

`code_quality` belongs to **GitHub Code Quality**, a separate product from CodeQL despite the naming. It waits on a check called `CodeQL - Code Quality`. That check has never run here and cannot: the product went GA on 2026-07-20, bills per active committer, and is available only on Team and Enterprise Cloud, which this account is not on.

```
$ gh api "repos/n24q02m/mnemo-mcp/code-scanning/analyses?per_page=30" --jq '[.[].tool.name]|unique'
["CodeQL"]

$ gh api repos/n24q02m/mnemo-mcp/code-quality
404
```

GitHub's own documentation warns about exactly this configuration — that without confirming the Code Quality workflow runs and reports back, "the ruleset could block the merging of **all** pull requests."

## Why removing it is safer, not laxer

The rule provided no protection while forcing every merge through admin bypass — and a bypass skips *every* rule in the set, including `code_scanning`, which does work and does have results. Fewer merges needing bypass means the real gates apply more often.

## Scope

Only `code_quality` is removed. Verified against a snapshot of the ruleset taken before the change:

```
removed: ['code_quality']
added  : []
params changed: none
bypass_actors unchanged: True
conditions unchanged: True
```

`code_scanning` (CodeQL, `errors` / `high_or_higher`), `pull_request`, `deletion`, `non_fast_forward`, `required_linear_history` and `update` are all untouched.

## Two things for the repo owner, not changed here

**1. This does not unblock merges on its own.** `update` — "restrict updates: only allow users with bypass permission to update matching refs" — also blocks, because a pull request merge updates `main`. Single-variable test on #1015, all checks green:

| Ruleset state | `mergeStateStatus` |
|---|---|
| as found | `BLOCKED` |
| minus `code_quality` | `BLOCKED` |
| minus `code_quality` and `update` | `CLEAN` |

`update` has been left in place. Note that `pull_request` already prevents direct pushes to `main`, so `update` is not what stops those; its practical effect here is that every merge needs bypass.

**2. This file has drifted from live in a second way.** It declares `required_approving_review_count: 1` and `require_code_owner_review: true`; live is `0` and `false`. Untouched deliberately — which of the two is intended is the owner's call. The same drift was found on wet-mcp.

The upstream template `templates/shared/.github/rulesets/main.json.tmpl` in the repo-bootstrap scripts also still contains `code_quality`, so any repo re-provisioned from it will pick the rule back up.