### PR TITLE
fix: make memory supersession atomic and close its transaction on every exit

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,6 +16,7 @@
 **A thread-hammering test was tried here and dropped.** Driving `upsert_sync_state` from two threads in a loop raises `SystemError: error return without exception set` from the `sqlite3` module, intermittently, on both the old and new code. `MemoryDB` shares one connection opened with `check_same_thread=False`, and that connection is not safe under genuinely simultaneous use — a separate pre-existing problem this change narrows but does not solve. Do not add a concurrency test here until the connection itself is guarded.
 
 ## 2026-08-01 - Supersede in one statement, and close the transaction on every exit
+**Commit:** 6633e6f (#1038)
 
 **Learning:** `MemoryDB.update` read the row with a `SELECT ... WHERE valid_to IS NULL`, then closed it with a separate `UPDATE`. A competing writer that supersedes the same row between the two statements leaves two live rows and a supersession chain that points at the wrong successor; injecting that writer deterministically reproduces it. The `SELECT` also carried the `valid_to IS NULL` guard that made the loser of the race back off, so the guard has to move onto the write for the check and the write to be one decision.
 
@@ -37,3 +38,6 @@ Both PRs proposed the correct change and justified it with impact numbers that c
 
 ### 2026-07-25 - Unexpanded shell substitution in ledger headings (#1000)
 The proposed entry was headed `## $(date +%Y-%m-%d)`, a literal shell command written into Markdown. Two entries in `.jules/palette.md` already carried this and both have been corrected to their real commit dates. Write the date out.
+
+### 2026-08-01 - Unmeasured speedup figures on `update` (#1029)
+Same failure as the 2026-07-25 entry above, on the PR whose idea was taken into #1038. The Impact section claimed the removed `SELECT` was a throughput win, with no harness in the diff. Measured here at 4500 samples x 4 runs per branch: the `SELECT` is 12.6us inside a ~350us call, and the spread within a single branch (297-383us) is wider than the difference between branches (~2us median-of-medians). The change was worth making for atomicity, and #1038 stands on that argument alone. A profile that says a statement is removable does not say the removal is measurable.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,6 +15,21 @@
 
 **A thread-hammering test was tried here and dropped.** Driving `upsert_sync_state` from two threads in a loop raises `SystemError: error return without exception set` from the `sqlite3` module, intermittently, on both the old and new code. `MemoryDB` shares one connection opened with `check_same_thread=False`, and that connection is not safe under genuinely simultaneous use — a separate pre-existing problem this change narrows but does not solve. Do not add a concurrency test here until the connection itself is guarded.
 
+## 2026-08-01 - Supersede in one statement, and close the transaction on every exit
+
+**Learning:** `MemoryDB.update` read the row with a `SELECT ... WHERE valid_to IS NULL`, then closed it with a separate `UPDATE`. A competing writer that supersedes the same row between the two statements leaves two live rows and a supersession chain that points at the wrong successor; injecting that writer deterministically reproduces it. The `SELECT` also carried the `valid_to IS NULL` guard that made the loser of the race back off, so the guard has to move onto the write for the check and the write to be one decision.
+
+The connection is opened in legacy autocommit-by-statement mode (`isolation_level=""`), where the first DML statement implicitly opens a transaction that only `commit()`/`rollback()` closes, and `MemoryDB.update` had no `try`/`rollback` at all. Two consequences, both measured:
+
+- When the successor `INSERT` aborts, the predecessor stays closed with `superseded_by` pointing at a row that was never written, and the next unrelated `add()` commits that state. A fresh connection then finds the memory gone -- no live row, no successor. This is the pre-existing data-loss path and it is independent of how the row is read.
+- `UPDATE ... RETURNING` opens a write transaction **even when it matches zero rows**, so the not-found branch must `rollback()` before returning. Without it the transaction stays open across subsequent `get`/`search`/`list` traffic, a second connection's write fails with `database is locked`, and `PRAGMA wal_checkpoint(TRUNCATE)` fails with `database table is locked`. This branch is ordinary, not rare: `update` is id-changing, so calling it again with the previous id lands there.
+
+`RETURNING` yields the row **after** the update is applied ([sqlite.org/lang_returning](https://sqlite.org/lang_returning.html) §2), so `valid_to` and `superseded_by` must be reset on the successor row rather than carried forward. `RETURNING` also requires SQLite >= 3.35.0 and is unsupported on virtual tables, so `memories_vec` keeps its separate `SELECT`.
+
+**Action:** Supersede with a single `UPDATE memories SET valid_to = ?, superseded_by = ? WHERE id = ? AND valid_to IS NULL RETURNING *`; wrap the body in `try/except BaseException: self._conn.rollback(); raise`; `rollback()` before the not-found `return None`; and check `sqlite3.sqlite_version_info` at open so an old library fails with a named requirement instead of a syntax error at the first write. Regression cover is `tests/test_db_update_atomicity.py` -- the guard test fails if `AND valid_to IS NULL` is deleted, and the not-found tests fail against the `RETURNING` form without the rollback.
+
+**This is an atomicity change, not a speed change.** The removed `SELECT` was measured at 12.6us inside a ~350us call, and the run-to-run spread within a single branch (297-383us) is wider than the difference between branches. There is no throughput claim to make here, per the 2026-07-25 entry below.
+
 ## Rejected
 
 ### 2026-07-25 - Unmeasured speedup figures on `upsert_sync_state` (#1000, #1004)

--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -31,6 +31,26 @@ _ALEMBIC_SCRIPT_LOCATION = Path(__file__).resolve().parent / "alembic"
 
 _STRUCT_CACHE: dict[int, struct.Struct] = {}
 
+# ``MemoryDB.update`` supersedes a row with a single ``UPDATE ... RETURNING *``
+# so the read and the write cannot be split by a competing writer. RETURNING
+# landed in SQLite 3.35.0 (https://sqlite.org/lang_returning.html). A Python
+# linked against an older library fails at the first update() call with a
+# syntax error rather than at install time, so check once at open.
+MIN_SQLITE_VERSION = (3, 35, 0)
+
+
+def _check_sqlite_version() -> None:
+    """Raise when the linked SQLite predates ``UPDATE ... RETURNING``."""
+    if sqlite3.sqlite_version_info >= MIN_SQLITE_VERSION:
+        return
+    required = ".".join(str(part) for part in MIN_SQLITE_VERSION)
+    raise RuntimeError(
+        f"mnemo-mcp needs SQLite >= {required} for UPDATE ... RETURNING, but "
+        f"this Python is linked against SQLite {sqlite3.sqlite_version}. "
+        "Upgrade the SQLite library this Python build uses, or install a "
+        "Python distribution that bundles a newer one."
+    )
+
 
 def _serialize_f32(vec: list[float], target_dims: int = 0) -> bytes:
     """Serialize float list to bytes for sqlite-vec.
@@ -124,7 +144,10 @@ class MemoryDB:
         Raises:
             EmbeddingModelMismatch: When the stored embedding identity differs
                 from the requested one and ``reindex_on_model_change`` is False.
+            RuntimeError: When the linked SQLite is older than
+                :data:`MIN_SQLITE_VERSION`.
         """
+        _check_sqlite_version()
         self._db_path = db_path
         if type(embedding_dims) is not int:
             raise ValueError(
@@ -1257,74 +1280,98 @@ class MemoryDB:
                 f"Content length {len(content)} exceeds limit of {MAX_CONTENT_LENGTH}"
             )
 
-        old_row = self._conn.execute(
-            "SELECT * FROM memories WHERE id = ? AND valid_to IS NULL", (memory_id,)
-        ).fetchone()
-        if old_row is None:
-            return None
-
         now = _now_iso()
         new_id = uuid.uuid4().hex
 
-        new_row = dict(old_row)
-        new_row["id"] = new_id
-        new_row["created_at"] = now
-        new_row["updated_at"] = now
-        new_row["last_accessed"] = now
-        new_row["access_count"] = 0
-        new_row["valid_from"] = now
-        new_row["valid_to"] = None
-        new_row["superseded_by"] = None
-        if "commit_sha" in new_row:
-            new_row["commit_sha"] = None
-
-        if content is not None:
-            new_row["content"] = content
-        if category is not None:
-            new_row["category"] = category
-        if tags is not None:
-            # Bolt Performance Optimization:
-            # Prevent expensive json.dumps calls for the default empty list.
-            new_row["tags"] = "[]" if not tags else json.dumps(tags)
-        if source is not None:
-            new_row["source"] = source
-        if importance is not None:
-            new_row["importance"] = max(0.0, min(1.0, importance))
-
-        columns = list(new_row.keys())
-        column_list = ", ".join(columns)
-        placeholders = ", ".join("?" for _ in columns)
-
-        self._conn.execute(
-            "UPDATE memories SET valid_to = ?, superseded_by = ? WHERE id = ?",
-            (now, new_id, memory_id),
-        )
-        self._conn.execute(
-            f"INSERT INTO memories ({column_list}) VALUES ({placeholders})",
-            [new_row[c] for c in columns],
-        )
-
-        # Embedding: an explicit value replaces; otherwise carry the old
-        # vector forward under the new id so semantic search keeps working
-        # for metadata-only edits (content-only re-embedding is the
-        # caller's responsibility, e.g. server._handle_update).
-        if self._vec_enabled:
-            old_vec = self._conn.execute(
-                "SELECT embedding FROM memories_vec WHERE id = ?", (memory_id,)
+        # Supersession is several writes on a connection opened in legacy
+        # autocommit-by-statement mode, so every exit path has to close the
+        # transaction the first write opens -- otherwise a half-applied
+        # supersession stays pending and the next unrelated commit() makes it
+        # durable, leaving the predecessor closed against a successor row that
+        # was never written.
+        try:
+            # Close the predecessor and read it back in ONE statement. Split
+            # into SELECT-then-UPDATE, a competing writer can supersede the
+            # same row in between, which leaves two live rows and a broken
+            # supersession chain; the ``valid_to IS NULL`` guard is what makes
+            # the loser of that race fall through to the not-found branch.
+            old_row = self._conn.execute(
+                "UPDATE memories SET valid_to = ?, superseded_by = ? "
+                "WHERE id = ? AND valid_to IS NULL RETURNING *",
+                (now, new_id, memory_id),
             ).fetchone()
-            self._conn.execute("DELETE FROM memories_vec WHERE id = ?", (memory_id,))
-            if embedding:
-                self._conn.execute(
-                    "INSERT INTO memories_vec (id, embedding) VALUES (?, ?)",
-                    (new_id, _serialize_f32(embedding, self._embedding_dims)),
-                )
-            elif old_vec is not None:
-                self._conn.execute(
-                    "INSERT INTO memories_vec (id, embedding) VALUES (?, ?)",
-                    (new_id, old_vec["embedding"]),
-                )
+            if old_row is None:
+                # pysqlite opens a write transaction for an UPDATE even when it
+                # matches zero rows. Returning without closing it would hold
+                # the database locked against every other writer for as long as
+                # this connection lives.
+                self._conn.rollback()
+                return None
 
-        self._conn.commit()
+            # RETURNING yields the row AFTER the update was applied, so the
+            # two columns it just wrote have to be reset for the successor.
+            new_row = dict(old_row)
+            new_row["id"] = new_id
+            new_row["created_at"] = now
+            new_row["updated_at"] = now
+            new_row["last_accessed"] = now
+            new_row["access_count"] = 0
+            new_row["valid_from"] = now
+            new_row["valid_to"] = None
+            new_row["superseded_by"] = None
+            if "commit_sha" in new_row:
+                new_row["commit_sha"] = None
+
+            if content is not None:
+                new_row["content"] = content
+            if category is not None:
+                new_row["category"] = category
+            if tags is not None:
+                # Bolt Performance Optimization:
+                # Prevent expensive json.dumps calls for the default empty list.
+                new_row["tags"] = "[]" if not tags else json.dumps(tags)
+            if source is not None:
+                new_row["source"] = source
+            if importance is not None:
+                new_row["importance"] = max(0.0, min(1.0, importance))
+
+            columns = list(new_row.keys())
+            column_list = ", ".join(columns)
+            placeholders = ", ".join("?" for _ in columns)
+
+            self._conn.execute(
+                f"INSERT INTO memories ({column_list}) VALUES ({placeholders})",
+                [new_row[c] for c in columns],
+            )
+
+            # Embedding: an explicit value replaces; otherwise carry the old
+            # vector forward under the new id so semantic search keeps working
+            # for metadata-only edits (content-only re-embedding is the
+            # caller's responsibility, e.g. server._handle_update).
+            if self._vec_enabled:
+                # memories_vec is a virtual table; it does not support RETURNING.
+                old_vec = self._conn.execute(
+                    "SELECT embedding FROM memories_vec WHERE id = ?", (memory_id,)
+                ).fetchone()
+                self._conn.execute(
+                    "DELETE FROM memories_vec WHERE id = ?", (memory_id,)
+                )
+                if embedding:
+                    self._conn.execute(
+                        "INSERT INTO memories_vec (id, embedding) VALUES (?, ?)",
+                        (new_id, _serialize_f32(embedding, self._embedding_dims)),
+                    )
+                elif old_vec is not None:
+                    self._conn.execute(
+                        "INSERT INTO memories_vec (id, embedding) VALUES (?, ?)",
+                        (new_id, old_vec["embedding"]),
+                    )
+
+            self._conn.commit()
+        except BaseException:
+            self._conn.rollback()
+            raise
+
         logger.info(f"[AUDIT] update id={memory_id} -> new_id={new_id}")
         return new_id
 

--- a/tests/test_db_update_atomicity.py
+++ b/tests/test_db_update_atomicity.py
@@ -1,0 +1,253 @@
+"""Transactional-safety cover for ``MemoryDB.update()``.
+
+``update()`` supersedes a memory: it closes the predecessor row and writes a
+successor row. That is two writes that must land together or not at all, on a
+connection opened in legacy autocommit-by-statement mode
+(``isolation_level=""``), where any DML implicitly opens a transaction that
+only the next ``commit()``/``rollback()`` closes.
+
+Three distinct failure modes are covered here, each reproduced deterministically:
+
+1. The successor INSERT fails. Without a rollback the predecessor stays closed
+   against a successor that was never written, and the next unrelated
+   ``commit()`` makes that state durable -- the memory is unreachable.
+2. ``update()`` is called with an id that does not resolve. The supersede
+   statement is an ``UPDATE``, and pysqlite opens a write transaction for an
+   ``UPDATE`` even when it matches zero rows, so returning early without a
+   rollback leaves that transaction open and locks out every other writer.
+   This is an ordinary path, not a rare one: ``update()`` is id-changing, so
+   reusing the previous id reaches it.
+3. A competing writer supersedes the same row in between the check and the
+   write. The check and the write are one statement guarded by
+   ``valid_to IS NULL``; deleting that guard produces two live rows and a
+   broken supersession chain.
+
+Plus the feature floor the single-statement form depends on: ``RETURNING``
+requires SQLite >= 3.35.0.
+"""
+
+import sqlite3
+import uuid
+
+import pytest
+
+from mnemo_mcp import db as db_module
+from mnemo_mcp.db import MemoryDB
+
+
+class TestFailedSuccessorInsert:
+    """Failure mode 1: the successor INSERT aborts mid-supersession."""
+
+    def test_failed_insert_leaves_predecessor_live(self, tmp_db: MemoryDB):
+        mid = tmp_db.add("ORIGINAL CONTENT do-not-lose", category="fact", tags=["t1"])
+
+        # Abort the successor INSERT inside SQLite, the way a constraint
+        # violation or a broken FTS trigger would.
+        tmp_db._conn.execute(
+            "CREATE TRIGGER abort_insert BEFORE INSERT ON memories "
+            "BEGIN SELECT RAISE(ABORT, 'simulated successor insert failure'); END"
+        )
+        tmp_db._conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            tmp_db.update(mid, content="NEW CONTENT")
+
+        assert tmp_db._conn.in_transaction is False
+
+        row = tmp_db._conn.execute(
+            "SELECT valid_to, superseded_by FROM memories WHERE id = ?", (mid,)
+        ).fetchone()
+        assert row["valid_to"] is None
+        assert row["superseded_by"] is None
+        assert tmp_db.get(mid) is not None
+
+    def test_later_write_does_not_commit_a_dangling_pointer(self, tmp_db: MemoryDB):
+        """The damage is only durable once something else commits -- check that."""
+        mid = tmp_db.add("ORIGINAL CONTENT do-not-lose")
+
+        tmp_db._conn.execute(
+            "CREATE TRIGGER abort_insert BEFORE INSERT ON memories "
+            "BEGIN SELECT RAISE(ABORT, 'simulated successor insert failure'); END"
+        )
+        tmp_db._conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            tmp_db.update(mid, content="NEW CONTENT")
+
+        tmp_db._conn.execute("DROP TRIGGER abort_insert")
+        tmp_db.add("some later unrelated memory")  # commits
+
+        probe = sqlite3.connect(str(tmp_db._db_path))
+        probe.row_factory = sqlite3.Row
+        try:
+            durable = probe.execute(
+                "SELECT valid_to, superseded_by FROM memories WHERE id = ?", (mid,)
+            ).fetchone()
+            assert durable["valid_to"] is None
+            assert durable["superseded_by"] is None
+            successors = probe.execute(
+                "SELECT COUNT(*) FROM memories WHERE id = ?",
+                (durable["superseded_by"],),
+            ).fetchone()[0]
+            assert successors == 0
+        finally:
+            probe.close()
+
+
+class TestNotFoundBranch:
+    """Failure mode 2: the early return must not leak a write transaction."""
+
+    def test_unknown_id_leaves_no_open_transaction(self, tmp_db: MemoryDB):
+        tmp_db.add("seed")
+        assert tmp_db._conn.in_transaction is False
+
+        assert tmp_db.update(uuid.uuid4().hex, content="x") is None
+        assert tmp_db._conn.in_transaction is False
+
+    def test_stale_id_leaves_no_open_transaction(self, tmp_db: MemoryDB):
+        """``update()`` is id-changing, so reusing the old id is the ordinary
+        way callers reach the not-found branch."""
+        mid = tmp_db.add("seed content alpha")
+        new_id = tmp_db.update(mid, content="v2")
+        assert new_id is not None
+
+        assert tmp_db.update(mid, content="v3") is None
+        assert tmp_db._conn.in_transaction is False
+
+        # Read traffic does not release a leaked write transaction either.
+        tmp_db.get(new_id)
+        tmp_db.search("alpha", limit=3)
+        tmp_db.list_memories(limit=3)
+        assert tmp_db._conn.in_transaction is False
+
+    def test_unknown_id_does_not_lock_out_other_writers(self, tmp_db: MemoryDB):
+        assert tmp_db.update(uuid.uuid4().hex, content="x") is None
+
+        other = sqlite3.connect(str(tmp_db._db_path), timeout=1.0)
+        try:
+            other.execute("INSERT INTO store_meta (key, value) VALUES ('probe', '1')")
+            other.commit()
+        finally:
+            other.close()
+
+    def test_unknown_id_does_not_block_wal_checkpoint(self, tmp_db: MemoryDB):
+        tmp_db.add("seed")
+        assert tmp_db.update(uuid.uuid4().hex, content="x") is None
+
+        busy, _, _ = tmp_db._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        assert busy == 0, "checkpoint blocked -- a write transaction is still open"
+
+
+class _FireOnceProxy:
+    """Connection wrapper that runs ``hook`` once, immediately before the
+    supersede statement -- the exact window a competing writer would land in.
+    Everything else forwards to the real connection untouched.
+    """
+
+    def __init__(self, real, hook):
+        object.__setattr__(self, "_real", real)
+        object.__setattr__(self, "_hook", hook)
+        object.__setattr__(self, "_fired", False)
+
+    def execute(self, sql, params=()):
+        if not object.__getattribute__(self, "_fired") and sql.lstrip().startswith(
+            "UPDATE memories SET valid_to"
+        ):
+            object.__setattr__(self, "_fired", True)
+            object.__getattribute__(self, "_hook")()
+        return object.__getattribute__(self, "_real").execute(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "_real"), name)
+
+    def __setattr__(self, name, value):
+        setattr(object.__getattribute__(self, "_real"), name, value)
+
+
+class TestSupersedeGuard:
+    """Failure mode 3: regression cover for the ``valid_to IS NULL`` guard.
+
+    Deleting ``AND valid_to IS NULL`` from the supersede statement must make
+    this fail -- that guard is the whole reason the check and the write have
+    to be one statement.
+    """
+
+    def test_refuses_a_row_a_competitor_already_closed(
+        self, tmp_db: MemoryDB, monkeypatch
+    ):
+        mid = tmp_db.add("v1 original", category="fact")
+        tmp_db._conn.commit()
+        competitor_id = uuid.uuid4().hex
+
+        def competitor() -> None:
+            """A second connection supersedes the same row and commits."""
+            conn = sqlite3.connect(str(tmp_db._db_path), timeout=5.0)
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT * FROM memories WHERE id = ?", (mid,)
+                ).fetchone()
+                successor = dict(row)
+                successor["id"] = competitor_id
+                successor["content"] = "v2-COMPETITOR"
+                successor["valid_to"] = None
+                successor["superseded_by"] = None
+                conn.execute(
+                    "UPDATE memories SET valid_to = ?, superseded_by = ? "
+                    "WHERE id = ? AND valid_to IS NULL",
+                    ("2026-01-01T00:00:00+00:00", competitor_id, mid),
+                )
+                cols = list(successor)
+                conn.execute(
+                    f"INSERT INTO memories ({', '.join(cols)}) "
+                    f"VALUES ({', '.join('?' * len(cols))})",
+                    [successor[c] for c in cols],
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        # monkeypatch restores the real connection at teardown; the assertions
+        # below go through ``real`` directly either way.
+        real = tmp_db._conn
+        monkeypatch.setattr(tmp_db, "_conn", _FireOnceProxy(real, competitor))
+        loser = tmp_db.update(mid, content="v2-LOSER")
+
+        assert loser is None, "supersede must refuse an already-closed row"
+
+        live = [
+            r["id"]
+            for r in real.execute(
+                "SELECT id FROM memories WHERE valid_to IS NULL"
+            ).fetchall()
+        ]
+        assert live == [competitor_id], "the race left more than one live row"
+
+        closed = real.execute(
+            "SELECT superseded_by FROM memories WHERE id = ?", (mid,)
+        ).fetchone()
+        assert closed["superseded_by"] == competitor_id, "supersession chain broken"
+
+
+class TestSqliteFeatureFloor:
+    """``UPDATE ... RETURNING`` needs SQLite >= 3.35.0.
+
+    A Python linked against an older library fails at the first ``update()``
+    call with a syntax error, not at install time, so the check belongs at
+    open with a message that names the requirement.
+    """
+
+    def test_open_refuses_sqlite_without_returning(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(db_module.sqlite3, "sqlite_version_info", (3, 34, 0))
+        monkeypatch.setattr(db_module.sqlite3, "sqlite_version", "3.34.0")
+
+        with pytest.raises(RuntimeError, match=r"3\.35\.0"):
+            MemoryDB(tmp_path / "old_sqlite.db", embedding_dims=0)
+
+    def test_open_accepts_the_minimum_supported_version(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            db_module.sqlite3, "sqlite_version_info", db_module.MIN_SQLITE_VERSION
+        )
+
+        db = MemoryDB(tmp_path / "min_sqlite.db", embedding_dims=0)
+        db.close()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -56,6 +56,28 @@ def mock_sync():
         yield start, stop
 
 
+async def _settle_background_init() -> None:
+    """Wait for the background init tasks ``lifespan`` starts.
+
+    ``lifespan`` kicks off embedding and reranker init with
+    ``asyncio.create_task`` and keeps the handles to itself, so these tests
+    had no signal to wait on and slept a fixed 10ms instead. Each task makes
+    several ``asyncio.to_thread`` hops, which do not reliably finish inside
+    10ms on a loaded machine, so the assertions could read the context before
+    the task had written to it. ``start_auto_sync`` is mocked out here, so
+    those two are the only tasks on this loop and draining them is exact.
+    """
+    current = asyncio.current_task()
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 10.0
+    while loop.time() < deadline:
+        pending = {task for task in asyncio.all_tasks() if task is not current}
+        if not pending:
+            return
+        await asyncio.wait(pending, timeout=deadline - loop.time())
+    raise AssertionError("background lifespan init did not finish within 10s")
+
+
 @pytest.mark.asyncio
 async def test_lifespan_happy_path_cloud(
     mock_settings, mock_db, mock_embedder, mock_sync
@@ -71,7 +93,7 @@ async def test_lifespan_happy_path_cloud(
 
     server = MagicMock()
     async with lifespan(server) as ctx:
-        await asyncio.sleep(0.01)
+        await _settle_background_init()
         assert ctx["embedding_model"] == "cloud-model"
         assert ctx["embedding_dims"] == 128
         assert ctx["db"] == mock_db.return_value
@@ -108,7 +130,7 @@ async def test_lifespan_local_backend_explicit(
 
     server = MagicMock()
     async with lifespan(server) as ctx:
-        await asyncio.sleep(0.01)
+        await _settle_background_init()
         assert ctx["embedding_model"] == "__local__"
         assert ctx["embedding_dims"] == 768  # Default for stored
 
@@ -142,7 +164,7 @@ async def test_lifespan_explicit_cloud_exception_no_local_fallback(
 
     server = MagicMock()
     async with lifespan(server) as ctx:
-        await asyncio.sleep(0.01)
+        await _settle_background_init()
         # Model stays None since cloud failed and no local fallback
         assert ctx["embedding_model"] is None
 
@@ -160,7 +182,7 @@ async def test_lifespan_all_backends_fail(
 
     server = MagicMock()
     async with lifespan(server) as ctx:
-        await asyncio.sleep(0.01)
+        await _settle_background_init()
         assert ctx["embedding_model"] is None
         assert (
             ctx["embedding_dims"] == 768


### PR DESCRIPTION
## Vấn đề

`MemoryDB.update()` supersede một memory bằng nhiều lệnh ghi: đóng hàng cũ (`valid_to`, `superseded_by`) rồi INSERT hàng kế nhiệm. Connection mở ở chế độ autocommit-by-statement kế thừa (`isolation_level=""`), nên lệnh DML đầu tiên tự mở một transaction mà chỉ `commit()`/`rollback()` mới đóng lại được — và hàm này **không có một dòng `rollback` nào** (`git grep -c rollback origin/main -- src/mnemo_mcp/db.py` → exit 1).

### 1. Mất dữ liệu (lỗi có sẵn, không phải do PR nào)

Khi `INSERT` hàng kế nhiệm hỏng sau lúc `UPDATE` đã đóng hàng cũ, transaction treo lơ lửng: hàng cũ bị đóng với `superseded_by` trỏ vào một row **không tồn tại**. Một `add()` không liên quan sau đó gọi `commit()` và làm trạng thái hỏng đó thành vĩnh viễn. Connection mới mở lên không còn thấy memory: không hàng live, không hàng kế nhiệm.

Đo được trên `origin/main` — test `test_later_write_does_not_commit_a_dangling_pointer` đỏ với:

```
E   AssertionError: assert '2026-08-01T02:15:52.647386+00:00' is None
```

### 2. Race giữa check và write

`SELECT ... WHERE valid_to IS NULL` rồi `UPDATE` riêng là hai lệnh. Một writer cạnh tranh supersede cùng hàng đó ở khoảng giữa sẽ để lại **hai hàng live** và một chuỗi supersession trỏ sai. Tiêm writer đó một cách tất định thì `origin/main` đỏ:

```
E   AssertionError: supersede must refuse an already-closed row
E   assert 'a7d5b4b42f1543b9af80cfdc73421b29' is None
```

## Phần lấy từ #1029

Ý tưởng đúng của #1029: gộp check và write thành một lệnh `UPDATE ... RETURNING *`. Guard `AND valid_to IS NULL` chuyển từ `SELECT` sang chính lệnh ghi, nên bên thua cuộc rơi xuống nhánh not-found thay vì ghi đè. Việc #1029 reset `valid_to`/`superseded_by` về `None` cho hàng mới cũng bắt buộc và đúng, vì `RETURNING` trả giá trị **sau** khi update đã áp ([sqlite.org/lang_returning](https://sqlite.org/lang_returning.html) §2).

## Phần của #1029 đã tránh

`UPDATE ... RETURNING` mở write-transaction **kể cả khi khớp 0 dòng**. Bản trong #1029 `return None` ở nhánh not-found mà không commit/rollback, nên transaction đó ở lại mãi. Đây không phải đường lỗi hiếm: `update()` đổi id (docstring nói rõ), nên gọi lại bằng id cũ là chuyện thường.

Đo được trên bản chỉ có `RETURNING` (không rollback) — 4 test đỏ:

```
E   assert True is False        # in_transaction sau update(id không tồn tại)
E   assert True is False        # vẫn True sau 3 vòng get/search/list
E   sqlite3.OperationalError: database is locked          # connection khác không ghi được
E   sqlite3.OperationalError: database table is locked    # PRAGMA wal_checkpoint(TRUNCATE)
```

PR này thêm `rollback()` trước `return None`, và bọc thân hàm bằng `try/except BaseException: rollback(); raise`.

## Sàn phiên bản SQLite

`RETURNING` cần SQLite >= 3.35.0 và repo trước đây không ràng buộc ở đâu cả. CI xanh cả 3 OS nên runner đều đủ, nhưng người dùng chạy Python link vào system SQLite cũ sẽ chết bằng syntax error lúc **runtime**, không phải lúc cài. Thêm `_check_sqlite_version()` chạy lúc mở DB, thông báo nói rõ cần phiên bản nào và đang có phiên bản nào.

## Tại sao không có con số tốc độ nào trong PR này

Câu `SELECT` bị loại chỉ tốn 12.6us trong một lệnh gọi ~350us, và biên độ dao động **trong cùng một nhánh** (297-383us) rộng hơn chênh lệch **giữa hai nhánh** (~2us median-of-medians, 4500 mẫu x 4 lần mỗi nhánh). Không có kết luận throughput nào đứng vững ở đây. Thay đổi này đứng trên luận điểm atomicity — đúng theo tiền lệ đã ghi trong `.jules/bolt.md` mục 2026-07-25: chỉ trích dẫn con số khi harness sinh ra nó nằm trong repo và chạy đúng code path thật.

## Test

`tests/test_db_update_atomicity.py`, 9 test, mỗi failure mode có bằng chứng đỏ trước / xanh sau ở trên. Bộ test cũ không bắt được gì: xoá hẳn `AND valid_to IS NULL` vẫn xanh, và `grep -rnE "in_transaction|\.rollback\(\)|autocommit" tests/` trả về exit 1 trước PR này. Test guard ở đây đỏ khi xoá `AND valid_to IS NULL` (đã kiểm).

## Ngoài phạm vi PR này

Cùng kiểu rò rỉ transaction ở nhánh không-khớp **đã có sẵn trên `origin/main`** trong 4 phương thức khác của `db.py`, đo trực tiếp:

| phương thức | trả về | `in_transaction` sau đó |
|---|---|---|
| `delete(<id không tồn tại>)` | `False` | `True` |
| `restore_memory(<id không tồn tại>)` | `False` | `True` |
| `archive_old_memories()` khớp 0 dòng | `0` | `True` |
| `archive_by_score()` khớp 0 dòng | `0` | `True` |

Ngoài ra `add()`, `add_with_context_type()`, `delete()`, `restore_memory()` (nhánh legacy) và `import_jsonl()` đều có dạng "nhiều câu lệnh ghi, không rollback" giống `update()`. `update_importance()` không dính (commit vô điều kiện). Các hàm ghi trong `graph.py` (`upsert_entities`, `create_relations`, `link_memory_entities`) nhận `conn` từ ngoài và cố ý để caller quản transaction — khác loại.

Không sửa kèm ở đây để giữ diff hẹp đúng phạm vi `update()`; đề nghị làm riêng.

## Một sửa lỗi kèm theo, ngoài `update()`

`tests/test_lifespan.py` chặn pre-commit của PR này nên phải sửa để bộ test xanh. Bốn test đọc context của `lifespan` chờ một task nền (`asyncio.create_task`) bằng `await asyncio.sleep(0.01)` cố định. Task đó đi qua vài chặng `asyncio.to_thread`, trên máy đang tải nặng không kịp xong trong 10ms, nên assertion đọc context trước khi task ghi vào.

Đây là lỗi có sẵn, không phải do PR này: chạy `test_lifespan_local_backend_explicit` với **`db.py` nguyên bản của `origin/main`** vẫn đỏ 3/3 lần. `MemoryDB` trong test đó bị mock hoàn toàn nên thay đổi ở `db.py` không với tới được.

Sửa gốc: thay `sleep` cố định bằng việc chờ cạn đúng các task nền của vòng lặp (`start_auto_sync` đã mock nên chỉ còn hai task init của `lifespan`). Sau sửa: 5/5 lần xanh, và mỗi lần chạy nhanh hơn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
