### PR TITLE
fix: prevent information disclosure in gdrive merge handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,7 +16,7 @@ The finding was valid and shipped in #1005 (commit 080be86c). Two further PRs pr
 ### 2026-07-25 - Framing this class of finding as "stack trace exposure"
 These handlers return a JSON dict and never returned a traceback, so a catch-all added to suppress one would be guarding against something that cannot happen while swallowing errors that can. The real exposure was the interpolated `str(e)`, which for `httpx` and `botocore` failures can carry endpoint URLs, bucket names and local paths. State the leak precisely; it determines whether the fix is narrowing a message or restructuring the handler.
 
-## 2025-02-14 - Prevent Information Disclosure in Google Drive Sync Error Responses
+### 2026-08-01 - Prevent Information Disclosure in Google Drive Sync Error Responses
 **Vulnerability:** Similar to other sync and consolidation endpoints, `str(e)` was exposed in the JSON response of `src/mnemo_mcp/sync/gdrive.py`'s `pull` method when merging databases.
 **Learning:** Exception details can leak sensitive information about the file system, network, or internal logic. The pattern of replacing `except Exception as e:` logging `error` to catching `Exception` and logging `exception` (and returning a generic "internal error" message) should be uniformly applied anywhere an API returns a JSON error.
 **Prevention:** Always return generic error strings like "Merge failed: internal error" rather than the dynamically generated exception string, and rely on `logger.exception` to log the full stack trace server-side without an explicit `as e` binding.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,8 @@ The finding was valid and shipped in #1005 (commit 080be86c). Two further PRs pr
 
 ### 2026-07-25 - Framing this class of finding as "stack trace exposure"
 These handlers return a JSON dict and never returned a traceback, so a catch-all added to suppress one would be guarding against something that cannot happen while swallowing errors that can. The real exposure was the interpolated `str(e)`, which for `httpx` and `botocore` failures can carry endpoint URLs, bucket names and local paths. State the leak precisely; it determines whether the fix is narrowing a message or restructuring the handler.
+
+## 2025-02-14 - Prevent Information Disclosure in Google Drive Sync Error Responses
+**Vulnerability:** Similar to other sync and consolidation endpoints, `str(e)` was exposed in the JSON response of `src/mnemo_mcp/sync/gdrive.py`'s `pull` method when merging databases.
+**Learning:** Exception details can leak sensitive information about the file system, network, or internal logic. The pattern of replacing `except Exception as e:` logging `error` to catching `Exception` and logging `exception` (and returning a generic "internal error" message) should be uniformly applied anywhere an API returns a JSON error.
+**Prevention:** Always return generic error strings like "Merge failed: internal error" rather than the dynamically generated exception string, and rely on `logger.exception` to log the full stack trace server-side without an explicit `as e` binding.

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -604,10 +604,10 @@ async def sync_full(db: MemoryDB) -> dict:
             if import_result.get("imported", 0) > 0:
                 logger.info(f"Merged {import_result['imported']} memories from remote")
 
-        except Exception as e:
-            logger.error(f"Merge failed: {e}")
+        except Exception:
+            logger.exception("Merge failed")
             result["pull"] = {
-                "error": str(e),
+                "error": "Merge failed: internal error",
                 "suggestion": "Check remote database consistency and sync credentials.",
             }
         finally:


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Google Drive Sync handler

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information Disclosure. The `GDriveBackend.pull` method was catching generic exceptions and returning `str(e)` directly in the JSON response payload when a remote database merge failed.
🎯 **Impact:** Exposing internal error strings from the database driver or sync operations to the client can reveal system details such as file paths, environment states, or network configurations, aiding malicious actors.
🔧 **Fix:** Changed the catch-all to use `logger.exception("Merge failed")` to log the full stack trace securely on the server-side, and modified the JSON response to return a generic `"Merge failed: internal error"` static string.
✅ **Verification:** Verified by running `uv run ruff check .`, `uv run ty check`, and `uv run pytest`. All tests passed, confirming the fix does not break functionality and improves security.

---
*PR created automatically by Jules for task [16125757146469360809](https://jules.google.com/task/16125757146469360809) started by @n24q02m*