### PR TITLE
fix: test CONTAINER_ENV_KEYS covers every wrangler vars key

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -55,10 +55,20 @@ export interface Env {
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the container
 // process. Unset/empty values are dropped so an unused optional secret never
-// injects a blank. MCP_RELAY_PASSWORD MUST stay here: the container's OAuth-AS
-// browser form (Gate A) is gated by it -- dropping it would open the relay form
-// to anyone. CREDENTIAL_SECRET + MCP_DCR_SERVER_SECRET enable per-sub multi-user.
-const CONTAINER_ENV_KEYS = [
+// injects a blank. Every key declared in any wrangler*.jsonc `vars` block MUST
+// be listed here too -- otherwise its value is silently dropped and the
+// container falls back to a default with no error. tests/worker.test.ts asserts
+// this coverage against all three wrangler files (wrangler.jsonc,
+// wrangler.deploy.jsonc, wrangler.deploy.template.jsonc), so it fails loudly
+// instead. The other 10 keys below are NOT declared as `vars` anywhere and are
+// loaded with `wrangler secret put`: RECENCY_HALF_LIFE_DAYS, CREDENTIAL_SECRET,
+// JINA_AI_API_KEY, GEMINI_API_KEY, GOOGLE_VERTEX_EXPRESS_API_KEY,
+// MCP_RELAY_PASSWORD, MCP_DCR_SERVER_SECRET, OPENROUTER_API_BASE,
+// OPENROUTER_API_KEY, JINA_AI_API_BASE. MCP_RELAY_PASSWORD MUST stay here: the
+// container's OAuth-AS browser form (Gate A) is gated by it -- dropping it would
+// open the relay form to anyone. CREDENTIAL_SECRET + MCP_DCR_SERVER_SECRET
+// enable per-sub multi-user.
+export const CONTAINER_ENV_KEYS = [
   'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'MEMORY_DB_BACKEND',
   'MCP_D1_BASE_URL', 'MCP_VECTORIZE_BASE_URL', 'MCP_VECTORIZE_IDX',
   'EMBEDDING_MODELS', 'RERANK_MODELS', 'LLM_MODELS',

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import worker, { OUTBOUND_BY_HOST } from '../src/worker'
+import worker, { CONTAINER_ENV_KEYS, OUTBOUND_BY_HOST } from '../src/worker'
+// tsconfig.json's `types` deliberately lists only `@cloudflare/workers-types`
+// (no `@types/node`) so src/worker.ts type-checks against the workerd runtime,
+// not Node globals -- adding `@types/node` would blur that boundary for the
+// whole program (TS ambient types are program-wide, not file-scoped). This
+// file runs under plain Node via vitest and only needs one function from it.
+// @ts-expect-error -- no `@types/node`; see comment above
+import { readFileSync } from 'node:fs'
 
 function fakeEnv() {
   const kv = new Map<string, string>()
@@ -202,5 +209,89 @@ describe('standing GET /mcp SSE stream declined at the edge (idle-cost fix)', ()
     const res = await worker.fetch(new Request('https://mnemo.n24q02m.com/mcp', { method: 'GET' }), env as never)
     expect(res.status).toBe(401)
     expect(fetchCalls.length).toBe(0)
+  })
+})
+
+// Minimal JSONC -> JSON: strips `//` line comments and `/* */` block comments
+// while respecting string literals, so values like "http://kv.internal" survive
+// intact. wrangler*.jsonc files are read for real here (not hardcoded) so this
+// test actually catches drift instead of restating CONTAINER_ENV_KEYS.
+function stripJsonComments(src: string): string {
+  let out = ''
+  let inString = false
+  let inLineComment = false
+  let inBlockComment = false
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i]
+    const next = src[i + 1]
+    if (inLineComment) {
+      if (c === '\n') {
+        inLineComment = false
+        out += c
+      }
+      continue
+    }
+    if (inBlockComment) {
+      if (c === '*' && next === '/') {
+        inBlockComment = false
+        i++
+      }
+      continue
+    }
+    if (inString) {
+      out += c
+      if (c === '\\') {
+        out += next
+        i++
+        continue
+      }
+      if (c === '"') inString = false
+      continue
+    }
+    if (c === '"') {
+      inString = true
+      out += c
+      continue
+    }
+    if (c === '/' && next === '/') {
+      inLineComment = true
+      i++
+      continue
+    }
+    if (c === '/' && next === '*') {
+      inBlockComment = true
+      i++
+      continue
+    }
+    out += c
+  }
+  return out
+}
+
+// Path is relative to the repo root, which is the cwd `vitest` runs from
+// (package.json's `test:worker` script and the CI step both invoke it from
+// the repo root, never from `tests/`).
+function readWranglerVarKeys(repoRootRelPath: string): string[] {
+  const parsed = JSON.parse(stripJsonComments(readFileSync(repoRootRelPath, 'utf8'))) as { vars?: Record<string, unknown> }
+  return Object.keys(parsed.vars ?? {})
+}
+
+// A key declared in wrangler `vars` but missing from CONTAINER_ENV_KEYS is
+// silently dropped by pickContainerEnv -- the container just runs with whatever
+// default core-py falls back to, with no error anywhere. This reads all three
+// wrangler*.jsonc files for real (never hardcodes their `vars`) so it actually
+// fails when someone adds a wrangler var without wiring it into the Worker.
+describe('CONTAINER_ENV_KEYS covers every wrangler `vars` key', () => {
+  const wranglerFiles = ['wrangler.jsonc', 'wrangler.deploy.jsonc', 'wrangler.deploy.template.jsonc']
+
+  it('every `vars` key in each wrangler*.jsonc is forwarded by CONTAINER_ENV_KEYS', () => {
+    const forwarded = new Set<string>(CONTAINER_ENV_KEYS)
+    const missing: string[] = []
+    for (const file of wranglerFiles) {
+      for (const key of readWranglerVarKeys(file)) {
+        if (!forwarded.has(key)) missing.push(`${file}: ${key}`)
+      }
+    }
+    expect(missing).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Add a test in `tests/worker.test.ts` that reads `wrangler.jsonc`, `wrangler.deploy.jsonc`, and `wrangler.deploy.template.jsonc` for real (never hardcodes their `vars`) and asserts every declared `vars` key is present in `CONTAINER_ENV_KEYS` in `src/worker.ts`. A `vars` key missing from that list is silently dropped by `pickContainerEnv`, so the container just runs with whatever default falls back, with no error anywhere.
- Fix the stale comment above `CONTAINER_ENV_KEYS`: it undercounted the keys that aren't declared as `vars` and must be loaded via `wrangler secret put` (there are 10, not the smaller number it implied). Recount method: `CONTAINER_ENV_KEYS` minus the union of `vars` across all three wrangler files.
- Exported `CONTAINER_ENV_KEYS` from `src/worker.ts` so the test imports the real array instead of duplicating it.

No env keys were added, removed, or changed in value -- comment- and test-only.

## Test plan
- [x] `bun run test:worker` -- all 15 tests pass (14 existing + 1 new)
- [x] `bunx tsc --noEmit -p tsconfig.json` -- clean (baseline was clean too; kept it that way with a scoped `@ts-expect-error` for the one Node-only import, rather than adding `@types/node` project-wide, which would blur the workerd-only typing of `src/worker.ts`)
- [x] Verified the new test actually catches the bug it targets: temporarily removed a `vars`-declared key from `CONTAINER_ENV_KEYS` (twice, with two different keys) -> test went RED with a clear message; restored -> GREEN again.

## Out of scope (flagging, not fixing)
- `wrangler.jsonc` has its own separate stale comment ("Secrets via `wrangler secret put`: ...") listing only 5 of the 10 non-`vars` keys. Same root issue, different file/comment than the one this task scoped in (`src/worker.ts` near `CONTAINER_ENV_KEYS`). Left untouched per scope; happy to fix in a follow-up if wanted.
- `wrangler.deploy.jsonc` is committed to git with what look like real Cloudflare resource IDs (KV namespace id, D1 database id) despite its own header comment claiming it's "GITIGNORED". Did not touch -- unrelated to this task and touching it would be a security-relevant scope expansion that should get its own review.