### PR TITLE
fix: checkpoint the sqlite wal before uploading the db to google drive

### DIFF
--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -493,6 +493,12 @@ def _checkpoint_wal(db_path: Path) -> bool:
     silently when a reader is around, and ``FULL`` leaves the frames in the
     WAL after copying them, so neither guarantees the state we need on disk.
 
+    ``TRUNCATE`` waits for readers to let go, and auto-sync runs while the
+    server holds its own connection to the same file, so the busy timeout is
+    set explicitly to match ``MemoryDB`` (``db.py``) instead of relying on
+    the sqlite3 driver default -- without it a reader that happens to be
+    mid-query would abort the push.
+
     Returns ``True`` when the whole WAL was folded in, ``False`` when it was
     not -- in which case the file is not safe to upload.
     """
@@ -502,6 +508,7 @@ def _checkpoint_wal(db_path: Path) -> bool:
 
     conn = sqlite3.connect(str(db_path))
     try:
+        conn.execute("PRAGMA busy_timeout = 5000")
         busy, _, _ = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
         if busy:
             logger.error(

--- a/src/mnemo_mcp/sync/gdrive.py
+++ b/src/mnemo_mcp/sync/gdrive.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -479,11 +480,49 @@ async def _download_file(token: dict, file_id: str, dest_path: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _checkpoint_wal(db_path: Path) -> bool:
+    """Fold the ``-wal`` side file back into ``db_path`` before it is read.
+
+    In WAL mode SQLite keeps freshly committed pages in ``<db>-wal`` until a
+    checkpoint runs, so ``db_path`` on its own is a page-allocated shell with
+    an empty ``sqlite_master``. Drive stores the single ``.db`` object and
+    nothing else, hence the checkpoint has to happen before the upload.
+
+    ``TRUNCATE`` is the level that makes the file self-contained: it writes
+    every frame back *and* resets the WAL to zero bytes. ``PASSIVE`` gives up
+    silently when a reader is around, and ``FULL`` leaves the frames in the
+    WAL after copying them, so neither guarantees the state we need on disk.
+
+    Returns ``True`` when the whole WAL was folded in, ``False`` when it was
+    not -- in which case the file is not safe to upload.
+    """
+    if not db_path.exists():
+        logger.error(f"Cannot checkpoint {db_path}: database file does not exist")
+        return False
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        busy, _, _ = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if busy:
+            logger.error(
+                f"WAL checkpoint of {db_path.name} was blocked (busy); "
+                "recent writes are still in the -wal file"
+            )
+            return False
+        return True
+    except sqlite3.Error as e:
+        logger.error(f"WAL checkpoint of {db_path.name} failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
 async def sync_push(db_path: Path, folder_name: str) -> bool:
     """Push local database to Google Drive folder.
 
-    Uploads the SQLite database file to Google Drive.
-    Updates existing file or creates new one.
+    Checkpoints the WAL so the uploaded file is self-contained, then uploads
+    the SQLite database file to Google Drive. Updates existing file or
+    creates new one.
     """
     token = await _get_valid_token()
     if not token:
@@ -495,6 +534,12 @@ async def sync_push(db_path: Path, folder_name: str) -> bool:
     folder_id = await _find_or_create_folder(token, folder_name)
     if not folder_id:
         logger.error("Failed to find/create sync folder")
+        return False
+
+    # Never upload a database whose WAL has not been folded in: the remote
+    # copy would be a shell with no tables, silently replacing a good backup.
+    if not await asyncio.to_thread(_checkpoint_wal, db_path):
+        logger.error("Push aborted: local DB is not in a state safe to upload")
         return False
 
     existing = await _find_file_in_folder(token, folder_id, db_path.name)

--- a/tests/sync/test_gdrive_push.py
+++ b/tests/sync/test_gdrive_push.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+import threading
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -75,6 +77,46 @@ async def test_sync_push_uploads_a_db_the_wal_was_folded_into(tmp_path, upload_f
             )
         ]
         assert "memories" in tables
+        assert restored.execute("SELECT content FROM memories").fetchall() == [
+            ("xin chao",)
+        ]
+    finally:
+        restored.close()
+
+
+async def test_sync_push_waits_out_a_reader_that_lets_go(tmp_path, upload_file):
+    """A reader that finishes inside the busy timeout must not cost a push.
+
+    The server keeps its own connection to the same file while auto-sync
+    runs, so aborting on the first busy reply would trade "upload an empty
+    DB" for "never upload again".
+    """
+    db_path = tmp_path / "memories.db"
+    writer = _wal_db_with_one_row(db_path)
+    drive_copy = tmp_path / "drive_copy.db"
+    holding = threading.Event()
+
+    def hold_a_read_snapshot_briefly():
+        reader = sqlite3.connect(db_path)
+        reader.execute("BEGIN")
+        reader.execute("SELECT * FROM memories").fetchall()
+        holding.set()
+        time.sleep(0.5)
+        reader.close()
+
+    thread = threading.Thread(target=hold_a_read_snapshot_briefly)
+    thread.start()
+    assert holding.wait(5.0), "reader thread never took its snapshot"
+
+    try:
+        assert await sync_push(db_path, "folder") is True
+        shutil.copyfile(upload_file.await_args.args[1], drive_copy)
+    finally:
+        thread.join()
+        writer.close()
+
+    restored = sqlite3.connect(drive_copy)
+    try:
         assert restored.execute("SELECT content FROM memories").fetchall() == [
             ("xin chao",)
         ]

--- a/tests/sync/test_gdrive_push.py
+++ b/tests/sync/test_gdrive_push.py
@@ -1,0 +1,122 @@
+"""Regression tests: ``sync_push`` must upload a self-contained ``.db`` file.
+
+SQLite in WAL mode keeps freshly committed pages in the ``<db>-wal`` side
+file until a checkpoint folds them back into the main file. ``sync_push``
+hands the ``.db`` file straight to Google Drive and Drive stores that single
+object -- so without a checkpoint the backup is a page-allocated shell whose
+``sqlite_master`` is empty. That is the 2026-07-31 incident: the uploaded
+file had a plausible size but not a single table.
+
+No test here touches Google Drive; every network helper is patched out.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+import mnemo_mcp.sync.gdrive as gdrive
+from mnemo_mcp.sync.gdrive import sync_push
+
+
+@pytest.fixture
+def upload_file():
+    """Patch every Drive call ``sync_push`` makes; yield the upload mock."""
+    upload = AsyncMock(return_value=True)
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            gdrive, "_get_valid_token", AsyncMock(return_value={"access_token": "fake"})
+        )
+        mp.setattr(
+            gdrive, "_find_or_create_folder", AsyncMock(return_value="folder-id")
+        )
+        mp.setattr(gdrive, "_find_file_in_folder", AsyncMock(return_value=None))
+        mp.setattr(gdrive, "_upload_file", upload)
+        yield upload
+
+
+def _wal_db_with_one_row(db_path: Path) -> sqlite3.Connection:
+    """Create a WAL-mode DB holding one committed row, connection left open.
+
+    While the returned connection is open the row lives in ``<db>-wal`` and
+    ``db_path`` on its own has no tables at all.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=wal")
+    conn.execute("CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT)")
+    conn.execute("INSERT INTO memories (content) VALUES ('xin chao')")
+    conn.commit()
+    return conn
+
+
+async def test_sync_push_uploads_a_db_the_wal_was_folded_into(tmp_path, upload_file):
+    db_path = tmp_path / "memories.db"
+    writer = _wal_db_with_one_row(db_path)
+    drive_copy = tmp_path / "drive_copy.db"
+
+    try:
+        assert await sync_push(db_path, "folder") is True
+        # Drive keeps this one object and nothing else -- reproduce that by
+        # copying the uploaded file without its -wal / -shm side cars.
+        shutil.copyfile(upload_file.await_args.args[1], drive_copy)
+    finally:
+        writer.close()
+
+    restored = sqlite3.connect(drive_copy)
+    try:
+        tables = [
+            row[0]
+            for row in restored.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        ]
+        assert "memories" in tables
+        assert restored.execute("SELECT content FROM memories").fetchall() == [
+            ("xin chao",)
+        ]
+    finally:
+        restored.close()
+
+
+async def test_sync_push_aborts_when_a_reader_blocks_the_checkpoint(
+    tmp_path, upload_file
+):
+    """A blocked checkpoint leaves recent commits in the ``-wal`` file.
+
+    Uploading anyway would replace a good remote backup with a stale one, so
+    the push has to abort and let the next sync cycle retry.
+    """
+    db_path = tmp_path / "memories.db"
+    writer = _wal_db_with_one_row(db_path)
+    reader = sqlite3.connect(db_path)
+    reader.execute("BEGIN")
+    reader.execute("SELECT * FROM memories").fetchall()
+
+    try:
+        assert await sync_push(db_path, "folder") is False
+        upload_file.assert_not_awaited()
+    finally:
+        reader.close()
+        writer.close()
+
+
+async def test_sync_push_refuses_a_corrupt_local_db(tmp_path, upload_file):
+    db_path = tmp_path / "memories.db"
+    db_path.write_bytes(b"khong phai mot file sqlite" * 200)
+
+    assert await sync_push(db_path, "folder") is False
+    upload_file.assert_not_awaited()
+
+
+async def test_sync_push_does_not_invent_a_db_when_the_file_is_missing(
+    tmp_path, upload_file
+):
+    db_path = tmp_path / "memories.db"
+
+    assert await sync_push(db_path, "folder") is False
+    upload_file.assert_not_awaited()
+    assert not db_path.exists()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,5 +1,6 @@
 """Tests for mnemo_mcp.sync -- Google Drive sync operations."""
 
+import sqlite3
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -338,7 +339,12 @@ class TestSyncPush:
 
     async def test_success(self, tmp_path):
         db_path = tmp_path / "test.db"
-        db_path.write_bytes(b"data")
+        # A real SQLite file: sync_push now checkpoints the WAL before the
+        # upload, which means it refuses anything that is not a database.
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE memories (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
         token = {"access_token": "valid"}
 
         with (


### PR DESCRIPTION
## Triệu chứng

Sự cố 2026-07-31: file `.db` mà `sync_push` đẩy lên Google Drive có kích thước
trông hợp lý nhưng mở ra thì `sqlite_master` rỗng -- không một bảng nào, nghĩa là
bản sao lưu không chứa bất kỳ memory nào. Log vẫn báo `Push complete`, nên lỗi
hoàn toàn im lặng cho tới lúc cần khôi phục.

## Vì sao WAL gây ra chuyện đó

`MemoryDB` mở database ở chế độ WAL (`db.py`: `PRAGMA journal_mode = WAL`). Ở chế
độ này, mọi trang vừa commit nằm trong file phụ `memories.db-wal`, còn
`memories.db` chỉ được cập nhật khi có checkpoint. Trước khi sửa, `sync_push`
đưa thẳng đường dẫn `.db` cho `_upload_file`, hàm này `read_bytes()` đúng một file
đó và Drive lưu đúng một object đó -- không có `-wal` đi kèm. Kết quả: bản trên
Drive là cái vỏ đã cấp phát trang, header hợp lệ, dung lượng có vẻ thật, nhưng
không có dữ liệu.

Đo lại được bằng SQLite thuần: ghi 1 bảng + 1 dòng rồi commit trong chế độ WAL ->
`memories.db` = 4096 byte, `memories.db-wal` = 12392 byte, và copy riêng file
`.db` ra đọc thì `SELECT name FROM sqlite_master` trả về `[]`.

## Vì sao `TRUNCATE`, không phải `PASSIVE` / `FULL`

- `PASSIVE` bỏ cuộc trong im lặng khi có reader đang mở -- đúng kiểu thất bại đã
  gây ra sự cố này, chỉ khác là lần sau sẽ khó thấy hơn.
- `FULL` chép hết frame về file chính nhưng **giữ nguyên nội dung WAL**; file
  `.db` lúc đó đã đủ dữ liệu, song trạng thái trên đĩa vẫn là "một cặp file", và
  ta chỉ upload một nửa của cặp đó.
- `TRUNCATE` vừa chép hết frame về file chính, vừa reset WAL về 0 byte. Đó chính
  là bất biến cần có: **một file duy nhất, tự chứa**, đúng bằng thứ Drive lưu.

Checkpoint được đặt ngay sau khi có `folder_id` và trước `_find_file_in_folder`,
chạy trong `asyncio.to_thread` theo đúng quy ước I/O chặn của repo; connection
được đóng trong `finally`.

### `busy_timeout` đặt tường minh

`TRUNCATE` phải đợi mọi reader nhả ra, mà auto-sync chạy trong lúc server vẫn
giữ connection riêng tới đúng file đó (`db.py` mở với `journal_mode = WAL` +
`busy_timeout = 5000`). Nếu checkpoint bỏ cuộc ngay lần busy đầu tiên thì ta chỉ
đổi lỗi "đẩy lên DB rỗng" lấy lỗi "không bao giờ đẩy nữa" -- hai lỗi khác nhau,
cùng mức tệ. Nên connection dùng để checkpoint đặt `PRAGMA busy_timeout = 5000`
tường minh, khớp với `MemoryDB` và với helper tương ứng bên wet.

Đo trên máy (SQLite 3.53.1, `sqlite3` của CPython 3.13): reader nhả sau 300 ms
thì checkpoint chờ đúng 0,31 s rồi trả `busy=0`; reader giữ khoá không nhả thì
chờ hết 5 s rồi trả `busy=1` và push bị hủy; app connection mở nhưng nhàn rỗi
thì checkpoint xong trong 0,045 s. Nói cách khác, ca thường gặp không hề busy.

Thêm một guard đi kèm với chính lỗi này: nếu checkpoint không hoàn tất (`busy`),
hoặc file không tồn tại, hoặc file không phải SQLite, thì **hủy push** thay vì
upload. Ghi đè một bản backup tốt trên Drive bằng một file rỗng ruột là hệ quả
nặng nhất của sự cố; chu kỳ auto-sync kế tiếp sẽ thử lại.

## Rà soát các đường sao chép khác

Đã grep toàn repo (`read_bytes`, `shutil.copy*`, `open(..., "rb")`, `copytree`,
`sendfile`, và các chỗ nhắc tới `backup`). Chỉ có hai chỗ đọc thẳng file `.db`:

1. `sync/gdrive.py::_upload_file` -- đây là chỗ dính lỗi. Nó chỉ có **một**
   caller duy nhất là `sync_push`, nên bản vá này phủ hết đường upload.
2. `db.py::_backup_db_file` -- **không dính cùng lỗi**: hàm này chép `.db` kèm cả
   hai side car `-wal` và `-shm` sang cùng thư mục, nên bộ backup vẫn nhất quán
   và mở lại được. Đây cũng là backup cục bộ trước khi chạy Alembic migration,
   không đi ra mạng. Giữ nguyên, không sửa.

Các đường còn lại không đọc file thô:

- `GDriveBackend.push` / `sync/s3.py` nhận `bundle: bytes` do `sync/bundle.py` +
  `sync/delta.py` dựng từ truy vấn SQL trên connection đang sống, nên luôn thấy
  dữ liệu trong WAL.
- `sync_pull` tải file remote về rồi đọc bằng `MemoryDB(...).export_jsonl()`, tức
  qua SQL chứ không copy file thô.

## Kiểm thử

`tests/sync/test_gdrive_push.py` (mới, không chạm Google Drive thật -- mọi helper
mạng đều bị patch):

- upload xong, mở **chính file đã upload** (copy riêng, không kèm `-wal`) và
  khẳng định đọc được bảng `memories` cùng đúng bản ghi đã ghi;
- reader nhả trong khoảng timeout thì push vẫn **thành công** và file đẩy đi vẫn
  đọc ra bảng `memories`;
- hủy push khi reader giữ khoá không nhả;
- hủy push khi file cục bộ hỏng;
- không tự sinh ra một `.db` rỗng khi file không tồn tại.

Bốn test đầu tiên đều ĐỎ trên `main` (test đầu fail đúng bằng triệu chứng sự cố:
`assert 'memories' in []`) và XANH sau bản vá. Test reader-nhả cũng có răng: hạ
`busy_timeout` xuống `0` là nó fail sau 20 ms, đúng bằng kiểu "đổi lỗi này lấy
lỗi kia". Chạy lại 5 lần, lần nào cũng xanh trong khoảng 1 s -- không rung.

Đã chạy đủ bộ kiểm tra của CI: `ruff check`, `ruff format --check`, `ty check`,
và `pytest` toàn bộ -- tất cả xanh qua pre-commit của hai commit trong PR này.
