### PR TITLE
fix: stop .gitignore from silently dropping new .jules bot ledgers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,6 @@ dist/
 build/
 
 # AI Agent
-.jules/
-JULES.md
 
 # Code review knowledge graph
 .code-review-graph/
@@ -50,7 +48,6 @@ JULES.md
 docs/superpowers/
 
 # AI traces (public repo hygiene)
-.Jules/
 .superpower/
 
 # Alembic / SQLite migration artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ temp/
 dist/
 build/
 
-# AI Agent
-
 # Code review knowledge graph
 .code-review-graph/
 


### PR DESCRIPTION
## Defect

`.gitignore` still had `.jules/` (line 42), `JULES.md` (line 43), and
`.Jules/` (line 53) after `.jules/bolt.md`, `.jules/palette.md`, and
`.jules/sentinel.md` were already tracked on `main`. `.gitignore` only
governs *untracked* paths, so this is latent, not inert: the first time a
new bot writes its first ledger under `.jules/`, `git add` drops the new
file silently — exit code 0, no error — and the resulting PR ships `+0/-0`.

This is not hypothetical. `n24q02m/claude-plugins` hit exactly this: PR #544
was `+0/-0` for this reason, fixed in PR #591 (merged) by removing the same
ignore lines (`.jules/`, `.jules`, `.Jules/`) from that repo's `.gitignore`.
This repo's `.jules/` and `.Jules/` lines are removed following that
precedent exactly. claude-plugins never had a `JULES.md` line to begin
with, so there is no literal precedent for it there — this repo's
`JULES.md` line was added in the same original commit as `.jules/` (`Add
.jules/ and JULES.md to gitignore`, see CHANGELOG.md), was never used (no
`JULES.md` ever existed in this repo's history), and sits in the identical
"# AI Agent" block subject to the identical silent-drop bug, so it is
removed here too.

## Fix

Removed the three ignore lines. No other change.

```diff
 # AI Agent
-.jules/
-JULES.md

 # AI traces (public repo hygiene)
-.Jules/
 .superpower/
```

## Proof (run in a clean worktree off origin/main, before the fix)

```
$ echo "# Pilot bot ledger (test)" > .jules/pilot.md
$ git add -A .
exit code: 0
$ git status --short
(nothing — file NOT staged)
$ git check-ignore -v .jules/pilot.md
.gitignore:53:.Jules/	.jules/pilot.md
```

(Match is on the `.Jules/` line, not `.jules/`, because this filesystem is
case-insensitive; on case-sensitive CI, `.jules/` line 42 matches directly.
Both lines were confirmed dead weight and removed.)

## Proof (same test, after the fix)

```
$ echo "# Pilot bot ledger (test, after fix)" > .jules/pilot.md
$ git add -A .
exit code: 0
$ git status --short
M  .gitignore
A  .jules/pilot.md
$ git check-ignore -v .jules/pilot.md
(no match, exit 1)
```

Test file was removed before committing; the diff contains only `.gitignore`.

Not merging this myself — opened for review.