### PR TITLE
fix: align fork guard with the standard form

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -12,13 +12,34 @@ permissions:
 jobs:
   governance:
     name: Bot PR Rate Limit & Duplicate Check
-    runs-on: ubuntu-latest
-    # Only govern branches pushed to this repository. A pull request from a
-    # fork is an outside contribution: its branch name is not ours to read as
-    # a bot signature, and closing it on that heuristic would be wrong. The
-    # token is read-only for fork pull_request runs anyway, so the close and
-    # label calls below could not succeed.
+    # Govern only branches pushed to this repository. This repo is public, so
+    # it receives pull requests from forks; the Aiora original this was ported
+    # from is private and never saw one.
+    #
+    # Product reason: a fork pull request is an outside contribution. Its
+    # branch name is not ours to read as a bot signature, and closing someone
+    # else's first contribution because our own bots spent the day's rate
+    # limit is the wrong outcome.
+    #
+    # Technical reason: on the `pull_request` trigger a fork gets a read-only
+    # GITHUB_TOKEN, and the `permissions:` block above cannot raise it -- that
+    # is a ceiling, not a grant. Of the four writing `gh` calls below, the two
+    # `--add-label` ones end in `|| true`, but `gh pr close` and
+    # `gh pr comment` do not, so under `set -e` they would fail the job.
+    #
+    # Kept at job level, not inside the script: an in-script guard is only
+    # correct while it stays the first statement, and an ordering assumption
+    # is the very bug being fixed here. A later edit adding a `gh` call above
+    # it would silently reintroduce this. A job condition cannot be stepped
+    # over, and it skips without starting a runner.
+    #
+    # Compares `full_name` rather than testing `head.repo.fork`, because
+    # `fork` describes the source repo: were this repository itself ever made
+    # a fork, `head.repo.fork` would be true for our own branches too and
+    # governance would switch off permanently while the workflow still
+    # reported green.
     if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0


### PR DESCRIPTION
Brings the fork guard to the canonical shape agreed across the public repos, and writes down the reasoning so a later edit does not undo it.

## What was already there

#1015 shipped this guard at job level with the agreed condition:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

So the substance is unchanged. This PR moves `if` above `runs-on` to match the standard ordering, and replaces a four-line comment with one that records why each part is the way it is.

## Verified as a no-op in behaviour

Both versions parsed and compared:

```
permissions unchanged: True {'pull-requests': 'write', 'contents': 'read'}
triggers unchanged   : True {'pull_request': {'types': ['opened']}}
job if identical     : True
runs-on unchanged    : True
steps byte-identical : True
jobs                 : ['governance']   (1)
job keys order       : ['name', 'if', 'runs-on', 'steps']
```

## What the comment now records

**`permissions:` is a ceiling, not a grant.** A fork `pull_request` run receives a read-only `GITHUB_TOKEN` and nothing in that block raises it. Worth stating, because the natural reaction to seeing the failure is to widen `permissions:`, which cannot work.

**Which calls actually break.** Audited rather than assumed — of the four writing `gh` calls, the two `--add-label` ones end in `|| true`; `gh pr close` (line 76) and `gh pr comment` (line 99) do not, and `set -e` is set at line 37. So a fork run would fail the job, not merely do nothing quietly.

Those two stay unguarded deliberately. With the fork case covered by the job condition, a failure there is a real signal and a red job is the correct response.

**Why job level rather than in-script.** An in-script guard is only correct while it remains the first statement, and an ordering assumption is precisely the bug being fixed. A later edit inserting a `gh` call above it would reintroduce the problem with nothing to catch it. A job condition cannot be stepped over, and it skips without starting a runner.

**Why `full_name` rather than `head.repo.fork`.** `fork` describes the *source* repository. If this repo were ever itself made a fork, `head.repo.fork` would read true for our own branches, governance would switch off permanently, and the workflow would still report green. Today both forms behave identically here; this one does not have that failure mode.

## Verification

The workflow runs on this PR — the branch is human, so it should log `Not a bot PR (fix/fork-guard-canonical), skipping governance checks.` Confirmed below after the run.

The fork path itself is **not tested**. Doing so would need a real fork opening a real pull request against this repo, which I have not done and am not claiming.

Labels `bot-generated` (`#FFA500`) and `possible-duplicate` (`#CCCCCC`) confirmed present, so the `--add-label` calls will do something rather than silently no-op.