### PR TITLE
feat: add cloudflare d1 memory backend selected by MEMORY_DB_BACKEND

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ Run your own mnemo instance serverless on Cloudflare (Containers + D1 + Vectoriz
 6. `wrangler deploy` and complete setup in the browser relay form at your Worker domain.
 
 Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (credentials / tokens, encrypted),
-`DOCS_DB_BACKEND=cf-d1` (the memories database + FTS5 full-text -- the variable name is
-shared with the other Cloudflare workers in this stack and is not specific to docs), and Vectorize (embeddings,
+`MEMORY_DB_BACKEND=cf-d1` (the memories database + FTS5 full-text; unset or `sqlite`
+keeps the local SQLite file at `DB_PATH`), and Vectorize (embeddings,
 cosine). Embedding and reranking are forced cloud through the `EMBEDDING_MODELS` /
 `RERANK_MODELS` chains (`jina_ai/...`) so the container never downloads the local Qwen3 ONNX
 models, and graph / LLM features run through the `LLM_MODELS` chain (`vertex_express/...`).

--- a/src/mnemo_mcp/db_cf.py
+++ b/src/mnemo_mcp/db_cf.py
@@ -1,0 +1,684 @@
+"""Cloudflare D1 backend for the Mnemo memory store (S2 Task 3).
+
+``MemoryDBCfBackend`` presents the same surface as :class:`mnemo_mcp.db.MemoryDB`
+but reads and writes a Cloudflare D1 database over the Worker outbound handler
+(``src/worker.ts``'s ``d1Outbound``) instead of a local SQLite file. Selection
+happens in exactly one place -- :func:`open_memory_db`, driven by the
+``MEMORY_DB_BACKEND`` env var -- and the default stays SQLite.
+
+Scope of this task: **D1 + FTS5 only.** Vector search on D1 is served by
+Cloudflare Vectorize (``migrations/0001_init.sql`` deliberately has no
+``memories_vec``: D1 cannot load the ``sqlite-vec`` extension), and that wiring
+is Task 4. Until then every vector-carrying entry point raises
+:class:`NotImplementedError` naming what is missing. Nothing on this backend
+returns an empty list, a zero count, or a success flag for work it did not do.
+
+Design notes
+------------
+
+*Behaviour is borrowed, not copied.* The scoring pipeline (BM25 normalisation,
+RRF fusion, recency/frequency/importance weighting) and the read-only SQL are
+taken from ``MemoryDB`` by class-level assignment, through a ``_conn`` adapter
+that speaks the sqlite3 slice those methods actually use. Re-typing that SQL
+here would let the two backends drift apart silently, which is the one failure
+mode a parity test cannot catch after the fact. Methods that need something the
+D1 wire cannot give -- ``cursor.rowcount``, a real ``ROLLBACK`` -- are written
+out explicitly below instead of borrowed.
+
+*Transport errors are never swallowed.* ``MemoryDB._search_fts`` wraps each FTS
+tier in ``except Exception: logger.error(...)`` -- harmless against local SQLite,
+but on D1 an HTTP failure would be caught there and the search would return
+"no results" for what is actually an outage. :meth:`MemoryDBCfBackend._search_fts`
+re-raises any transport error the borrowed body absorbed.
+
+*Only ``POST /query`` is used.* ``src/worker.ts``'s ``d1Outbound`` routes
+``/query`` and returns 404 for anything else, so ``D1Backend.executemany``'s
+non-INSERT fallback (which POSTs ``/batch``) would 404 against this Worker.
+Bulk import below therefore builds its own multi-row INSERT and sends it through
+``/query``, chunked to respect D1's hard cap of 100 bound parameters per query
+(https://developers.cloudflare.com/d1/platform/limits/) -- a cap
+``D1Backend.executemany`` does not model, since it chunks by rows, not params.
+
+*No transactions.* D1 wraps each query in its own implicit transaction and the
+``/query`` wire has no BEGIN/COMMIT, so multi-statement writes cannot be atomic
+here. :meth:`update` is the only such write; it is ordered so the guarded
+``UPDATE ... RETURNING`` is the serialisation point, and it issues a
+compensating write plus a loud log if the successor INSERT fails.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any, cast
+
+from loguru import logger
+from mcp_core.storage.d1 import D1Backend, d1_backend_from_env
+
+from mnemo_mcp.db import MAX_CONTENT_LENGTH, MemoryDB, _now_iso
+
+# Cloudflare D1 rejects a query carrying more than this many bound parameters.
+# https://developers.cloudflare.com/d1/platform/limits/
+D1_MAX_BOUND_PARAMS = 100
+
+# Tables `MemoryDBCfBackend` reads or writes. wrangler owns schema creation via
+# `migrations/0001_init.sql`; this backend only asserts the migration ran.
+REQUIRED_TABLES = (
+    "memories",
+    "memories_fts",
+    "store_meta",
+    "archived_memories",
+)
+
+# Columns written by the bulk-import path, in the order `_process_import_batch`
+# emits them. Kept as a constant so the generated multi-row INSERT never
+# interpolates anything caller-controlled.
+_IMPORT_COLUMNS = (
+    "id",
+    "content",
+    "category",
+    "tags",
+    "source",
+    "created_at",
+    "updated_at",
+    "access_count",
+    "last_accessed",
+    "importance",
+)
+_IMPORT_ROWS_PER_STATEMENT = D1_MAX_BOUND_PARAMS // len(_IMPORT_COLUMNS)
+
+_VECTOR_TASK = (
+    "Vector search on the D1 backend is served by Cloudflare Vectorize, which "
+    "is wired up in S2 Task 4. This backend (Task 3) is D1 + FTS5 only: "
+    "migrations/0001_init.sql has no memories_vec table because D1 cannot load "
+    "the sqlite-vec extension."
+)
+
+
+class _D1Row(dict):
+    """A D1 result row that also answers positional lookups.
+
+    D1 returns each row as a JSON object, so key access works out of the box.
+    Several borrowed ``MemoryDB`` methods index rows positionally
+    (``fetchone()[0]``, ``legacy[3]``) the way ``sqlite3.Row`` allows; JSON
+    preserves the SELECT's column order, so position ``n`` is the ``n``-th value.
+    """
+
+    def __getitem__(self, key: Any) -> Any:
+        if isinstance(key, int):
+            return list(self.values())[key]
+        return super().__getitem__(key)
+
+
+class _D1Cursor:
+    """Result handle over a materialised D1 row set.
+
+    ``rowcount`` is deliberately absent: ``POST /query`` returns rows only, with
+    no "rows changed" counter, so anything that needs a write count uses
+    ``RETURNING`` explicitly rather than reading a fabricated number here.
+    """
+
+    def __init__(self, conn: _D1Connection, rows: list[_D1Row]) -> None:
+        self._conn = conn
+        self.rows = rows
+
+    def execute(self, sql: str, params: Any = ()) -> _D1Cursor:
+        return self._conn.execute(sql, params)
+
+    def fetchall(self) -> list[_D1Row]:
+        return self.rows
+
+    def fetchone(self) -> _D1Row | None:
+        return self.rows[0] if self.rows else None
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class _D1Connection:
+    """The slice of the ``sqlite3.Connection`` API the borrowed methods use.
+
+    Every statement is a separate ``POST /query``, which is also how D1 behaves:
+    one implicit transaction per query. ``commit`` is therefore a no-op and
+    ``rollback`` raises -- a silent no-op rollback would let borrowed code
+    believe it had undone a write it could not undo.
+    """
+
+    def __init__(self, backend: D1Backend) -> None:
+        self._backend = backend
+        self._closed = False
+        self.last_error: Exception | None = None
+
+    def execute(self, sql: str, params: Any = ()) -> _D1Cursor:
+        if self._closed:
+            raise RuntimeError("Cannot operate on a closed MemoryDBCfBackend.")
+        try:
+            rows = self._backend.fetchall(sql, list(params))
+        except Exception as exc:
+            self.last_error = exc
+            raise
+        return _D1Cursor(self, [_D1Row(r) for r in rows])
+
+    def cursor(self) -> _D1Cursor:
+        return _D1Cursor(self, [])
+
+    def commit(self) -> None:
+        """No-op: D1 commits each query on its own."""
+
+    def rollback(self) -> None:
+        raise NotImplementedError(
+            "The D1 /query wire has no ROLLBACK -- each query is committed on "
+            "its own. A caller reaching this needs an explicit compensating "
+            "write instead."
+        )
+
+    def executescript(self, sql: str) -> None:
+        raise NotImplementedError(
+            "Schema creation on D1 belongs to wrangler "
+            "(`wrangler d1 migrations apply`), not to this backend."
+        )
+
+    def close(self) -> None:
+        self._closed = True
+
+    def clear_error(self) -> None:
+        self.last_error = None
+
+    def raise_if_error(self, what: str) -> None:
+        """Re-raise a transport error that borrowed code caught and logged."""
+        exc = self.last_error
+        if exc is None:
+            return
+        self.last_error = None
+        raise RuntimeError(
+            f"{what} against Cloudflare D1 failed; the result set below it is "
+            f"incomplete and must not be treated as 'no matches': {exc}"
+        ) from exc
+
+
+def _reject_embedding(method):
+    """Wrap ``method`` so passing an ``embedding`` raises instead of dropping it.
+
+    ``MemoryDB.add`` / ``add_with_context_type`` guard their vector INSERT with
+    ``if embedding and self._vec_enabled``, and ``MemoryDB.search`` guards its
+    vector branch the same way. Borrowed as-is with ``_vec_enabled=False`` they
+    would accept a vector, write nothing, and report success -- so the caller is
+    told, loudly, that the vector went nowhere.
+    """
+    signature = inspect.signature(method)
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        bound = signature.bind(self, *args, **kwargs)
+        if bound.arguments.get("embedding") is not None:
+            raise NotImplementedError(
+                f"MemoryDBCfBackend.{method.__name__}() was given an embedding, "
+                f"which it cannot store or query. {_VECTOR_TASK}"
+            )
+        return method(self, *args, **kwargs)
+
+    return wrapper
+
+
+class MemoryDBCfBackend:
+    """Cloudflare D1 implementation of the :class:`MemoryDB` surface."""
+
+    # -- Borrowed from MemoryDB -------------------------------------------
+    # Pure scoring helpers: they touch only ``self._recency_half_life``.
+    _build_filter_sql = MemoryDB._build_filter_sql
+    _calc_recency = MemoryDB._calc_recency
+    _calc_frequency = MemoryDB._calc_frequency
+    _compute_hybrid_scores = MemoryDB._compute_hybrid_scores
+    rrf_fuse = staticmethod(MemoryDB.rrf_fuse)
+
+    # Read paths and single-statement writes: they use only
+    # ``self._conn.execute`` / ``.cursor()`` and never need a rows-changed count.
+    get_store_meta = MemoryDB.get_store_meta
+    _set_store_meta = MemoryDB._set_store_meta
+    _stamp_embedding_identity = MemoryDB._stamp_embedding_identity
+    _guard_embedding_identity = MemoryDB._guard_embedding_identity
+    _update_access_stats = MemoryDB._update_access_stats
+    list_memories = MemoryDB.list_memories
+    get = MemoryDB.get
+    stats = MemoryDB.stats
+    export_jsonl = MemoryDB.export_jsonl
+    list_archived = MemoryDB.list_archived
+    check_duplicate = MemoryDB.check_duplicate
+    _clear_for_import = MemoryDB._clear_for_import
+    _parse_import_data = MemoryDB._parse_import_data
+    _process_import_batch = MemoryDB._process_import_batch
+
+    # Vector-carrying entry points: same bodies, but a vector argument raises
+    # rather than being silently discarded.
+    add = _reject_embedding(MemoryDB.add)
+    add_with_context_type = _reject_embedding(MemoryDB.add_with_context_type)
+    _search = _reject_embedding(MemoryDB.search)
+
+    def __init__(
+        self,
+        backend: D1Backend | None = None,
+        *,
+        embedding_dims: int = 0,
+        recency_half_life_days: float = 7.0,
+        embedding_model: str = "",
+        reindex_on_model_change: bool = False,
+    ) -> None:
+        """Open the D1-backed store.
+
+        Args:
+            backend: Wire client. Defaults to
+                :func:`mcp_core.storage.d1.d1_backend_from_env`, which reads
+                ``MCP_D1_BASE_URL`` (default ``http://d1.internal``) and
+                ``MCP_D1_TOKEN``.
+            embedding_dims: Recorded in ``store_meta`` for the identity guard.
+                No vectors are stored by this backend (see :data:`_VECTOR_TASK`).
+            recency_half_life_days: Half-life in days for recency decay.
+            embedding_model: Active embedding-model identity string.
+            reindex_on_model_change: Accepted for signature parity; a mismatch
+                raises rather than dropping vectors, because dropping them is
+                the Vectorize path.
+
+        Raises:
+            RuntimeError: When the D1 database has not had
+                ``migrations/0001_init.sql`` applied.
+            EmbeddingModelMismatch: Same contract as :class:`MemoryDB`.
+        """
+        if type(embedding_dims) is not int:
+            raise ValueError(
+                f"embedding_dims must be an integer, got {type(embedding_dims).__name__}"
+            )
+        if not (0 <= embedding_dims <= 10000):
+            raise ValueError(
+                f"embedding_dims must be between 0 and 10000, got {embedding_dims}"
+            )
+
+        self._backend = backend if backend is not None else d1_backend_from_env()
+        self._conn = _D1Connection(self._backend)
+        self._db_path = f"cf-d1:{self._backend.base_url}"
+        self._embedding_dims = embedding_dims
+        self._embedding_model = embedding_model
+        self._reindex_on_model_change = reindex_on_model_change
+        self._recency_half_life = float(recency_half_life_days)
+        self._vec_enabled = False
+
+        self._require_schema()
+        self._guard_embedding_identity()
+
+    def _require_schema(self) -> None:
+        """Fail at open time when the D1 migration has not been applied.
+
+        Without this the first query fails as an opaque ``HTTP 500`` from the
+        Worker, several calls away from the actual cause.
+        """
+        try:
+            rows = self._backend.fetchall(
+                "SELECT name FROM sqlite_master WHERE type = 'table'", []
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"Could not read the schema of the D1 database at "
+                f"{self._backend.base_url}: {exc}"
+            ) from exc
+        present = {r["name"] for r in rows}
+        missing = [t for t in REQUIRED_TABLES if t not in present]
+        if missing:
+            raise RuntimeError(
+                f"D1 database at {self._backend.base_url} is missing "
+                f"{', '.join(missing)}. Apply the schema first: "
+                "`wrangler d1 migrations apply mnemo-memories`."
+            )
+
+    @property
+    def vec_enabled(self) -> bool:
+        """Always ``False`` on this backend."""
+        return False
+
+    def _drop_vectors_for_reindex(self) -> None:
+        """Reached from the borrowed embedding-identity guard on a mismatch."""
+        raise NotImplementedError(
+            "REINDEX_ON_MODEL_CHANGE cannot be honoured by MemoryDBCfBackend: "
+            f"there are no stored vectors here to drop. {_VECTOR_TASK}"
+        )
+
+    # -- Search ------------------------------------------------------------
+
+    def _search_fts(self, *args, **kwargs) -> dict[str, dict]:
+        """Borrowed FTS search, with swallowed transport errors re-raised."""
+        self._conn.clear_error()
+        # cast: the borrow is structural -- the body only reaches for
+        # ``self._conn`` and the filter helpers, both of which exist here.
+        results = MemoryDB._search_fts(cast(MemoryDB, self), *args, **kwargs)
+        self._conn.raise_if_error("FTS5 search")
+        return results
+
+    @functools.wraps(MemoryDB.search)
+    def search(self, *args, **kwargs) -> list[dict]:
+        return self._search(*args, **kwargs)
+
+    # -- Writes that need a rows-changed count or a rollback ---------------
+
+    def update(
+        self,
+        memory_id: str,
+        content: str | None = None,
+        category: str | None = None,
+        tags: list[str] | None = None,
+        source: str | None = None,
+        importance: float | None = None,
+        embedding: list[float] | None = None,
+    ) -> str | None:
+        """Supersede a memory with a new version. See :meth:`MemoryDB.update`.
+
+        Not atomic, and cannot be: the ``/query`` wire commits each statement on
+        its own. The guarded ``UPDATE ... WHERE valid_to IS NULL RETURNING *``
+        runs first, so a competing writer still loses the race exactly as on
+        SQLite; if the successor INSERT then fails, the predecessor is reopened
+        by a compensating write and the failure is re-raised. Should the
+        compensation itself fail, the row id is logged at ERROR -- the one case
+        that needs a human -- rather than being reported as a successful update.
+        """
+        if embedding is not None:
+            raise NotImplementedError(
+                "MemoryDBCfBackend.update() was given an embedding, which it "
+                f"cannot store. {_VECTOR_TASK}"
+            )
+        if content is not None and len(content) > MAX_CONTENT_LENGTH:
+            raise ValueError(
+                f"Content length {len(content)} exceeds limit of {MAX_CONTENT_LENGTH}"
+            )
+
+        now = _now_iso()
+        new_id = uuid.uuid4().hex
+
+        old_row = self._backend.fetchone(
+            "UPDATE memories SET valid_to = ?, superseded_by = ? "
+            "WHERE id = ? AND valid_to IS NULL RETURNING *",
+            [now, new_id, memory_id],
+        )
+        if old_row is None:
+            return None
+
+        new_row = dict(old_row)
+        new_row["id"] = new_id
+        new_row["created_at"] = now
+        new_row["updated_at"] = now
+        new_row["last_accessed"] = now
+        new_row["access_count"] = 0
+        new_row["valid_from"] = now
+        new_row["valid_to"] = None
+        new_row["superseded_by"] = None
+        if "commit_sha" in new_row:
+            new_row["commit_sha"] = None
+
+        if content is not None:
+            new_row["content"] = content
+        if category is not None:
+            new_row["category"] = category
+        if tags is not None:
+            new_row["tags"] = "[]" if not tags else json.dumps(tags)
+        if source is not None:
+            new_row["source"] = source
+        if importance is not None:
+            new_row["importance"] = max(0.0, min(1.0, importance))
+
+        columns = list(new_row.keys())
+        column_list = ", ".join(columns)
+        placeholders = ", ".join("?" for _ in columns)
+
+        try:
+            self._backend.execute(
+                f"INSERT INTO memories ({column_list}) VALUES ({placeholders})",
+                [new_row[c] for c in columns],
+            )
+        except Exception:
+            try:
+                self._backend.execute(
+                    "UPDATE memories SET valid_to = NULL, superseded_by = NULL "
+                    "WHERE id = ? AND superseded_by = ?",
+                    [memory_id, new_id],
+                )
+            except Exception as compensation_error:
+                logger.error(
+                    "[AUDIT] update id={} FAILED after closing the predecessor, "
+                    "and reopening it also failed ({}). Row {} is now closed "
+                    "with no successor and needs manual repair.",
+                    memory_id,
+                    compensation_error,
+                    memory_id,
+                )
+            raise
+
+        logger.info(f"[AUDIT] update id={memory_id} -> new_id={new_id}")
+        return new_id
+
+    def delete(self, memory_id: str) -> bool:
+        """Soft-close a memory. See :meth:`MemoryDB.delete`."""
+        rows = self._backend.fetchall(
+            "UPDATE memories SET valid_to = ? WHERE id = ? AND valid_to IS NULL "
+            "RETURNING id",
+            [_now_iso(), memory_id],
+        )
+        if not rows:
+            return False
+        logger.info(f"[AUDIT] delete id={memory_id}")
+        return True
+
+    def update_importance(self, memory_id: str, importance: float) -> bool:
+        """Update the importance score. See :meth:`MemoryDB.update_importance`."""
+        importance = max(0.0, min(1.0, importance))
+        rows = self._backend.fetchall(
+            "UPDATE memories SET importance = ? WHERE id = ? RETURNING id",
+            [importance, memory_id],
+        )
+        return bool(rows)
+
+    def archive_old_memories(
+        self, days: int = 90, importance_threshold: float = 0.3
+    ) -> int:
+        """Soft-archive old, low-importance rows. See :meth:`MemoryDB`."""
+        rows = self._backend.fetchall(
+            "UPDATE memories SET archived_at = ? "
+            "WHERE archived_at IS NULL "
+            "  AND last_accessed < datetime('now', ?) "
+            "  AND importance < ? "
+            "RETURNING id",
+            [_now_iso(), f"-{days} days", importance_threshold],
+        )
+        count = len(rows)
+        if count > 0:
+            logger.info(f"[AUDIT] archived count={count} mode=soft")
+        return count
+
+    def archive_by_score(
+        self,
+        archive_after_days: int | None = None,
+        score_threshold: float = 1.0,
+    ) -> int:
+        """Archive by ``archive_score``. See :meth:`MemoryDB.archive_by_score`."""
+        if archive_after_days is None:
+            try:
+                from mnemo_mcp.config import settings as _settings
+
+                archive_after_days = int(_settings.archive_after_days)
+            except Exception:
+                archive_after_days = 90
+        archive_after_days = max(1, int(archive_after_days))
+
+        rows = self._backend.fetchall(
+            "UPDATE memories SET archived_at = ? "
+            "WHERE archived_at IS NULL "
+            "AND ( MAX(0.0, julianday('now') - julianday(updated_at)) / ? ) "
+            "    * (1.0 - MAX(0.0, MIN(1.0, COALESCE(importance, 0.0)))) > ? "
+            "RETURNING id",
+            [_now_iso(), float(archive_after_days), score_threshold],
+        )
+        count = len(rows)
+        if count > 0:
+            logger.info(
+                f"[AUDIT] archived_by_score count={count} "
+                f"after_days={archive_after_days} threshold={score_threshold}"
+            )
+        return count
+
+    def restore_memory(self, memory_id: str) -> bool:
+        """Restore an archived memory. See :meth:`MemoryDB.restore_memory`."""
+        now = _now_iso()
+        rows = self._backend.fetchall(
+            "UPDATE memories SET archived_at = NULL, last_accessed = ? "
+            "WHERE id = ? AND archived_at IS NOT NULL RETURNING id",
+            [now, memory_id],
+        )
+        if rows:
+            logger.info(f"[AUDIT] restore id={memory_id} mode=soft")
+            return True
+
+        legacy = self._backend.fetchone(
+            "SELECT * FROM archived_memories WHERE id = ?", [memory_id]
+        )
+        if not legacy:
+            return False
+        self._backend.execute(
+            "INSERT OR REPLACE INTO memories "
+            "(id, content, category, tags, source, importance, "
+            " created_at, updated_at, access_count, last_accessed) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                legacy["id"],
+                legacy["content"],
+                legacy["category"],
+                legacy["tags"],
+                legacy["source"],
+                legacy["importance"],
+                legacy["created_at"],
+                now,
+                legacy["access_count"],
+                now,
+            ],
+        )
+        self._backend.execute("DELETE FROM archived_memories WHERE id = ?", [memory_id])
+        logger.info(f"[AUDIT] restore id={memory_id} mode=legacy")
+        return True
+
+    def _execute_import_batch(
+        self, to_insert: list[tuple], mode: str
+    ) -> tuple[int, int]:
+        """Insert prepared rows with multi-row INSERTs sized for D1's param cap.
+
+        ``RETURNING id`` supplies the inserted count that ``cursor.rowcount``
+        would give on SQLite; ``INSERT OR IGNORE`` emits no row for a conflict,
+        so the difference is the skipped count.
+        """
+        if not to_insert:
+            return 0, 0
+        op = "REPLACE" if mode == "replace" else "IGNORE"
+        column_list = ", ".join(_IMPORT_COLUMNS)
+        row_placeholder = "(" + ", ".join("?" for _ in _IMPORT_COLUMNS) + ")"
+
+        imported = 0
+        for i in range(0, len(to_insert), _IMPORT_ROWS_PER_STATEMENT):
+            chunk = to_insert[i : i + _IMPORT_ROWS_PER_STATEMENT]
+            values_sql = ", ".join([row_placeholder] * len(chunk))
+            flat = [value for row in chunk for value in row]
+            rows = self._backend.fetchall(
+                f"INSERT OR {op} INTO memories ({column_list}) "
+                f"VALUES {values_sql} RETURNING id",
+                flat,
+            )
+            imported += len(rows)
+
+        skipped = len(to_insert) - imported if mode != "replace" else 0
+        return imported, skipped
+
+    def import_jsonl(self, data: str | list | dict, mode: str = "merge") -> dict:
+        """Import memories from JSONL. See :meth:`MemoryDB.import_jsonl`."""
+        self._clear_for_import(mode)
+        items, rejected = self._parse_import_data(data)
+        imported = 0
+        skipped = 0
+        now = _now_iso()
+        for i in range(0, len(items), 900):
+            to_insert, batch_rejected = self._process_import_batch(
+                items[i : i + 900], now
+            )
+            rejected += batch_rejected
+            batch_imported, batch_skipped = self._execute_import_batch(to_insert, mode)
+            imported += batch_imported
+            skipped += batch_skipped
+        if imported > 0:
+            logger.info(f"[AUDIT] import count={imported} mode={mode}")
+        return {"imported": imported, "skipped": skipped, "rejected": rejected}
+
+    # -- Not available on this backend -------------------------------------
+
+    def get_sync_state(self, backend: str) -> dict | None:
+        raise NotImplementedError(
+            "sync_state is not part of migrations/0001_init.sql, so the D1 "
+            "database has no delta-sync cursor table. Add it in a follow-up "
+            "migration before running the sync pipeline against cf-d1."
+        )
+
+    def upsert_sync_state(
+        self,
+        backend: str,
+        last_sync_at: float | None = None,
+        last_commit_sha: str | None = None,
+        upload_cursor: int | None = None,
+    ) -> None:
+        raise NotImplementedError(
+            "sync_state is not part of migrations/0001_init.sql, so the D1 "
+            "database has no delta-sync cursor table. Add it in a follow-up "
+            "migration before running the sync pipeline against cf-d1."
+        )
+
+    def close(self) -> None:
+        """Release the store.
+
+        There is no persistent connection to close -- each query is its own HTTP
+        request -- but the handle is marked closed so later use raises instead of
+        quietly succeeding against a store the caller believes it released.
+        """
+        self._conn.close()
+
+
+def open_memory_db(
+    db_path: Path,
+    *,
+    embedding_dims: int = 0,
+    recency_half_life_days: float = 7.0,
+    embedding_model: str = "",
+    reindex_on_model_change: bool = False,
+) -> MemoryDB | MemoryDBCfBackend:
+    """Build the memory store selected by ``MEMORY_DB_BACKEND``.
+
+    This is the only place the variable is read. ``sqlite`` (the default) opens
+    the local file at ``db_path``; ``cf-d1`` opens the Cloudflare D1 database
+    described by ``MCP_D1_BASE_URL`` / ``MCP_D1_TOKEN`` and ignores ``db_path``.
+    An unrecognised value raises rather than falling back, so a typo in the
+    Worker's ``vars`` cannot quietly deploy the wrong store.
+    """
+    kind = os.environ.get("MEMORY_DB_BACKEND", "sqlite").strip().lower()
+    if kind in ("", "sqlite"):
+        return MemoryDB(
+            db_path,
+            embedding_dims=embedding_dims,
+            recency_half_life_days=recency_half_life_days,
+            embedding_model=embedding_model,
+            reindex_on_model_change=reindex_on_model_change,
+        )
+    if kind == "cf-d1":
+        return MemoryDBCfBackend(
+            embedding_dims=embedding_dims,
+            recency_half_life_days=recency_half_life_days,
+            embedding_model=embedding_model,
+            reindex_on_model_change=reindex_on_model_change,
+        )
+    raise ValueError(
+        f"Unknown MEMORY_DB_BACKEND: {kind!r} (expected 'sqlite' or 'cf-d1')"
+    )
+
+
+__all__ = ["MemoryDBCfBackend", "open_memory_db"]

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -25,6 +25,7 @@ from mcp.types import ToolAnnotations
 
 from mnemo_mcp.config import settings
 from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.db_cf import open_memory_db
 
 # Resolved via importlib.metadata (not ``from mnemo_mcp import __version__``)
 # to avoid a circular import: ``mnemo_mcp/__init__`` imports ``server.main``.
@@ -271,7 +272,10 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
         embedding_model_identity = settings.embedding_primary() or ""
 
     db_path = settings.get_db_path()
-    db = MemoryDB(
+    # MEMORY_DB_BACKEND picks the store: the default SQLite file at db_path, or
+    # the Cloudflare D1 database when the Worker sets cf-d1. This is the only
+    # place that choice is made.
+    db = open_memory_db(
         db_path,
         embedding_dims=embedding_dims,
         recency_half_life_days=settings.recency_half_life_days,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,7 +35,7 @@ export interface Env {
   // forwarded into the container process via MnemoContainer.envVars.
   MCP_STORAGE_BACKEND: string
   MCP_KV_BASE_URL: string
-  DOCS_DB_BACKEND: string
+  MEMORY_DB_BACKEND: string
   MCP_D1_BASE_URL: string
   MCP_VECTORIZE_BASE_URL: string
   MCP_VECTORIZE_IDX: string
@@ -59,7 +59,7 @@ export interface Env {
 // browser form (Gate A) is gated by it -- dropping it would open the relay form
 // to anyone. CREDENTIAL_SECRET + MCP_DCR_SERVER_SECRET enable per-sub multi-user.
 const CONTAINER_ENV_KEYS = [
-  'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'DOCS_DB_BACKEND',
+  'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'MEMORY_DB_BACKEND',
   'MCP_D1_BASE_URL', 'MCP_VECTORIZE_BASE_URL', 'MCP_VECTORIZE_IDX',
   'EMBEDDING_MODELS', 'RERANK_MODELS', 'LLM_MODELS',
   'EMBEDDING_DIMS', 'RECENCY_HALF_LIFE_DAYS',
@@ -249,7 +249,7 @@ export class MnemoContainer extends Container<Env> {
   // internet; kv/d1/vectorize.internal stay intercepted (see outboundByHost).
   enableInternet = true
   // Forward Worker config (vars) + secrets into the container process. Without
-  // this the Python server defaults to MCP_STORAGE_BACKEND=local / DOCS_DB_BACKEND=sqlite
+  // this the Python server defaults to MCP_STORAGE_BACKEND=local / MEMORY_DB_BACKEND=sqlite
   // on the ephemeral container FS and downloads local ONNX models.
   envVars = pickContainerEnv(this.env)
 }

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -1,0 +1,732 @@
+"""Tests for ``mnemo_mcp.db_cf`` -- the Cloudflare D1 memory backend.
+
+The centrepiece is :class:`TestBackendParity`: every scenario there runs twice,
+once against a real ``MemoryDB`` on a temp SQLite file and once against
+``MemoryDBCfBackend``, and asserts the two agree. A surface that merely *looks*
+substitutable is what this is meant to catch.
+
+How the D1 side is exercised
+----------------------------
+
+``D1Backend`` takes an injectable transport (``http=``) whose contract is
+``request(method, url, body, headers) -> (status, bytes)``. :class:`FakeD1Worker`
+implements that transport by transcribing ``src/worker.ts``'s ``d1Outbound``
+handler -- ``POST /query`` runs ``prepare(sql).bind(...params).all()`` and
+answers ``Response.json({ results })``; every other route 404s -- against a real
+SQLite database that has ``migrations/0001_init.sql`` applied.
+
+What that reproduces faithfully: the SQL text and bound parameters actually sent,
+the JSON request/response envelope, rows as JSON objects, one statement per
+request with no client-side transaction, the real D1 schema (including the FTS5
+external-content triggers), and the absence of ``sqlite-vec``. Also the route
+surface -- ``test_fake_worker_matches_worker_ts`` pins the transcription against
+``src/worker.ts`` so the double cannot drift away from the Worker it stands in
+for, and ``test_only_query_route_is_used`` proves the backend never calls a route
+the Worker does not serve.
+
+What it does not reproduce: the network hop itself, D1's exact SQLite build,
+Cloudflare's per-query limits (the 100-bound-parameter cap is enforced in the
+backend and asserted separately here rather than by the double), and
+concurrency. Driving a real local D1 through ``wrangler`` would add the network
+hop at the cost of a node + wrangler subprocess per query, which cannot live in
+the default pytest run; the SQL-level fidelity above is what the parity claim
+rests on, and it is the part that can silently break.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sqlite3
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.db_cf import (
+    D1_MAX_BOUND_PARAMS,
+    MemoryDBCfBackend,
+    open_memory_db,
+)
+from mnemo_mcp.exceptions import EmbeddingModelMismatch
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
+_WORKER_TS = _REPO_ROOT / "src" / "worker.ts"
+
+
+class FakeD1Worker:
+    """In-process stand-in for ``d1Outbound`` in ``src/worker.ts``.
+
+    Deliberately literal: it serves ``POST /query`` and nothing else, exactly
+    like the handler it transcribes, so a backend that reaches for ``/batch``
+    fails here the same way it would fail in production.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+        self.requests: list[tuple[str, str, list]] = []
+
+    def request(self, method, url, data=None, headers=None):
+        path = url.split("//", 1)[-1].split("/", 1)[-1]
+        self.requests.append((method, "/" + path, []))
+        if path != "query" or method != "POST":
+            # `return new Response('not found', { status: 404 })`
+            return (404, b"not found")
+
+        payload = json.loads(data.decode())
+        sql, params = payload["sql"], payload.get("params") or []
+        self.requests[-1] = (method, "/" + path, params)
+        cursor = self.conn.execute(sql, params)
+        columns = [d[0] for d in cursor.description] if cursor.description else []
+        results = [dict(zip(columns, row, strict=True)) for row in cursor.fetchall()]
+        return (200, json.dumps({"results": results}).encode())
+
+
+@pytest.fixture
+def d1_conn(tmp_path) -> sqlite3.Connection:
+    """A SQLite database carrying the real D1 schema.
+
+    ``isolation_level=None`` puts pysqlite in autocommit, which is how D1
+    behaves: every statement is committed on its own and there is no
+    client-side transaction to roll back. sqlite-vec is never loaded, matching
+    D1's inability to load extensions.
+    """
+    conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
+    conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+    return conn
+
+
+@pytest.fixture
+def fake_worker(d1_conn: sqlite3.Connection) -> FakeD1Worker:
+    return FakeD1Worker(d1_conn)
+
+
+def _cf_db(worker: FakeD1Worker, **kwargs) -> MemoryDBCfBackend:
+    from mcp_core.storage.d1 import D1Backend
+
+    return MemoryDBCfBackend(
+        D1Backend(base_url="http://d1.internal", http=worker), **kwargs
+    )
+
+
+@pytest.fixture
+def cf_db(fake_worker: FakeD1Worker) -> MemoryDBCfBackend:
+    return _cf_db(fake_worker)
+
+
+@pytest.fixture
+def sqlite_db(tmp_path) -> Generator[MemoryDB]:
+    db = MemoryDB(tmp_path / "memories.db", embedding_dims=0)
+    yield db
+    db.close()
+
+
+@pytest.fixture(params=["sqlite", "cf-d1"])
+def either_db(request, tmp_path, fake_worker: FakeD1Worker):
+    """The same scenario, once per backend."""
+    if request.param == "sqlite":
+        db = MemoryDB(tmp_path / "memories.db", embedding_dims=0)
+        yield db
+        db.close()
+    else:
+        db = _cf_db(fake_worker)
+        yield db
+        db.close()
+
+
+# Age of the rows `_seed_aged` inserts. Doubles as the `archive_after_days`
+# denominator in the archive-by-score test, which pins recency_factor at 1.0 so
+# only importance separates the two rows.
+_AGE_DAYS = 1000
+
+
+def _seed_aged(db) -> None:
+    """Insert two rows dated ``_AGE_DAYS`` in the past.
+
+    ``add()`` always stamps "now", and the archive policies key off
+    ``last_accessed`` / ``updated_at``, so ageing a row means importing one:
+    ``import_jsonl`` honours explicit timestamps.
+    """
+    old = (datetime.now(UTC) - timedelta(days=_AGE_DAYS)).isoformat()
+    db.import_jsonl(
+        "\n".join(
+            json.dumps(
+                {
+                    "id": mid,
+                    "content": content,
+                    "category": "tech",
+                    "importance": importance,
+                    "created_at": old,
+                    "updated_at": old,
+                    "last_accessed": old,
+                }
+            )
+            for mid, content, importance in (
+                ("aged-forgettable", "a forgotten note about a kangaroo", 0.1),
+                ("aged-important", "an important note about a kangaroo", 0.9),
+            )
+        )
+    )
+
+
+def _seed(db) -> dict[str, str]:
+    return {
+        "python": db.add(
+            "Python is a programming language", category="tech", tags=["python", "lang"]
+        ),
+        "typescript": db.add(
+            "TypeScript is used for web development",
+            category="tech",
+            tags=["typescript", "web"],
+        ),
+        "groceries": db.add(
+            "Remember to buy groceries", category="personal", tags=["todo"]
+        ),
+    }
+
+
+class TestFakeWorkerFidelity:
+    """The double is only evidence if it matches the Worker it replaces."""
+
+    def test_fake_worker_matches_worker_ts(self):
+        """``d1Outbound`` serves POST /query and 404s everything else.
+
+        Pinned against the real file so a new route in the Worker (or a removed
+        one) breaks this test instead of silently invalidating the parity suite.
+        """
+        source = _WORKER_TS.read_text(encoding="utf-8")
+        handler = source.split("const d1Outbound", 1)[1].split("\nconst ", 1)[0]
+        routes = set(re.findall(r"url\.pathname === '([^']+)'", handler))
+        assert routes == {"/query"}, (
+            f"src/worker.ts d1Outbound now serves {routes}; FakeD1Worker and "
+            "MemoryDBCfBackend's single-route assumption need updating together"
+        )
+        assert "Response.json({ results })" in handler
+        assert "status: 404" in handler
+
+    def test_only_query_route_is_used(self, cf_db, fake_worker: FakeD1Worker):
+        """Every backend operation must stay on the one route D1 serves.
+
+        ``D1Backend.executemany`` falls back to ``POST /batch``, which this
+        Worker 404s -- so the backend must never reach it.
+        """
+        mid = cf_db.add("route check", category="tech")
+        cf_db.search("route")
+        cf_db.list_memories()
+        cf_db.stats()
+        cf_db.import_jsonl(
+            "\n".join(
+                json.dumps({"id": f"i{i}", "content": f"row {i}"}) for i in range(25)
+            )
+        )
+        cf_db.update(mid, content="route check edited")
+        cf_db.export_jsonl()
+        assert {path for _, path, _ in fake_worker.requests} == {"/query"}
+
+    def test_unknown_route_404s_like_the_worker(self, fake_worker: FakeD1Worker):
+        status, _ = fake_worker.request("POST", "http://d1.internal/batch", b"[]")
+        assert status == 404
+
+    def test_import_respects_d1_bound_parameter_cap(
+        self, cf_db, fake_worker: FakeD1Worker
+    ):
+        """D1 rejects any query with more than 100 bound parameters.
+
+        The chunking that keeps imports under that cap is invisible in the
+        result, so assert it on the wire.
+        """
+        payload = "\n".join(
+            json.dumps({"id": f"m{i}", "content": f"memory number {i}"})
+            for i in range(60)
+        )
+        cf_db.import_jsonl(payload)
+        widest = max(len(params) for _, _, params in fake_worker.requests)
+        assert widest <= D1_MAX_BOUND_PARAMS, (
+            f"a query carried {widest} bound parameters; D1 caps them at "
+            f"{D1_MAX_BOUND_PARAMS}"
+        )
+
+
+class TestBackendParity:
+    """Same scenario, both backends, results compared."""
+
+    def test_add_then_get_roundtrip(self, either_db):
+        mid = either_db.add(
+            "Python is a programming language", category="tech", tags=["python"]
+        )
+        row = either_db.get(mid)
+        assert row["content"] == "Python is a programming language"
+        assert row["category"] == "tech"
+        assert json.loads(row["tags"]) == ["python"]
+        assert row["access_count"] == 0
+
+    def test_add_rejects_oversized_content(self, either_db):
+        with pytest.raises(ValueError, match="exceeds limit"):
+            either_db.add("x" * 5001)
+
+    def test_search_finds_by_full_text(self, either_db):
+        ids = _seed(either_db)
+        hits = either_db.search("programming language")
+        assert [h["id"] for h in hits][:1] == [ids["python"]]
+
+    def test_search_filters_by_category(self, either_db):
+        _seed(either_db)
+        hits = either_db.search("Python", category="personal")
+        assert hits == []
+
+    def test_search_filters_by_tags(self, either_db):
+        ids = _seed(either_db)
+        hits = either_db.search("development", tags=["web"])
+        assert [h["id"] for h in hits] == [ids["typescript"]]
+
+    def test_search_increments_access_count(self, either_db):
+        ids = _seed(either_db)
+        either_db.search("groceries")
+        assert either_db.get(ids["groceries"])["access_count"] == 1
+
+    def test_search_scores_are_identical_across_backends(
+        self, sqlite_db, cf_db, monkeypatch
+    ):
+        """Scoring is borrowed rather than re-implemented; prove it agrees.
+
+        Recency decay makes the absolute score time-dependent, so compare the
+        ordering and the score values the two backends produce for the same
+        corpus inserted in the same order.
+        """
+        for db in (sqlite_db, cf_db):
+            _seed(db)
+        left = sqlite_db.search("web development programming")
+        right = cf_db.search("web development programming")
+        assert [h["content"] for h in left] == [h["content"] for h in right]
+        for a, b in zip(left, right, strict=True):
+            assert a["score"] == pytest.approx(b["score"], rel=1e-6)
+
+    def test_search_returns_nothing_for_unmatched_query(self, either_db):
+        _seed(either_db)
+        assert either_db.search("kangaroo") == []
+
+    def test_list_memories_orders_by_updated_desc(self, either_db):
+        _seed(either_db)
+        rows = either_db.list_memories()
+        assert len(rows) == 3
+        assert [r["updated_at"] for r in rows] == sorted(
+            (r["updated_at"] for r in rows), reverse=True
+        )
+
+    def test_list_memories_filters_by_category(self, either_db):
+        _seed(either_db)
+        assert len(either_db.list_memories(category="tech")) == 2
+
+    def test_update_supersedes_and_changes_id(self, either_db):
+        ids = _seed(either_db)
+        new_id = either_db.update(ids["python"], content="Python 3.13 is current")
+        assert new_id and new_id != ids["python"]
+        assert either_db.get(ids["python"]) is None
+        assert either_db.get(new_id)["content"] == "Python 3.13 is current"
+
+    def test_update_carries_unspecified_fields_forward(self, either_db):
+        ids = _seed(either_db)
+        new_id = either_db.update(ids["python"], importance=0.9)
+        row = either_db.get(new_id)
+        assert row["content"] == "Python is a programming language"
+        assert row["category"] == "tech"
+        assert row["importance"] == pytest.approx(0.9)
+        assert row["access_count"] == 0
+
+    def test_update_of_missing_id_returns_none(self, either_db):
+        assert either_db.update("does-not-exist", content="x") is None
+
+    def test_update_twice_supersedes_the_successor(self, either_db):
+        ids = _seed(either_db)
+        first = either_db.update(ids["python"], content="v2")
+        second = either_db.update(first, content="v3")
+        assert either_db.get(first) is None
+        assert either_db.get(second)["content"] == "v3"
+
+    def test_updated_row_is_searchable_and_old_text_is_not(self, either_db):
+        """FTS5 is external-content; the triggers are what keep it honest."""
+        ids = _seed(either_db)
+        either_db.update(ids["groceries"], content="Remember to buy stationery")
+        assert either_db.search("stationery")
+        assert either_db.search("groceries") == []
+
+    def test_delete_hides_the_row(self, either_db):
+        ids = _seed(either_db)
+        assert either_db.delete(ids["groceries"]) is True
+        assert either_db.get(ids["groceries"]) is None
+        assert len(either_db.list_memories()) == 2
+
+    def test_delete_of_missing_id_is_false(self, either_db):
+        assert either_db.delete("does-not-exist") is False
+
+    def test_delete_twice_is_false_the_second_time(self, either_db):
+        ids = _seed(either_db)
+        assert either_db.delete(ids["python"]) is True
+        assert either_db.delete(ids["python"]) is False
+
+    def test_stats_counts_current_rows_only(self, either_db):
+        ids = _seed(either_db)
+        either_db.delete(ids["groceries"])
+        stats = either_db.stats()
+        assert stats["total_memories"] == 2
+        assert stats["categories"] == {"tech": 2}
+        assert stats["vec_enabled"] is False
+
+    def test_export_jsonl_roundtrips_through_import(self, either_db):
+        _seed(either_db)
+        payload, count = either_db.export_jsonl()
+        assert count == 3
+        lines = [json.loads(line) for line in payload.strip().split("\n")]
+        assert {line["content"] for line in lines} == {
+            "Python is a programming language",
+            "TypeScript is used for web development",
+            "Remember to buy groceries",
+        }
+
+    def test_import_merge_skips_existing_ids(self, either_db):
+        _seed(either_db)
+        payload, _ = either_db.export_jsonl()
+        assert either_db.import_jsonl(payload) == {
+            "imported": 0,
+            "skipped": 3,
+            "rejected": 0,
+        }
+
+    def test_import_merge_adds_new_ids(self, either_db):
+        _seed(either_db)
+        payload = json.dumps({"id": "brand-new", "content": "a fresh memory"})
+        assert either_db.import_jsonl(payload) == {
+            "imported": 1,
+            "skipped": 0,
+            "rejected": 0,
+        }
+        assert either_db.get("brand-new")["content"] == "a fresh memory"
+
+    def test_import_replace_clears_first(self, either_db):
+        _seed(either_db)
+        payload = json.dumps({"id": "only-one", "content": "sole survivor"})
+        result = either_db.import_jsonl(payload, mode="replace")
+        assert result["imported"] == 1
+        assert [r["id"] for r in either_db.list_memories()] == ["only-one"]
+
+    def test_import_rejects_oversized_and_malformed_rows(self, either_db):
+        payload = "\n".join(
+            [
+                json.dumps({"id": "ok", "content": "fine"}),
+                json.dumps({"id": "big", "content": "x" * 5001}),
+                "{not json",
+            ]
+        )
+        assert either_db.import_jsonl(payload) == {
+            "imported": 1,
+            "skipped": 0,
+            "rejected": 2,
+        }
+
+    def test_import_chunks_beyond_one_statement(self, either_db):
+        """More rows than fit in a single D1 statement must all land."""
+        payload = "\n".join(
+            json.dumps({"id": f"bulk{i}", "content": f"bulk memory {i}"})
+            for i in range(45)
+        )
+        assert either_db.import_jsonl(payload)["imported"] == 45
+        assert either_db.stats()["total_memories"] == 45
+
+    def test_archive_leaves_fresh_rows_alone(self, either_db):
+        _seed(either_db)
+        assert either_db.archive_old_memories(days=90) == 0
+        assert len(either_db.list_memories()) == 3
+
+    def test_archive_old_memories_by_age(self, either_db):
+        _seed_aged(either_db)
+        assert either_db.archive_old_memories(days=90) == 1
+        assert {r["id"] for r in either_db.list_memories()} == {"aged-important"}
+
+    def test_archive_respects_importance_threshold(self, either_db):
+        _seed_aged(either_db)
+        assert either_db.archive_old_memories(days=90, importance_threshold=0.95) == 2
+
+    def test_archive_by_score_weights_importance(self, either_db):
+        """score = (days_old / archive_after_days) * (1 - importance).
+
+        Both rows are the same age, so only importance separates them: at
+        recency_factor 1.0 the low-importance row scores 0.9 and the
+        high-importance one 0.1.
+        """
+        _seed_aged(either_db)
+        assert (
+            either_db.archive_by_score(
+                archive_after_days=_AGE_DAYS, score_threshold=0.5
+            )
+            == 1
+        )
+        assert {r["id"] for r in either_db.list_memories()} == {"aged-important"}
+
+    def test_archived_rows_drop_out_of_search_and_list(self, either_db):
+        _seed_aged(either_db)
+        either_db.archive_old_memories(days=90, importance_threshold=1.0)
+        assert either_db.list_memories() == []
+        assert either_db.search("kangaroo") == []
+        assert len(either_db.list_memories(include_archived=True)) == 2
+
+    def test_list_archived_and_restore(self, either_db):
+        _seed_aged(either_db)
+        either_db.archive_old_memories(days=90, importance_threshold=1.0)
+        archived = either_db.list_archived()
+        assert {a["id"] for a in archived} == {"aged-forgettable", "aged-important"}
+        # list_archived parses the JSON tags column into a real list.
+        assert all(isinstance(a["tags"], list) for a in archived)
+        assert either_db.restore_memory("aged-important") is True
+        assert [r["id"] for r in either_db.list_memories()] == ["aged-important"]
+
+    def test_restore_of_active_row_is_false(self, either_db):
+        ids = _seed(either_db)
+        assert either_db.restore_memory(ids["python"]) is False
+
+    def test_update_importance_clamps_and_reports(self, either_db):
+        ids = _seed(either_db)
+        assert either_db.update_importance(ids["python"], 5.0) is True
+        assert either_db.get(ids["python"])["importance"] == pytest.approx(1.0)
+        assert either_db.update_importance("missing", 0.5) is False
+
+    def test_check_duplicate_detects_repeat(self, either_db):
+        either_db.add("Python is a programming language", category="tech")
+        hit = either_db.check_duplicate("Python is a programming language")
+        assert hit and hit["duplicate"] is True
+
+    def test_check_duplicate_returns_none_for_novel_text(self, either_db):
+        _seed(either_db)
+        assert either_db.check_duplicate("entirely unrelated kangaroo content") is None
+
+    def test_add_with_context_type(self, either_db):
+        mid = either_db.add_with_context_type(
+            "prefers dark mode", context_type="preference", importance=0.8
+        )
+        row = either_db.get(mid)
+        assert row["context_type"] == "preference"
+        assert row["importance"] == pytest.approx(0.8)
+
+    def test_rrf_fuse_agrees(self, either_db):
+        fused = either_db.rrf_fuse(["a", "b"], ["b", "c"])
+        assert fused[0][0] == "b"
+
+    def test_vec_enabled_is_false_without_embeddings(self, either_db):
+        assert either_db.vec_enabled is False
+
+    def test_public_surface_matches_memorydb(self, either_db):
+        """No method may be missing from either backend."""
+        expected = {
+            name
+            for name in vars(MemoryDB)
+            if not name.startswith("_") and not name.startswith("run_")
+        }
+        assert expected <= {n for n in dir(either_db) if not n.startswith("_")}
+
+
+class TestVectorPathIsLoud:
+    """Task 3 has no vector path. It must say so, never return an empty list."""
+
+    def test_add_with_embedding_raises(self, cf_db):
+        with pytest.raises(NotImplementedError, match="Task 4"):
+            cf_db.add("with a vector", embedding=[0.1] * 768)
+
+    def test_add_with_context_type_with_embedding_raises(self, cf_db):
+        with pytest.raises(NotImplementedError, match="Task 4"):
+            cf_db.add_with_context_type("with a vector", embedding=[0.1] * 768)
+
+    def test_search_with_embedding_raises(self, cf_db):
+        _seed(cf_db)
+        with pytest.raises(NotImplementedError, match="Task 4"):
+            cf_db.search("anything", embedding=[0.1] * 768)
+
+    def test_update_with_embedding_raises(self, cf_db):
+        ids = _seed(cf_db)
+        with pytest.raises(NotImplementedError, match="Task 4"):
+            cf_db.update(ids["python"], embedding=[0.1] * 768)
+
+    def test_search_without_embedding_still_works(self, cf_db):
+        """Rejecting vectors must not break the FTS-only path."""
+        _seed(cf_db)
+        assert cf_db.search("Python")
+
+    def test_reindex_on_model_change_raises_instead_of_pretending(self, fake_worker):
+        db = _cf_db(fake_worker, embedding_dims=768, embedding_model="model-a")
+        db.close()
+        with pytest.raises(NotImplementedError, match="Task 4"):
+            _cf_db(
+                fake_worker,
+                embedding_dims=768,
+                embedding_model="model-b",
+                reindex_on_model_change=True,
+            )
+
+
+class TestUnavailableSurface:
+    """Methods this backend cannot serve raise and say what is missing."""
+
+    def test_get_sync_state_raises(self, cf_db):
+        with pytest.raises(NotImplementedError, match="sync_state"):
+            cf_db.get_sync_state("gdrive")
+
+    def test_upsert_sync_state_raises(self, cf_db):
+        with pytest.raises(NotImplementedError, match="sync_state"):
+            cf_db.upsert_sync_state("gdrive", last_sync_at=1.0)
+
+    def test_sync_state_is_genuinely_absent_from_the_d1_schema(self, d1_conn):
+        """The NotImplementedError above states a fact; check the fact."""
+        names = {
+            r[0] for r in d1_conn.execute("SELECT name FROM sqlite_master").fetchall()
+        }
+        assert "sync_state" not in names
+        assert "memories" in names
+
+    def test_rollback_is_not_silently_a_noop(self, cf_db):
+        with pytest.raises(NotImplementedError, match="ROLLBACK"):
+            cf_db._conn.rollback()
+
+    def test_schema_creation_is_wranglers_job(self, cf_db):
+        with pytest.raises(NotImplementedError, match="wrangler"):
+            cf_db._conn.executescript("CREATE TABLE t (x)")
+
+
+class TestFailLoud:
+    """Nothing here may report success, emptiness, or zero for a failure."""
+
+    def test_missing_schema_fails_at_open(self, tmp_path):
+        blank = sqlite3.connect(tmp_path / "blank.sqlite", isolation_level=None)
+        with pytest.raises(RuntimeError, match="migrations apply"):
+            _cf_db(FakeD1Worker(blank))
+
+    def test_transport_failure_during_search_raises(self, cf_db, fake_worker):
+        """A dead D1 must not look like "no matches".
+
+        ``MemoryDB._search_fts`` catches per-tier exceptions and logs them; on
+        this backend that would turn an outage into an empty result set.
+        """
+        _seed(cf_db)
+
+        def dead(method, url, data=None, headers=None):
+            return (500, b"internal error")
+
+        fake_worker.request = dead
+        with pytest.raises(RuntimeError, match="must not be treated as 'no matches'"):
+            cf_db.search("Python")
+
+    def test_transport_failure_during_add_raises(self, cf_db, fake_worker):
+        def dead(method, url, data=None, headers=None):
+            return (500, b"internal error")
+
+        fake_worker.request = dead
+        with pytest.raises(RuntimeError):
+            cf_db.add("this write cannot land")
+
+    def test_failed_successor_insert_reopens_the_predecessor(self, cf_db, fake_worker):
+        """A half-applied supersession must not leave a row closed forever."""
+        ids = _seed(cf_db)
+        real_request = fake_worker.request
+
+        def fail_the_insert(method, url, data=None, headers=None):
+            payload = json.loads(data.decode())
+            if payload["sql"].startswith("INSERT INTO memories"):
+                return (500, b"insert exploded")
+            return real_request(method, url, data, headers)
+
+        fake_worker.request = fail_the_insert
+        with pytest.raises(RuntimeError):
+            cf_db.update(ids["python"], content="never lands")
+
+        fake_worker.request = real_request
+        row = cf_db.get(ids["python"])
+        assert row is not None, "predecessor was left closed with no successor"
+        assert row["content"] == "Python is a programming language"
+
+    def test_use_after_close_raises(self, cf_db):
+        cf_db.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            cf_db.list_memories()
+
+    def test_embedding_identity_mismatch_raises(self, fake_worker):
+        db = _cf_db(fake_worker, embedding_dims=768, embedding_model="model-a")
+        db.close()
+        with pytest.raises(EmbeddingModelMismatch):
+            _cf_db(fake_worker, embedding_dims=768, embedding_model="model-b")
+
+    def test_embedding_identity_is_stamped_on_a_fresh_store(self, fake_worker):
+        db = _cf_db(fake_worker, embedding_dims=768, embedding_model="model-a")
+        assert db.get_store_meta("embedding_dims") == "768"
+        assert db.get_store_meta("embedding_model") == "model-a"
+
+    def test_rejects_non_integer_dims(self, fake_worker):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _cf_db(fake_worker, embedding_dims=768.0)
+
+
+class TestBackendSelection:
+    """``MEMORY_DB_BACKEND`` is read in exactly one place."""
+
+    def test_defaults_to_sqlite(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MEMORY_DB_BACKEND", raising=False)
+        db = open_memory_db(tmp_path / "memories.db")
+        try:
+            assert isinstance(db, MemoryDB)
+        finally:
+            db.close()
+
+    def test_explicit_sqlite(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MEMORY_DB_BACKEND", "sqlite")
+        db = open_memory_db(tmp_path / "memories.db")
+        try:
+            assert isinstance(db, MemoryDB)
+        finally:
+            db.close()
+
+    def test_cf_d1_selects_the_d1_backend(self, tmp_path, monkeypatch, fake_worker):
+        monkeypatch.setenv("MEMORY_DB_BACKEND", "cf-d1")
+        monkeypatch.setattr(
+            "mnemo_mcp.db_cf.d1_backend_from_env",
+            lambda: __import__("mcp_core.storage.d1", fromlist=["D1Backend"]).D1Backend(
+                base_url="http://d1.internal", http=fake_worker
+            ),
+        )
+        db = open_memory_db(tmp_path / "memories.db")
+        try:
+            assert isinstance(db, MemoryDBCfBackend)
+        finally:
+            db.close()
+
+    def test_unknown_backend_raises_rather_than_falling_back(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("MEMORY_DB_BACKEND", "cf-dl")
+        with pytest.raises(ValueError, match="Unknown MEMORY_DB_BACKEND"):
+            open_memory_db(tmp_path / "memories.db")
+
+    def test_selection_kwargs_reach_the_sqlite_backend(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MEMORY_DB_BACKEND", raising=False)
+        db = open_memory_db(tmp_path / "memories.db", recency_half_life_days=3.0)
+        try:
+            assert db._recency_half_life == 3.0
+        finally:
+            db.close()
+
+
+def test_docs_db_backend_is_gone_from_the_repo():
+    """The old name is dead config; nothing may reintroduce it.
+
+    It was copied in from the wet-mcp Worker template and no Python in this repo
+    (nor in mcp-core) ever read it, so it was renamed rather than aliased.
+    """
+    tracked = [
+        _REPO_ROOT / "src" / "worker.ts",
+        _REPO_ROOT / "wrangler.jsonc",
+        _REPO_ROOT / "wrangler.deploy.jsonc",
+        _REPO_ROOT / "wrangler.deploy.template.jsonc",
+        _REPO_ROOT / "README.md",
+    ]
+    for path in tracked:
+        body = path.read_text(encoding="utf-8")
+        assert "DOCS_DB_BACKEND" not in body, f"{path.name} still names DOCS_DB_BACKEND"
+        assert "MEMORY_DB_BACKEND" in body, f"{path.name} lost MEMORY_DB_BACKEND"

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -25,7 +25,10 @@ def mock_settings():
 
 @pytest.fixture
 def mock_db():
-    with patch("mnemo_mcp.server.MemoryDB") as m:
+    # lifespan builds the store through open_memory_db, which picks SQLite or
+    # Cloudflare D1 from MEMORY_DB_BACKEND; that factory is the construction
+    # site to intercept.
+    with patch("mnemo_mcp.server.open_memory_db") as m:
         db_instance = MagicMock()
         db_instance.stats.return_value = {"total_memories": 10, "vec_enabled": True}
         db_instance.vec_enabled = True

--- a/wrangler.deploy.jsonc
+++ b/wrangler.deploy.jsonc
@@ -27,7 +27,7 @@
     "PUBLIC_URL": "https://mnemo.n24q02m.com",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
-    "DOCS_DB_BACKEND": "cf-d1",
+    "MEMORY_DB_BACKEND": "cf-d1",
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "mnemo-memory-vectors",

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -30,7 +30,7 @@
     "PUBLIC_URL": "${PUBLIC_URL}",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
-    "DOCS_DB_BACKEND": "cf-d1",
+    "MEMORY_DB_BACKEND": "cf-d1",
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "${CF_VECTORIZE_ID}",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,7 +39,7 @@
     "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
-    "DOCS_DB_BACKEND": "cf-d1",
+    "MEMORY_DB_BACKEND": "cf-d1",
     "MCP_D1_BASE_URL": "http://d1.internal",
     "MCP_VECTORIZE_BASE_URL": "http://vectorize.internal",
     "MCP_VECTORIZE_IDX": "mnemo-memory-vectors",


### PR DESCRIPTION
S2 Task 3. Adds `src/mnemo_mcp/db_cf.py` with `MemoryDBCfBackend`, a Cloudflare
D1 implementation of the `MemoryDB` surface, and selects between the two in one
place via `MEMORY_DB_BACKEND`. Default is unchanged (SQLite).

## What is in scope

**D1 + FTS5 only.** Vector search on D1 is Vectorize, which is Task 4:
`migrations/0001_init.sql` deliberately has no `memories_vec` because D1 cannot
load the `sqlite-vec` extension. So `vec_enabled` is `False` and `search` runs
FTS-only.

Nothing degrades quietly. Every path that cannot do its job raises and says what
is missing:

| Method | Raises | Why |
|---|---|---|
| `add`, `add_with_context_type`, `search`, `update` | `NotImplementedError`, only when an `embedding` argument is passed | `MemoryDB` guards its vector writes with `if embedding and self._vec_enabled`. Borrowed as-is with `_vec_enabled=False`, they would accept a vector, store nothing, and return a memory id. Without the embedding argument these all work normally. |
| `get_sync_state`, `upsert_sync_state` | `NotImplementedError`, always | `sync_state` is not in `migrations/0001_init.sql` (`tests/test_d1_migrations.py` already records it as a conscious omission). There is no cursor table to read. A follow-up migration has to add it before the sync pipeline can run on cf-d1. |
| `_drop_vectors_for_reindex` (reached from the embedding-identity guard when `REINDEX_ON_MODEL_CHANGE` is set) | `NotImplementedError` | There are no stored vectors here to drop; that is the Vectorize path. A mismatch without the flag still raises `EmbeddingModelMismatch`, same as SQLite. |
| `_D1Connection.rollback` | `NotImplementedError` | The `/query` wire has no ROLLBACK. A no-op rollback would let code believe it undid a write it could not undo. |

Every other method of the 22 is implemented.

## Substitutability is tested, not asserted

`TestBackendParity` is parameterised over both backends: each of ~35 scenarios
runs once on a real `MemoryDB` (temp SQLite file) and once on
`MemoryDBCfBackend`, and the results are compared. That includes one test that
compares the actual relevance scores the two produce for the same corpus.

The D1 side runs against `FakeD1Worker`, a transcription of `src/worker.ts`'s
`d1Outbound` handler injected as `D1Backend`'s transport, backed by a real
SQLite database with `migrations/0001_init.sql` applied. What that reproduces:
the SQL text and bound params actually sent, the JSON envelope, rows as JSON
objects, one statement per request with no client transaction, the real D1
schema including the FTS5 external-content triggers, and no `sqlite-vec`. What
it does not: the network hop, D1's exact SQLite build, and concurrency. Driving
a real local D1 through `wrangler` would add the hop at the cost of a
node subprocess per query, which cannot live in the default pytest run.

Two tests defend the double itself: `test_fake_worker_matches_worker_ts` pins the
transcription against the real `src/worker.ts` (a new route there breaks the
test), and `test_only_query_route_is_used` asserts the backend never reaches a
route the Worker does not serve.

## Notable implementation choices

**Behaviour is borrowed, not retyped.** The scoring pipeline and the read-only
SQL come from `MemoryDB` by class-level assignment, through a `_conn` adapter
implementing the small sqlite3 slice those methods use. Retyping ~400 lines of
SQL here would let the backends drift apart silently, which is what a parity
test cannot catch after the fact. Methods needing `cursor.rowcount` or a real
rollback are written out explicitly and use `RETURNING` for their counts.
`db.py` itself is untouched.

**Swallowed transport errors are re-raised.** `MemoryDB._search_fts` wraps each
FTS tier in `except Exception: logger.error(...)`. Harmless on local SQLite; on
D1 it would turn an outage into an empty result set. The override re-raises
anything the borrowed body absorbed.

**`update` cannot be atomic here** and does not pretend to be. D1 commits each
query on its own and the `/query` wire has no BEGIN/COMMIT. The guarded
`UPDATE ... WHERE valid_to IS NULL RETURNING *` runs first, so a competing writer
still loses the race exactly as on SQLite; if the successor INSERT then fails,
the predecessor is reopened by a compensating write and the error is re-raised
(`test_failed_successor_insert_reopens_the_predecessor`). If the compensation
also fails, the row id is logged at ERROR rather than reported as success.

**Only `POST /query` is used.** `d1Outbound` routes `/query` and 404s everything
else, so `D1Backend.executemany`'s fallback (which POSTs `/batch`) would 404
against this Worker. Bulk import builds its own multi-row INSERT instead,
chunked to stay under D1's cap of
[100 bound parameters per query](https://developers.cloudflare.com/d1/platform/limits/) --
a cap `executemany` does not model, since it chunks by rows (100) rather than
params, so a 10-column INSERT would send 1000.

## `DOCS_DB_BACKEND` -> `MEMORY_DB_BACKEND`

Renamed at all 7 sites (`src/worker.ts` x3, three `wrangler*.jsonc`, `README.md`)
with no compatibility shim, because there is no contract to keep: the variable
arrived from the wet-mcp Worker template and nothing in this repo or in mcp-core
ever read it. Verified on `origin/main` before the rename and against the
installed `mcp_core` 1.21.0 (its only occurrence is a comment in
`storage/vectorize.py`). This PR is what first gives the variable a consumer.
`test_docs_db_backend_is_gone_from_the_repo` keeps the old name from coming back.

`tests/test_lifespan.py` moves its patch from `mnemo_mcp.server.MemoryDB` to
`mnemo_mcp.server.open_memory_db`, since that is now the construction site.

## Verification

- `uv run pytest tests/test_db_cf.py` -- 106 passed
- `uv run pytest` -- 1525 passed, 5 skipped, 78 deselected
- `bun run test:worker` -- 14 passed
- `ruff check` / `ruff format --check` / `ty check` -- clean
- `git grep -n DOCS_DB_BACKEND` -- no matches (exit 1); control `git grep -n MEMORY_DB_BACKEND` returns 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
