### PR TITLE
fix: derive test_config clean_env list from Settings, not a hand-written list

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic_settings.sources import EnvSettingsSource
 
 from mnemo_mcp.config import (
     Settings,
@@ -13,56 +14,121 @@ from mnemo_mcp.config import (
     _has_gguf_support,
     _resolve_local_model,
 )
+from mnemo_mcp.credential_state import CLOUD_KEYS
+
+
+def _settings_env_names() -> set[str]:
+    """Every env var name that ``Settings`` itself reads.
+
+    Derived from the model instead of hand-listed. ``EnvSettingsSource`` is the
+    very resolver pydantic-settings runs at load time, so it already accounts
+    for ``env_prefix`` (empty in this repo), ``case_sensitive`` and any
+    ``validation_alias``/``alias`` on a field -- e.g. ``db_path`` expands to
+    both ``DB_PATH`` and ``MNEMO_DB_PATH``. Adding or renaming a settings field
+    therefore updates this set automatically.
+
+    This replaces a hand-written list that had silently drifted behind the
+    code: it still cleared the deprecated singular ``EMBEDDING_MODEL`` /
+    ``RERANK_MODEL`` / ``*_BACKEND`` vars while missing the plural
+    ``EMBEDDING_MODELS`` / ``RERANK_MODELS`` / ``LLM_MODELS`` chains that
+    replaced them, so any developer shell exporting a chain var turned five
+    tests in this file red regardless of what the commit changed.
+    """
+    source = EnvSettingsSource(Settings)
+    return {
+        # (field_key, env_name, value_is_complex) -- index 1 is the resolved
+        # env name *including* env_prefix; index 0 omits the prefix.
+        env_name.upper()
+        for field_name, field in Settings.model_fields.items()
+        for _, env_name, _ in source._extract_field_info(field, field_name)
+    }
+
+
+# Env vars that steer these tests but are NOT declared as ``Settings`` fields,
+# so they cannot be derived from the model and must be named by hand:
+#   * ``CLOUD_KEYS`` -- provider API keys plus the per-task ``EMBEDDING_API_BASE``
+#     / ``RERANK_API_BASE`` / ``LLM_API_BASE`` endpoints. mnemo and litellm read
+#     these straight from ``os.environ`` (see ``embedder.py``, ``reranker.py``,
+#     ``graph.py``); ``Settings`` only observes them indirectly, through
+#     ``_key_available`` chain filtering. Imported from ``credential_state``
+#     rather than retyped so the two lists cannot diverge.
+#   * The two alias keys ``resolve_provider_mode`` probes that ``CLOUD_KEYS``
+#     does not carry.
+#   * Toggles read by mcp-core / qwen3-embed during field-default resolution.
+_EXTRA_ENV_NAMES = {
+    *CLOUD_KEYS,
+    # config.resolve_provider_mode() / Settings._ENV_ALIASES probe these.
+    "GOOGLE_API_KEY",
+    "CO_API_KEY",
+    # mcp_core.auth.resolve_bundled_client() reads this while resolving the
+    # google_drive_client_* field defaults.
+    "USE_BUNDLED_GOOGLE_CLIENT",
+    "MCP_RELAY_URL",
+    "QWEN3_EMBED_CACHE_PATH",
+}
+# litellm's per-provider endpoint override lives beside each provider key
+# (JINA_AI_API_KEY -> JINA_AI_API_BASE). Real developer shells do export these
+# (a gateway URL), so derive the siblings instead of listing them one by one.
+_EXTRA_ENV_NAMES |= {
+    f"{key.removesuffix('_API_KEY')}_API_BASE"
+    for key in _EXTRA_ENV_NAMES
+    if key.endswith("_API_KEY")
+}
+
+
+def _clean_env_names() -> set[str]:
+    """Full set of env vars the ``clean_env`` fixture unsets."""
+    return _settings_env_names() | _EXTRA_ENV_NAMES
 
 
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch):
     """Ensure environment isolation for configuration tests.
 
-    Clears all provider API keys and Mnemo-specific configuration variables.
+    Clears every env var ``Settings`` declares (derived from the model, see
+    :func:`_settings_env_names`) plus the provider keys and endpoint overrides
+    that are read directly from ``os.environ``.
     """
-    vars_to_clear = {
-        "JINA_AI_API_KEY",
-        "GEMINI_API_KEY",
-        "GOOGLE_API_KEY",
-        "OPENAI_API_KEY",
-        "COHERE_API_KEY",
-        "CO_API_KEY",
-        "XAI_API_KEY",
-        "API_KEYS",
-        "EMBEDDING_MODEL",
-        "EMBEDDING_DIMS",
-        "EMBEDDING_BACKEND",
-        "RERANK_ENABLED",
-        "RERANK_BACKEND",
-        "RERANK_MODEL",
-        "SYNC_ENABLED",
-        "SYNC_FOLDER",
-        "SYNC_INTERVAL",
-        "GOOGLE_DRIVE_CLIENT_ID",
-        "GOOGLE_DRIVE_CLIENT_SECRET",
-        "USE_BUNDLED_GOOGLE_CLIENT",
-        "DB_PATH",
-        "MNEMO_DB_PATH",
-        "LOG_LEVEL",
-        "MCP_RELAY_URL",
-        "QWEN3_EMBED_CACHE_PATH",
-        "COMPRESSION_ENABLED",
-        "COMPRESSION_PROVIDER",
-        "COMPRESSION_MODEL",
-        "LOCAL_EMBEDDING_MODEL",
-        "LOCAL_RERANK_MODEL",
-        "LOCAL_EMBEDDING_POOLING",
-        "LOCAL_EMBEDDING_DIM",
-        "LOCAL_EMBEDDING_NORMALIZE",
-        "LOCAL_EMBEDDING_MODEL_FILE",
-    }
+    vars_to_clear = _clean_env_names()
     # Thoroughly clear any variant of these keys in os.environ
     for k in list(os.environ.keys()):
         if k.upper() in vars_to_clear:
             monkeypatch.delenv(k, raising=False)
     for v in vars_to_clear:
         monkeypatch.delenv(v, raising=False)
+
+
+class TestCleanEnvCoverage:
+    """Guards against the clear-list drifting behind ``Settings`` again."""
+
+    def test_current_chain_vars_are_derived(self):
+        """The plural chain vars the old hand-written list had missed."""
+        derived = _settings_env_names()
+        for name in ("EMBEDDING_MODELS", "RERANK_MODELS", "LLM_MODELS"):
+            assert name in derived, name
+
+    def test_validation_alias_choices_are_expanded(self):
+        """``db_path`` declares AliasChoices -- both names must be covered."""
+        derived = _settings_env_names()
+        assert {"DB_PATH", "MNEMO_DB_PATH"} <= derived
+
+    def test_deprecated_singular_vars_still_covered(self):
+        """The deprecated shims are still fields, so they stay in the set."""
+        derived = _settings_env_names()
+        assert {"EMBEDDING_MODEL", "RERANK_MODEL", "EMBEDDING_BACKEND"} <= derived
+
+    def test_endpoint_overrides_are_cleared(self):
+        """``*_API_BASE`` is read via os.getenv, never declared on Settings."""
+        names = _clean_env_names()
+        assert {"EMBEDDING_API_BASE", "RERANK_API_BASE", "LLM_API_BASE"} <= names
+        # litellm per-provider endpoint siblings.
+        assert {"JINA_AI_API_BASE", "GEMINI_API_BASE"} <= names
+
+    def test_every_settings_field_is_represented(self):
+        """No field may be silently absent from the clear-list."""
+        names = _clean_env_names()
+        missing = [f for f in Settings.model_fields if f.upper() not in names]
+        assert missing == []
 
 
 # Test Setup


### PR DESCRIPTION
## The drift mechanism

`tests/test_config.py` has an autouse `clean_env` fixture that unsets a
**hand-maintained list** of env var names. That list fell behind the code:

| in the old list | actually read by `Settings` today |
|---|---|
| `EMBEDDING_MODEL`, `RERANK_MODEL` (deprecated singular) | yes, still deprecated shims |
| `EMBEDDING_BACKEND`, `RERANK_BACKEND` (deprecated) | yes, still deprecated shims |
| **missing** | `EMBEDDING_MODELS`, `RERANK_MODELS`, `LLM_MODELS` (current chains) |
| **missing** | `EMBEDDING_API_BASE`, `RERANK_API_BASE`, `LLM_API_BASE` |
| **missing** | 34 further fields (`SYNC_S3_*`, `TEMPORAL_*`, `ARCHIVE_*`, `DISABLE_LOCAL_*`, ...) |

Every env rename since the singular-to-chain migration had to be mirrored by
hand into the fixture, and wasn't. A hand-list patched with the four missing
names would drift again at the next rename, so this fixes the mechanism, not
the symptom.

**Measured impact:** a dev machine whose profile exports `EMBEDDING_MODELS`,
`JINA_AI_API_KEY`, `JINA_AI_API_BASE` gets 5 red tests in this file on *every*
commit, unrelated to what the commit changes, so pre-commit blocks wrongly.
CI runners are clean, so this never showed up in CI -- it only ever hazed
local dev.

## The fix

`Settings` is a `pydantic_settings.BaseSettings`, so it already knows every env
name it reads. `_settings_env_names()` derives the clear-list from the model
using the library's own `EnvSettingsSource` resolver, which is the same code
path pydantic-settings runs at load time. It therefore accounts for
`env_prefix` (empty here), `case_sensitive`, and any `validation_alias` --
e.g. `db_path` correctly expands to both `DB_PATH` and `MNEMO_DB_PATH`.
Adding or renaming a settings field now updates the fixture automatically.

A small manual group remains, with a comment explaining why it must:
provider API keys and the per-task `*_API_BASE` endpoints are read straight
from `os.environ` by mnemo and litellm (`embedder.py`, `reranker.py`,
`graph.py`) and are never declared as `Settings` fields. Those are **imported
from `credential_state.CLOUD_KEYS`** rather than retyped, so the two lists
cannot diverge. litellm's per-provider endpoint siblings
(`JINA_AI_API_KEY` -> `JINA_AI_API_BASE`) are derived from that same list.

Five `TestCleanEnvCoverage` tests lock the invariant in, including
`test_every_settings_field_is_represented`, which fails loudly if any future
field escapes the clear-list.

## Evidence

**1. Red before** -- `EMBEDDING_MODELS` + `JINA_AI_API_KEY` + `JINA_AI_API_BASE`
exported, on unpatched `cb188da`:

```
$ uv run pytest tests/test_config.py -q
FAILED tests/test_config.py::TestEmbeddingModel::test_sdk_mode_returns_default_chain
FAILED tests/test_config.py::TestEmbeddingModel::test_no_keys_returns_empty
FAILED tests/test_config.py::TestEmbeddingModel::test_legacy_singular_folded_into_chain
FAILED tests/test_config.py::TestEmbeddingBackend::test_inferred_local_no_chain
FAILED tests/test_config.py::TestResolveEmbeddingBackendAuto::test_auto_detect_with_no_config
5 failed, 92 passed in 20.62s
```

Failure shape: `assert 'cloud' == 'local'` -- the leaked chain var makes
`resolve_embedding_backend()` infer cloud where the test expects local.

**2. Green after** -- same polluted environment:

```
$ env | grep -cE '^(EMBEDDING_MODELS|JINA_AI_API_KEY|JINA_AI_API_BASE)='
3
$ uv run pytest tests/test_config.py -q
102 passed in 8.16s
```

**3. No regression** -- same command with those three vars unset:

```
$ env -u EMBEDDING_MODELS -u JINA_AI_API_KEY -u JINA_AI_API_BASE uv run pytest tests/test_config.py -q
102 passed in 4.50s
```

**4. Anti-drift** -- the derived set now covers what the hand-list missed:

```
derived-from-Settings: 50   manual-extras: 24   total: 74

  EMBEDDING_MODELS                 derived=True
  RERANK_MODELS                    derived=True
  LLM_MODELS                       derived=True
  EMBEDDING_API_BASE               in-clear-set=True  (manual)
  RERANK_API_BASE                  in-clear-set=True  (manual)
  LLM_API_BASE                     in-clear-set=True  (manual)
  JINA_AI_API_BASE                 in-clear-set=True  (manual)

old hand-list=34  ->  new=74
NEWLY COVERED (40): ANTHROPIC_API_BASE, ANTHROPIC_API_KEY, ARCHIVE_AFTER_DAYS,
ARCHIVE_ENABLED, ARCHIVE_IMPORTANCE_THRESHOLD, COHERE_API_BASE, CO_API_BASE,
DEDUP_THRESHOLD, DEDUP_WARN_THRESHOLD, DISABLE_LOCAL_EMBED,
DISABLE_LOCAL_RERANK, EMBEDDING_API_BASE, EMBEDDING_MODELS, GEMINI_API_BASE,
GOOGLE_API_BASE, GOOGLE_VERTEX_EXPRESS_API_BASE, GOOGLE_VERTEX_EXPRESS_API_KEY,
JINA_AI_API_BASE, KG_AUTO_ENABLED, LLM_API_BASE, LLM_MODELS,
LOCAL_RERANK_MODEL_FILE, OPENAI_API_BASE, RECENCY_HALF_LIFE_DAYS,
REINDEX_ON_MODEL_CHANGE, RERANK_API_BASE, RERANK_MODELS, RERANK_TOP_N,
SYNC_BACKEND, SYNC_PASSPHRASE, SYNC_S3_ACCESS_KEY_ID, SYNC_S3_BUCKET,
SYNC_S3_ENDPOINT, SYNC_S3_PREFIX, SYNC_S3_REGION, SYNC_S3_SECRET_ACCESS_KEY,
TEMPORAL_ENTITY_RESOLUTION_THRESHOLD, TEMPORAL_SUPERSESSION_ENABLED,
TEMPORAL_SUPERSESSION_THRESHOLD, XAI_API_BASE
DROPPED (0): none
```

Strict superset -- no name the old list cleared is now left set.

**5. Full suite**

```
before (polluted env, unpatched):  5 failed, 1414 passed, 5 skipped, 78 deselected in 437.57s
after  (polluted env, patched):        1424 passed, 5 skipped, 78 deselected in 235.73s
```

1419 -> 1424 accounts exactly for the 5 new `TestCleanEnvCoverage` tests.

## Survey of other test files

Five other files construct `Settings()`: `test_graph.py`, `test_sync_security.py`,
`test_passport_actions.py`, `sync/test_scheduler.py`, `sync/test_sync_backend_resolve.py`.
Each does a *narrow, targeted* `delenv` of just the vars its assertions depend
on, rather than a broad Mnemo-wide list, so none carries the same drift
liability. Verified empirically -- those five plus `test_compression_env.py`
and `test_embedder_providers.py` are `136 passed` under both the polluted and
the clean environment, and the pre-patch full-suite baseline above shows the
only red tests in the entire repo were the 5 in `test_config.py`.

No change made to them: out of scope, and nothing is broken there today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
