### PR TITLE
feat: wire Cloudflare Vectorize into the D1 memory backend

### DIFF
--- a/src/mnemo_mcp/db_cf.py
+++ b/src/mnemo_mcp/db_cf.py
@@ -1,4 +1,4 @@
-"""Cloudflare D1 backend for the Mnemo memory store (S2 Task 3).
+"""Cloudflare D1 + Vectorize backend for the Mnemo memory store (S2 Tasks 3-4).
 
 ``MemoryDBCfBackend`` presents the same surface as :class:`mnemo_mcp.db.MemoryDB`
 but reads and writes a Cloudflare D1 database over the Worker outbound handler
@@ -6,12 +6,59 @@ but reads and writes a Cloudflare D1 database over the Worker outbound handler
 happens in exactly one place -- :func:`open_memory_db`, driven by the
 ``MEMORY_DB_BACKEND`` env var -- and the default stays SQLite.
 
-Scope of this task: **D1 + FTS5 only.** Vector search on D1 is served by
-Cloudflare Vectorize (``migrations/0001_init.sql`` deliberately has no
-``memories_vec``: D1 cannot load the ``sqlite-vec`` extension), and that wiring
-is Task 4. Until then every vector-carrying entry point raises
-:class:`NotImplementedError` naming what is missing. Nothing on this backend
-returns an empty list, a zero count, or a success flag for work it did not do.
+Storage split: rows and the FTS5 index live in D1; dense vectors live in a
+Cloudflare Vectorize index reached through ``src/worker.ts``'s
+``vectorizeOutbound``. ``migrations/0001_init.sql`` deliberately has no
+``memories_vec`` -- D1 cannot load the ``sqlite-vec`` extension -- so there is no
+in-database vector table to fall back on. When the store is opened with
+``embedding_dims=0`` no Vectorize index is attached, ``vec_enabled`` is ``False``,
+and an entry point handed an embedding raises rather than dropping it.
+
+Vector design notes
+-------------------
+
+*The 50-candidate ceiling is announced, not absorbed.* Cloudflare Vectorize caps
+``topK`` at 50, and ``mcp_core.storage.vectorize.VectorizeBackend.query`` applies
+that cap with a bare ``top_k = min(top_k, 50)`` -- no exception, no warning, no
+signal of any kind. ``MemoryDB.search`` asks for ``max(limit * 10, 50)``
+candidates, so every search with ``limit > 5`` would quietly fuse a full-width
+FTS ranking against a 50-deep vector ranking and call the result "top N".
+:meth:`MemoryDBCfBackend._vector_candidates` therefore compares the two numbers
+itself, logs a WARNING naming both, and records the shortfall on
+:attr:`MemoryDBCfBackend.last_vector_cap` so a caller can see it without reading
+logs. The cap is not raised anywhere -- it cannot be -- but it is never silent.
+
+*Read-after-write on the vector arm is eventually consistent, and says so.* D1 is
+strongly consistent, so a row is FTS-searchable the instant ``add`` returns.
+Vectorize is not: an upsert becomes queryable seconds later. The obvious
+mitigation, ``VectorizeBackend.wait_until_indexed()``, does NOT work here and is
+deliberately not called: it polls ``GET {base}``, and ``vectorizeOutbound`` answers
+*every* GET with ``{ready: true}`` unconditionally (``src/worker.ts``). It reports
+that the outbound handler is wired, never that a particular mutation landed, so
+calling it after an upsert would manufacture exactly the false "indexed" signal
+this repo has already paid for once. A per-mutation wait needs a Worker route
+that does not exist yet. Until then the behaviour is: a just-added memory is
+immediately findable by text and joins the semantic ranking once Vectorize
+indexes it. That is written down here, asserted in
+``tests/test_db_cf_vectors.py``, and never papered over with a retry loop.
+
+*Superseded rows cannot resurface, by construction.* ``delete`` only sets
+``valid_to`` and ``update`` opens a new id while closing the old one, neither of
+which Vectorize knows about. Two independent mechanisms cover it. Write side:
+both methods delete the closed id's vector via ``POST /deleteByIds``. Read side --
+the authoritative one -- every id Vectorize returns is re-fetched from D1 through
+the same ``_build_filter_sql`` tail the FTS arm uses, whose first fragment is
+``AND m.valid_to IS NULL``; an id that does not survive that query is dropped
+from the fusion. The read-side filter holds even if a write-side delete failed or
+has not propagated, which is why it is the one the correctness claim rests on.
+
+*Vector loss is loud, and only where it is unavoidable.* A metadata-only
+``update`` (no new content, so no new embedding) carries the old vector forward on
+SQLite. That is impossible here: Vectorize has no read-by-id, ``VectorizeBackend``
+exposes no getter, and ``vectorizeOutbound`` routes no such path, so the vector
+cannot be copied to the successor id. The successor is left unvectorised and a
+WARNING names the id and the reason, rather than leaving a caller to discover the
+gap through degraded recall.
 
 Design notes
 ------------
@@ -54,16 +101,47 @@ import json
 import os
 import uuid
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from loguru import logger
 from mcp_core.storage.d1 import D1Backend, d1_backend_from_env
+from mcp_core.storage.vectorize import VectorizeBackend, vectorize_backend_from_env
 
-from mnemo_mcp.db import MAX_CONTENT_LENGTH, MemoryDB, _now_iso
+from mnemo_mcp.db import MAX_CONTENT_LENGTH, MAX_TAGS_FILTER, MemoryDB, _now_iso
 
 # Cloudflare D1 rejects a query carrying more than this many bound parameters.
 # https://developers.cloudflare.com/d1/platform/limits/
 D1_MAX_BOUND_PARAMS = 100
+
+# Cloudflare Vectorize refuses to return more than this many matches from one
+# query. `VectorizeBackend.query` already clamps to it -- with a bare
+# `top_k = min(top_k, 50)` that raises nothing and logs nothing -- so the number
+# is restated here to be compared against the requested pool before the call.
+# https://developers.cloudflare.com/vectorize/platform/limits/
+VECTORIZE_MAX_TOP_K = 50
+
+# Ids per `POST /deleteByIds` request. A client-side bound to keep a reindex of a
+# large store from building one enormous request body; Cloudflare documents no
+# hard id count for this endpoint, so this mirrors no platform cap and can be
+# raised freely.
+VECTORIZE_DELETE_CHUNK = 500
+
+
+class VectorCandidateCap(NamedTuple):
+    """How much of a requested vector candidate pool Vectorize actually served.
+
+    Recorded on :attr:`MemoryDBCfBackend.last_vector_cap` after every search that
+    ran the vector arm, so "the fused list is top-N over a truncated vector
+    ranking" is observable in-process and not only in the log stream.
+    """
+
+    requested: int
+    served: int
+
+    @property
+    def truncated(self) -> bool:
+        return self.served < self.requested
+
 
 # Tables `MemoryDBCfBackend` reads or writes. wrangler owns schema creation via
 # `migrations/0001_init.sql`; this backend only asserts the migration ran.
@@ -91,11 +169,12 @@ _IMPORT_COLUMNS = (
 )
 _IMPORT_ROWS_PER_STATEMENT = D1_MAX_BOUND_PARAMS // len(_IMPORT_COLUMNS)
 
-_VECTOR_TASK = (
-    "Vector search on the D1 backend is served by Cloudflare Vectorize, which "
-    "is wired up in S2 Task 4. This backend (Task 3) is D1 + FTS5 only: "
-    "migrations/0001_init.sql has no memories_vec table because D1 cannot load "
-    "the sqlite-vec extension."
+_NO_VECTOR_INDEX = (
+    "This store was opened with embedding_dims=0, so no Cloudflare Vectorize "
+    "index is attached and there is nowhere for the vector to go. D1 itself "
+    "cannot hold it: migrations/0001_init.sql has no memories_vec table because "
+    "D1 cannot load the sqlite-vec extension. Open the store with the embedding "
+    "dimension of the active model (and MCP_VECTORIZE_IDX set) to enable vectors."
 )
 
 
@@ -200,26 +279,81 @@ class _D1Connection:
         ) from exc
 
 
-def _reject_embedding(method):
-    """Wrap ``method`` so passing an ``embedding`` raises instead of dropping it.
+def _vectorize_from_env() -> VectorizeBackend:
+    """Build the Vectorize client, turning a missing index name into an answer.
 
-    ``MemoryDB.add`` / ``add_with_context_type`` guard their vector INSERT with
-    ``if embedding and self._vec_enabled``, and ``MemoryDB.search`` guards its
-    vector branch the same way. Borrowed as-is with ``_vec_enabled=False`` they
-    would accept a vector, write nothing, and report success -- so the caller is
-    told, loudly, that the vector went nowhere.
+    ``vectorize_backend_from_env`` reads ``MCP_VECTORIZE_IDX`` with ``[]`` and so
+    fails with a bare ``KeyError('MCP_VECTORIZE_IDX')`` several frames from
+    anything that explains it.
+    """
+    try:
+        return vectorize_backend_from_env()
+    except KeyError as exc:
+        raise RuntimeError(
+            "MCP_VECTORIZE_IDX is not set, so the D1 backend has no Cloudflare "
+            "Vectorize index to store or query embeddings in. Set it (and "
+            "MCP_VECTORIZE_BASE_URL if the Worker is not at the default "
+            "http://vectorize.internal), or open the store with EMBEDDING_DIMS=0 "
+            "to declare it text-only. Starting without either would leave "
+            "semantic search missing with nothing to say so."
+        ) from exc
+
+
+def _vectorize_delete_by_ids(vectors: VectorizeBackend, ids: list[str]) -> None:
+    """``POST {base}/deleteByIds`` -- the route ``VectorizeBackend`` omits.
+
+    ``src/worker.ts``'s ``vectorizeOutbound`` serves ``/deleteByIds`` and calls
+    ``env.VECTORIZE.deleteByIds``, but ``mcp_core.storage.vectorize`` (1.21.0)
+    ships only ``upsert``, ``query`` and ``wait_until_indexed``. This reuses the
+    backend's own transport and auth headers rather than opening a second HTTP
+    client, so the injected ``http=`` seam the tests rely on keeps covering every
+    request the store makes -- including this one.
+    """
+    if not ids:
+        return
+    for i in range(0, len(ids), VECTORIZE_DELETE_CHUNK):
+        chunk = ids[i : i + VECTORIZE_DELETE_CHUNK]
+        body = json.dumps({"ids": chunk}).encode()
+        status, _ = vectors._http.request(
+            "POST", f"{vectors.base_url}/deleteByIds", body, vectors._headers()
+        )
+        if status != 200:
+            raise RuntimeError(
+                f"Vectorize deleteByIds failed: HTTP {status} for {len(chunk)} id(s) "
+                f"starting at {chunk[0]!r}. The vectors are still queryable."
+            )
+
+
+def _vector_write(method):
+    """Wrap an ``add``-shaped ``MemoryDB`` method to write D1 first, then Vectorize.
+
+    The borrowed body would run ``INSERT INTO memories_vec`` against a table this
+    database does not have, so the embedding is withheld from it and sent to
+    Vectorize afterwards, keyed by the id the body just allocated. D1 is written
+    first on purpose: a row with no vector degrades to text-only recall and is
+    repaired by a reindex, whereas a vector whose row was never written is an
+    orphan that nothing points at.
+
+    With no Vectorize index attached, an embedding raises instead of being
+    dropped -- ``if embedding and self._vec_enabled`` in the borrowed body would
+    otherwise accept the vector, store nothing, and report success.
     """
     signature = inspect.signature(method)
 
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         bound = signature.bind(self, *args, **kwargs)
-        if bound.arguments.get("embedding") is not None:
-            raise NotImplementedError(
-                f"MemoryDBCfBackend.{method.__name__}() was given an embedding, "
-                f"which it cannot store or query. {_VECTOR_TASK}"
-            )
-        return method(self, *args, **kwargs)
+        bound.apply_defaults()
+        embedding = bound.arguments.get("embedding")
+        if embedding:
+            self._require_vectors(method.__name__)
+        # Withheld unconditionally: the borrowed body has no reachable vector
+        # target on D1 under any setting.
+        bound.arguments["embedding"] = None
+        memory_id = method(*bound.args, **bound.kwargs)
+        if embedding:
+            self._upsert_vector(memory_id, embedding)
+        return memory_id
 
     return wrapper
 
@@ -248,20 +382,19 @@ class MemoryDBCfBackend:
     export_jsonl = MemoryDB.export_jsonl
     list_archived = MemoryDB.list_archived
     check_duplicate = MemoryDB.check_duplicate
-    _clear_for_import = MemoryDB._clear_for_import
     _parse_import_data = MemoryDB._parse_import_data
     _process_import_batch = MemoryDB._process_import_batch
 
-    # Vector-carrying entry points: same bodies, but a vector argument raises
-    # rather than being silently discarded.
-    add = _reject_embedding(MemoryDB.add)
-    add_with_context_type = _reject_embedding(MemoryDB.add_with_context_type)
-    _search = _reject_embedding(MemoryDB.search)
+    # Vector-carrying write paths: same bodies, but the embedding is routed to
+    # Vectorize instead of to a `memories_vec` table that does not exist here.
+    add = _vector_write(MemoryDB.add)
+    add_with_context_type = _vector_write(MemoryDB.add_with_context_type)
 
     def __init__(
         self,
         backend: D1Backend | None = None,
         *,
+        vectors: VectorizeBackend | None = None,
         embedding_dims: int = 0,
         recency_half_life_days: float = 7.0,
         embedding_model: str = "",
@@ -270,21 +403,29 @@ class MemoryDBCfBackend:
         """Open the D1-backed store.
 
         Args:
-            backend: Wire client. Defaults to
+            backend: D1 wire client. Defaults to
                 :func:`mcp_core.storage.d1.d1_backend_from_env`, which reads
                 ``MCP_D1_BASE_URL`` (default ``http://d1.internal``) and
                 ``MCP_D1_TOKEN``.
-            embedding_dims: Recorded in ``store_meta`` for the identity guard.
-                No vectors are stored by this backend (see :data:`_VECTOR_TASK`).
+            vectors: Vectorize wire client. Defaults to
+                :func:`mcp_core.storage.vectorize.vectorize_backend_from_env`,
+                which reads ``MCP_VECTORIZE_BASE_URL`` (default
+                ``http://vectorize.internal``) and requires ``MCP_VECTORIZE_IDX``.
+                Only consulted when ``embedding_dims > 0``.
+            embedding_dims: Vector width, recorded in ``store_meta`` for the
+                identity guard. ``0`` declares the store text-only: no Vectorize
+                index is attached and an embedding passed anywhere raises.
             recency_half_life_days: Half-life in days for recency decay.
             embedding_model: Active embedding-model identity string.
-            reindex_on_model_change: Accepted for signature parity; a mismatch
-                raises rather than dropping vectors, because dropping them is
-                the Vectorize path.
+            reindex_on_model_change: When set, an embedding-identity mismatch
+                deletes every stored vector and re-stamps, instead of raising.
 
         Raises:
+            ValueError: On an out-of-range ``embedding_dims``, or when
+                ``vectors`` is supplied for a store declared text-only.
             RuntimeError: When the D1 database has not had
-                ``migrations/0001_init.sql`` applied.
+                ``migrations/0001_init.sql`` applied, or when vectors are
+                requested without ``MCP_VECTORIZE_IDX``.
             EmbeddingModelMismatch: Same contract as :class:`MemoryDB`.
         """
         if type(embedding_dims) is not int:
@@ -295,6 +436,12 @@ class MemoryDBCfBackend:
             raise ValueError(
                 f"embedding_dims must be between 0 and 10000, got {embedding_dims}"
             )
+        if vectors is not None and embedding_dims <= 0:
+            raise ValueError(
+                "vectors= was supplied with embedding_dims=0. That combination "
+                "would attach a Vectorize index the store then refuses to write "
+                "to, so it is rejected rather than quietly ignored."
+            )
 
         self._backend = backend if backend is not None else d1_backend_from_env()
         self._conn = _D1Connection(self._backend)
@@ -303,7 +450,16 @@ class MemoryDBCfBackend:
         self._embedding_model = embedding_model
         self._reindex_on_model_change = reindex_on_model_change
         self._recency_half_life = float(recency_half_life_days)
-        self._vec_enabled = False
+
+        if embedding_dims > 0:
+            self._vectors = vectors if vectors is not None else _vectorize_from_env()
+        else:
+            self._vectors = None
+        self._vec_enabled = self._vectors is not None
+
+        #: Width of the last vector candidate pool asked for vs. served. ``None``
+        #: until a search runs the vector arm. See :class:`VectorCandidateCap`.
+        self.last_vector_cap: VectorCandidateCap | None = None
 
         self._require_schema()
         self._guard_embedding_identity()
@@ -334,15 +490,112 @@ class MemoryDBCfBackend:
 
     @property
     def vec_enabled(self) -> bool:
-        """Always ``False`` on this backend."""
-        return False
+        """Whether a Cloudflare Vectorize index is attached to this store."""
+        return self._vectors is not None
+
+    # -- Vectors -----------------------------------------------------------
+
+    def _require_vectors(self, what: str) -> VectorizeBackend:
+        if self._vectors is None:
+            raise NotImplementedError(
+                f"MemoryDBCfBackend.{what}() was given an embedding, which it "
+                f"cannot store or query. {_NO_VECTOR_INDEX}"
+            )
+        return self._vectors
+
+    def _fit_dims(self, embedding: list[float]) -> list[float]:
+        """Truncate or zero-pad to ``embedding_dims``, exactly as SQLite does.
+
+        ``db._serialize_f32`` reshapes every vector to the store's width before
+        writing it, so a caller that hands over a differently-sized vector gets
+        the same result on both backends rather than an error on one of them.
+        """
+        vec = [float(x) for x in embedding]
+        dims = self._embedding_dims
+        if dims > 0:
+            if len(vec) > dims:
+                vec = vec[:dims]
+            elif len(vec) < dims:
+                vec = vec + [0.0] * (dims - len(vec))
+        return vec
+
+    def _upsert_vector(self, memory_id: str, embedding: list[float]) -> None:
+        """Write one vector, keyed by the memory id it belongs to."""
+        vectors = self._require_vectors("_upsert_vector")
+        vectors.upsert([{"id": memory_id, "values": self._fit_dims(embedding)}])
+
+    def _discard_vectors(self, ids: list[str], context: str) -> None:
+        """Delete vectors whose rows are gone, without failing the row change.
+
+        The D1 write that closed those rows has already committed and is the
+        state search reads: ``_vector_candidates`` re-checks every Vectorize hit
+        against ``valid_to IS NULL``, so a vector that outlives its row cannot
+        surface in results. Raising here would report a delete or update that
+        did take effect as failed, and a caller retrying it would then be told
+        the row was already closed. So the row change stands and the orphan is
+        logged at ERROR with its id -- it wastes index space until the next
+        reindex, which is a cleanup job, not a correctness one.
+        """
+        if self._vectors is None or not ids:
+            return
+        try:
+            _vectorize_delete_by_ids(self._vectors, ids)
+        except Exception as exc:
+            logger.error(
+                "[AUDIT] {} closed row(s) {} in D1 but could not delete their "
+                "vectors ({}). The rows are gone from search either way -- every "
+                "Vectorize hit is re-checked against D1 -- but the vectors are "
+                "orphaned in the index until the next reindex.",
+                context,
+                ", ".join(ids),
+                exc,
+            )
 
     def _drop_vectors_for_reindex(self) -> None:
-        """Reached from the borrowed embedding-identity guard on a mismatch."""
-        raise NotImplementedError(
-            "REINDEX_ON_MODEL_CHANGE cannot be honoured by MemoryDBCfBackend: "
-            f"there are no stored vectors here to drop. {_VECTOR_TASK}"
+        """Delete every stored vector so the embed pipeline rebuilds them.
+
+        Reached from the borrowed identity guard when the embedding model or
+        width changed and ``REINDEX_ON_MODEL_CHANGE`` is set. Vectorize has no
+        "delete everything" call, so the ids are read out of D1 -- the store's
+        own list of what it ever embedded -- and deleted in batches.
+
+        Failure propagates, unlike :meth:`_discard_vectors`. The guard calls this
+        *before* ``_stamp_embedding_identity``, so raising leaves the old stamp in
+        place and the next boot retries; swallowing the error would re-stamp the
+        new model over an index still holding the old model's vectors, and mixed
+        vector spaces at the same width degrade search silently -- the exact
+        failure the identity guard exists to prevent.
+        """
+        vectors = self._vectors
+        if vectors is None:
+            raise NotImplementedError(
+                "REINDEX_ON_MODEL_CHANGE cannot be honoured: no Vectorize index "
+                f"is attached to this store. {_NO_VECTOR_INDEX}"
+            )
+        rows = self._backend.fetchall("SELECT id FROM memories", [])
+        ids = [r["id"] for r in rows]
+        _vectorize_delete_by_ids(vectors, ids)
+        logger.warning(
+            "[AUDIT] reindex dropped {} vector(s) from the Vectorize index; they "
+            "rebuild on the next embed pass.",
+            len(ids),
         )
+
+    def _clear_for_import(self, mode: str) -> None:
+        """Clear memories for a replace-mode import, vectors included.
+
+        Overrides the borrowed body, which would run ``DELETE FROM memories_vec``
+        against a table this database does not have. Vectors go first: if the
+        Vectorize delete fails the D1 rows are still present, so the ids needed
+        to retry are still readable. The reverse order would strand every vector
+        with no list of what to delete.
+        """
+        if mode != "replace":
+            return
+        if self._vectors is not None:
+            rows = self._backend.fetchall("SELECT id FROM memories", [])
+            _vectorize_delete_by_ids(self._vectors, [r["id"] for r in rows])
+        self._backend.execute("DELETE FROM memories", [])
 
     # -- Search ------------------------------------------------------------
 
@@ -355,9 +608,183 @@ class MemoryDBCfBackend:
         self._conn.raise_if_error("FTS5 search")
         return results
 
-    @functools.wraps(MemoryDB.search)
-    def search(self, *args, **kwargs) -> list[dict]:
-        return self._search(*args, **kwargs)
+    def _vector_candidates(
+        self,
+        embedding: list[float],
+        pool: int,
+        category: str | None,
+        tags: list[str] | None,
+        filter_kwargs: dict,
+    ) -> dict[str, dict]:
+        """Rank ids by Vectorize similarity, then re-authorise each against D1.
+
+        Two things happen here that have no counterpart in the SQLite path.
+
+        First, the candidate pool is capped. ``MemoryDB.search`` asks for
+        ``max(limit * 10, 50)`` candidates but Vectorize returns at most
+        :data:`VECTORIZE_MAX_TOP_K`, and ``VectorizeBackend.query`` applies that
+        cap without a word. The two numbers are compared here so the shortfall
+        reaches a log line and :attr:`last_vector_cap` instead of disappearing:
+        above ``limit=5`` the fused ranking is top-N over a 50-deep vector arm,
+        which is a weaker claim than the SQLite path makes and must not read as
+        the same one.
+
+        Second, every returned id is re-fetched from D1 under the caller's
+        filters -- whose ``_build_filter_sql`` tail always begins ``AND
+        m.valid_to IS NULL``. That is what keeps a superseded or soft-deleted row
+        out of the results even when its vector is still in the index, and it is
+        also why no metadata filter is sent to Vectorize: filtering there would
+        need metadata indexes declared at index-creation time in wrangler, and
+        would still not be authoritative about supersession, which only D1 knows.
+        The cost is real and one-directional -- a narrow ``category`` filter can
+        leave few of the 50 candidates standing -- so it is stated here rather
+        than presented as a filtered top-50.
+
+        Transport errors propagate. ``MemoryDB.search`` wraps its vector branch
+        in ``except Exception: logger.debug(...)``, which against a network
+        backend would turn a Vectorize outage into a search that silently
+        returns FTS-only results and looks healthy.
+        """
+        vectors = self._require_vectors("search")
+        top_k = min(pool, VECTORIZE_MAX_TOP_K)
+        self.last_vector_cap = VectorCandidateCap(requested=pool, served=top_k)
+        if top_k < pool:
+            logger.warning(
+                "Vector search asked for {} candidates but Cloudflare Vectorize "
+                "returns at most {}; the fused ranking below is top-N over a "
+                "{}-deep vector arm against a {}-deep FTS arm, not over the whole "
+                "store. Lower `limit` (pool = max(limit * 10, 50)) or pass an "
+                "explicit `candidate_pool` <= {} to make the two arms match.",
+                pool,
+                VECTORIZE_MAX_TOP_K,
+                top_k,
+                pool,
+                VECTORIZE_MAX_TOP_K,
+            )
+
+        matches = vectors.query(self._fit_dims(embedding), top_k)
+        scores: dict[str, float] = {}
+        for match in matches:
+            mid = match.get("id")
+            if mid is None:
+                continue
+            # Vectorize returns a similarity score, where sqlite-vec returns a
+            # distance that db.py converts with ``1.0 - distance``. Both land in
+            # [0, 1] and only the ordering feeds RRF.
+            scores[mid] = max(0.0, min(1.0, float(match.get("score", 0.0))))
+        if not scores:
+            return {}
+
+        fragments = ["WHERE m.id IN (SELECT value FROM json_each(?))"]
+        params: list = [json.dumps(list(scores))]
+        if category:
+            fragments.append("AND m.category = ?")
+            params.append(category)
+        if tags:
+            fragments.append(
+                "AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS "
+                "(SELECT 1 FROM json_each(m.tags) WHERE value IN "
+                "(SELECT value FROM json_each(?)))"
+            )
+            params.append(json.dumps(tags))
+        extra_sql, extra_params = self._build_filter_sql(**filter_kwargs)
+        if extra_sql:
+            fragments.append(extra_sql)
+            params.extend(extra_params)
+
+        rows = self._backend.fetchall(
+            "SELECT m.* FROM memories m " + " ".join(fragments), params
+        )
+        # Re-keyed by Vectorize's ranking, not by whatever order D1 returned the
+        # rows in. `_compute_hybrid_scores` derives both arms' ranks with a
+        # stable sort, so insertion order is what settles a tie between equal
+        # scores. Preserving the vector ranking here makes that tie-break
+        # meaningful instead of arbitrary.
+        #
+        # Note this is one place the two backends can legitimately disagree:
+        # `MemoryDB.search` re-reads its vector matches with a `WHERE id IN
+        # (...)` query, which yields rows in table order rather than by
+        # distance, so exactly-tied fused scores can come out ordered
+        # differently there. Only the tie-break differs -- any pair whose scores
+        # actually differ ranks the same on both -- and the fix belongs in
+        # `db.py`, where changing it would move SQLite's output.
+        by_id = {row["id"]: row for row in rows}
+        return {
+            mid: {**dict(by_id[mid]), "vec_score": score}
+            for mid, score in scores.items()
+            if mid in by_id
+        }
+
+    def search(
+        self,
+        query: str,
+        embedding: list[float] | None = None,
+        category: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 5,
+        *,
+        context_type: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        min_importance: float = 0.0,
+        include_archived: bool = False,
+        candidate_pool: int | None = None,
+    ) -> list[dict]:
+        """Hybrid FTS5 + Vectorize search. See :meth:`MemoryDB.search`.
+
+        Same shape as the SQLite path and the same fusion: the candidate pool,
+        the tiered FTS query, ``_compute_hybrid_scores`` (RRF at k=60, then
+        recency/frequency/importance) and the access-stat update are all the
+        borrowed ones, so the two backends cannot drift on ranking. Only the
+        source of the vector ranking differs -- ``memories_vec`` there, a
+        Vectorize index here -- and what that costs is set out in
+        :meth:`_vector_candidates`.
+        """
+        if tags and len(tags) > MAX_TAGS_FILTER:
+            raise ValueError(
+                f"Maximum of {MAX_TAGS_FILTER} tags allowed in search filter"
+            )
+
+        if isinstance(limit, int):
+            limit = max(1, min(limit, 100))
+
+        filter_kwargs = {
+            "context_type": context_type,
+            "since": since,
+            "until": until,
+            "min_importance": min_importance,
+            "include_archived": include_archived,
+        }
+
+        pool = candidate_pool if candidate_pool is not None else max(limit * 10, 50)
+        results = self._search_fts(query, category, tags, pool, **filter_kwargs)
+
+        # No `and self._vectors is not None` guard: without an index the
+        # embedding must raise (inside `_vector_candidates`), not be dropped into
+        # an FTS-only search the caller would read as a hybrid one.
+        if embedding:
+            for mid, row in self._vector_candidates(
+                embedding, pool, category, tags, filter_kwargs
+            ).items():
+                if mid in results:
+                    results[mid]["vec_score"] = row["vec_score"]
+                else:
+                    results[mid] = {**row, "fts_score": 0.0}
+
+        if not results:
+            return []
+
+        scored = self._compute_hybrid_scores(results)
+        effective_top = limit if candidate_pool is None else min(pool, len(scored))
+        top = scored[:effective_top]
+        self._update_access_stats(top)
+
+        for m in top:
+            m.pop("fts_score", None)
+            m.pop("vec_score", None)
+            m.pop("bm25_score", None)
+
+        return top
 
     # -- Writes that need a rows-changed count or a rollback ---------------
 
@@ -380,12 +807,20 @@ class MemoryDBCfBackend:
         by a compensating write and the failure is re-raised. Should the
         compensation itself fail, the row id is logged at ERROR -- the one case
         that needs a human -- rather than being reported as a successful update.
+
+        Vectors follow the id: the predecessor's vector is deleted and, when an
+        ``embedding`` is supplied, the successor's is written. Without one the
+        successor is left unvectorised and a WARNING says so. SQLite carries the
+        old vector forward in that case; this backend cannot, because nothing can
+        read a vector back out of Vectorize -- ``VectorizeBackend`` exposes no
+        getter and ``src/worker.ts``'s ``vectorizeOutbound`` routes no get-by-id --
+        and a successor that silently lost its vector would show up only as recall
+        that quietly got worse. Re-embedding restores it; note that
+        ``server._handle_update`` already re-embeds whenever ``content`` changes,
+        so this affects metadata-only edits.
         """
         if embedding is not None:
-            raise NotImplementedError(
-                "MemoryDBCfBackend.update() was given an embedding, which it "
-                f"cannot store. {_VECTOR_TASK}"
-            )
+            self._require_vectors("update")
         if content is not None and len(content) > MAX_CONTENT_LENGTH:
             raise ValueError(
                 f"Content length {len(content)} exceeds limit of {MAX_CONTENT_LENGTH}"
@@ -452,11 +887,25 @@ class MemoryDBCfBackend:
                 )
             raise
 
+        if self._vectors is not None:
+            self._discard_vectors([memory_id], f"update id={memory_id}")
+            if embedding:
+                self._upsert_vector(new_id, embedding)
+            else:
+                logger.warning(
+                    "[AUDIT] update id={} -> new_id={} carried no embedding, so "
+                    "the successor has no vector and is reachable by text search "
+                    "only until it is re-embedded. Vectorize cannot be read back, "
+                    "so the predecessor's vector could not be copied forward.",
+                    memory_id,
+                    new_id,
+                )
+
         logger.info(f"[AUDIT] update id={memory_id} -> new_id={new_id}")
         return new_id
 
     def delete(self, memory_id: str) -> bool:
-        """Soft-close a memory. See :meth:`MemoryDB.delete`."""
+        """Soft-close a memory and drop its vector. See :meth:`MemoryDB.delete`."""
         rows = self._backend.fetchall(
             "UPDATE memories SET valid_to = ? WHERE id = ? AND valid_to IS NULL "
             "RETURNING id",
@@ -464,6 +913,7 @@ class MemoryDBCfBackend:
         )
         if not rows:
             return False
+        self._discard_vectors([memory_id], f"delete id={memory_id}")
         logger.info(f"[AUDIT] delete id={memory_id}")
         return True
 

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -44,6 +44,11 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+# The Vectorize double lives next to the fidelity test that pins it against
+# `src/worker.ts`. Imported here so the two suites cannot describe two different
+# Workers.
+from test_db_cf_vectors import FakeVectorizeWorker
+
 from mnemo_mcp.db import MemoryDB
 from mnemo_mcp.db_cf import (
     D1_MAX_BOUND_PARAMS,
@@ -104,11 +109,35 @@ def fake_worker(d1_conn: sqlite3.Connection) -> FakeD1Worker:
     return FakeD1Worker(d1_conn)
 
 
-def _cf_db(worker: FakeD1Worker, **kwargs) -> MemoryDBCfBackend:
-    from mcp_core.storage.d1 import D1Backend
+@pytest.fixture
+def fake_vectorize() -> FakeVectorizeWorker:
+    return FakeVectorizeWorker()
 
+
+def _cf_db(
+    worker: FakeD1Worker,
+    vectorize: FakeVectorizeWorker | None = None,
+    **kwargs,
+) -> MemoryDBCfBackend:
+    """Open a D1-backed store. Text-only unless a Vectorize double is passed.
+
+    Vectors are the subject of ``tests/test_db_cf_vectors.py``; here an index is
+    attached only where ``embedding_dims > 0`` makes one mandatory.
+    """
+    from mcp_core.storage.d1 import D1Backend
+    from mcp_core.storage.vectorize import VectorizeBackend
+
+    vectors = (
+        None
+        if vectorize is None
+        else VectorizeBackend(
+            base_url="http://vectorize.internal", idx="mnemo-test", http=vectorize
+        )
+    )
     return MemoryDBCfBackend(
-        D1Backend(base_url="http://d1.internal", http=worker), **kwargs
+        D1Backend(base_url="http://d1.internal", http=worker),
+        vectors=vectors,
+        **kwargs,
     )
 
 
@@ -527,41 +556,36 @@ class TestBackendParity:
 
 
 class TestVectorPathIsLoud:
-    """Task 3 has no vector path. It must say so, never return an empty list."""
+    """A text-only store must refuse a vector, never quietly discard it.
+
+    ``cf_db`` is opened with ``embedding_dims=0``, which declares the store
+    text-only: no Vectorize index is attached and there is nowhere for a vector
+    to go, since D1 has no ``memories_vec``. The wired path -- what happens once
+    an index *is* attached -- is ``tests/test_db_cf_vectors.py``.
+    """
 
     def test_add_with_embedding_raises(self, cf_db):
-        with pytest.raises(NotImplementedError, match="Task 4"):
+        with pytest.raises(NotImplementedError, match="embedding_dims=0"):
             cf_db.add("with a vector", embedding=[0.1] * 768)
 
     def test_add_with_context_type_with_embedding_raises(self, cf_db):
-        with pytest.raises(NotImplementedError, match="Task 4"):
+        with pytest.raises(NotImplementedError, match="embedding_dims=0"):
             cf_db.add_with_context_type("with a vector", embedding=[0.1] * 768)
 
     def test_search_with_embedding_raises(self, cf_db):
         _seed(cf_db)
-        with pytest.raises(NotImplementedError, match="Task 4"):
+        with pytest.raises(NotImplementedError, match="embedding_dims=0"):
             cf_db.search("anything", embedding=[0.1] * 768)
 
     def test_update_with_embedding_raises(self, cf_db):
         ids = _seed(cf_db)
-        with pytest.raises(NotImplementedError, match="Task 4"):
+        with pytest.raises(NotImplementedError, match="embedding_dims=0"):
             cf_db.update(ids["python"], embedding=[0.1] * 768)
 
     def test_search_without_embedding_still_works(self, cf_db):
         """Rejecting vectors must not break the FTS-only path."""
         _seed(cf_db)
         assert cf_db.search("Python")
-
-    def test_reindex_on_model_change_raises_instead_of_pretending(self, fake_worker):
-        db = _cf_db(fake_worker, embedding_dims=768, embedding_model="model-a")
-        db.close()
-        with pytest.raises(NotImplementedError, match="Task 4"):
-            _cf_db(
-                fake_worker,
-                embedding_dims=768,
-                embedding_model="model-b",
-                reindex_on_model_change=True,
-            )
 
 
 class TestUnavailableSurface:
@@ -648,14 +672,25 @@ class TestFailLoud:
         with pytest.raises(RuntimeError, match="closed"):
             cf_db.list_memories()
 
-    def test_embedding_identity_mismatch_raises(self, fake_worker):
-        db = _cf_db(fake_worker, embedding_dims=768, embedding_model="model-a")
+    def test_embedding_identity_mismatch_raises(self, fake_worker, fake_vectorize):
+        db = _cf_db(
+            fake_worker, fake_vectorize, embedding_dims=768, embedding_model="model-a"
+        )
         db.close()
         with pytest.raises(EmbeddingModelMismatch):
-            _cf_db(fake_worker, embedding_dims=768, embedding_model="model-b")
+            _cf_db(
+                fake_worker,
+                fake_vectorize,
+                embedding_dims=768,
+                embedding_model="model-b",
+            )
 
-    def test_embedding_identity_is_stamped_on_a_fresh_store(self, fake_worker):
-        db = _cf_db(fake_worker, embedding_dims=768, embedding_model="model-a")
+    def test_embedding_identity_is_stamped_on_a_fresh_store(
+        self, fake_worker, fake_vectorize
+    ):
+        db = _cf_db(
+            fake_worker, fake_vectorize, embedding_dims=768, embedding_model="model-a"
+        )
         assert db.get_store_meta("embedding_dims") == "768"
         assert db.get_store_meta("embedding_model") == "model-a"
 

--- a/tests/test_db_cf_vectors.py
+++ b/tests/test_db_cf_vectors.py
@@ -1,0 +1,809 @@
+"""Tests for the Cloudflare Vectorize arm of ``mnemo_mcp.db_cf`` (S2 Task 4).
+
+``tests/test_db_cf.py`` covers the D1 + FTS5 half of ``MemoryDBCfBackend`` and
+owns the backend-parity suite. This file covers what happens once a Vectorize
+index is attached, and it is organised around the four places where the D1 build
+cannot simply behave like the SQLite one:
+
+1. Cloudflare returns at most 50 vector matches per query, and
+   ``VectorizeBackend.query`` applies that cap with a bare ``min(top_k, 50)`` --
+   no exception, no warning. ``TestTopKCeiling`` pins the announcement.
+2. Vectorize is eventually consistent while D1 is not, so a just-added memory is
+   text-searchable before it is vector-searchable. ``TestEventualConsistency``
+   asserts that behaviour rather than hiding it behind a retry, and pins the
+   reason the obvious fix does not work.
+3. ``delete`` and ``update`` only move ``valid_to``, which Vectorize knows nothing
+   about. ``TestSupersededRowsStayGone`` proves a closed row cannot come back --
+   including when its vector is still sitting in the index.
+4. ``REINDEX_ON_MODEL_CHANGE`` has real vectors to drop now.
+   ``TestReindexDropsVectors`` covers the success and the failure path.
+
+How the Vectorize side is exercised
+-----------------------------------
+
+Same approach as ``FakeD1Worker``: :class:`FakeVectorizeWorker` implements the
+``request(method, url, body, headers) -> (status, bytes)`` transport that
+``VectorizeBackend`` takes via ``http=``, transcribing ``vectorizeOutbound`` from
+``src/worker.ts`` route for route -- including its unconditional
+``GET -> {ready: true}``, which is the whole reason
+``wait_until_indexed()`` is useless here.
+``test_fake_worker_matches_worker_ts`` pins the transcription against the real
+file so a new route cannot drift away from the double.
+
+What it adds beyond transcription: a two-stage index (``pending`` then
+``visible``) so eventual consistency can be exercised deterministically instead
+of by sleeping, and a ``fail_delete`` switch so the read-side supersession filter
+can be tested with the write-side deliberately broken. What it does not
+reproduce: Cloudflare's actual ANN recall (the double is an exact cosine scan, so
+ranking is exact where production is approximate), real propagation timing, and
+metadata-filter behaviour -- which the backend never uses, by design.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+import re
+import sqlite3
+from collections.abc import Generator
+from urllib.parse import urlparse
+
+import pytest
+from loguru import logger
+
+from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.db_cf import (
+    VECTORIZE_MAX_TOP_K,
+    MemoryDBCfBackend,
+    VectorCandidateCap,
+)
+from mnemo_mcp.exceptions import EmbeddingModelMismatch
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
+_WORKER_TS = _REPO_ROOT / "src" / "worker.ts"
+
+# Test vectors are 8-wide for readability. `test_wire_carries_full_width_vector`
+# covers the real 768 the store_meta of the live store records.
+DIMS = 8
+
+
+def _unit(axis: int, dims: int = DIMS) -> list[float]:
+    """A one-hot vector, so cosine similarity between test vectors is obvious."""
+    vec = [0.0] * dims
+    vec[axis] = 1.0
+    return vec
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+class FakeVectorizeWorker:
+    """In-process stand-in for ``vectorizeOutbound`` in ``src/worker.ts``.
+
+    Serves ``/upsert``, ``/query`` and ``/deleteByIds``, answers any GET with
+    ``{ready: true}``, and 404s the rest -- exactly the route surface of the
+    handler it transcribes.
+
+    An upsert lands in ``pending`` and only becomes queryable on
+    :meth:`settle`, which is how Vectorize behaves and how the read-after-write
+    gap is tested without sleeping. ``settle_immediately`` collapses that for the
+    tests where indexing lag is not the subject.
+    """
+
+    def __init__(self, *, settle_immediately: bool = True) -> None:
+        self.visible: dict[str, list[float]] = {}
+        self.pending: dict[str, list[float]] = {}
+        self.settle_immediately = settle_immediately
+        self.fail_delete = False
+        self.requests: list[tuple[str, str, object]] = []
+
+    def settle(self) -> None:
+        """Make every pending upsert queryable, as Vectorize eventually does."""
+        self.visible.update(self.pending)
+        self.pending.clear()
+
+    def request(self, method, url, data=None, headers=None):
+        path = urlparse(url).path
+
+        if method == "POST" and path == "/upsert":
+            # `(await request.text()).split('\n').filter(Boolean).map(JSON.parse)`
+            vectors = [json.loads(line) for line in data.decode().split("\n") if line]
+            self.requests.append((method, path, vectors))
+            target = self.visible if self.settle_immediately else self.pending
+            for vector in vectors:
+                target[vector["id"]] = vector["values"]
+            return (200, json.dumps({"mutationId": "m-upsert"}).encode())
+
+        if method == "POST" and path == "/query":
+            payload = json.loads(data.decode())
+            self.requests.append((method, path, payload))
+            vector, top_k = payload["vector"], payload["topK"]
+            ranked = sorted(
+                ((mid, _cosine(vector, v)) for mid, v in self.visible.items()),
+                key=lambda kv: kv[1],
+                reverse=True,
+            )
+            matches = [{"id": m, "score": s} for m, s in ranked[:top_k]]
+            return (200, json.dumps({"matches": matches}).encode())
+
+        if method == "POST" and path == "/deleteByIds":
+            payload = json.loads(data.decode())
+            self.requests.append((method, path, payload))
+            if self.fail_delete:
+                return (500, b"internal error")
+            for mid in payload["ids"]:
+                self.visible.pop(mid, None)
+                self.pending.pop(mid, None)
+            return (200, json.dumps({"mutationId": "m-delete"}).encode())
+
+        self.requests.append((method, path, None))
+        if method == "GET":
+            # `if (request.method === 'GET') return Response.json({ ready: true })`
+            # -- unconditional, which is the point.
+            return (200, json.dumps({"ready": True}).encode())
+
+        return (404, b"not found")
+
+
+class FakeD1Worker:
+    """``d1Outbound`` stand-in. Mirrors the one in ``tests/test_db_cf.py``."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+        self.requests: list[tuple[str, str, list]] = []
+
+    def request(self, method, url, data=None, headers=None):
+        path = urlparse(url).path
+        if path != "/query" or method != "POST":
+            return (404, b"not found")
+        payload = json.loads(data.decode())
+        sql, params = payload["sql"], payload.get("params") or []
+        self.requests.append((method, path, params))
+        cursor = self.conn.execute(sql, params)
+        columns = [d[0] for d in cursor.description] if cursor.description else []
+        results = [dict(zip(columns, row, strict=True)) for row in cursor.fetchall()]
+        return (200, json.dumps({"results": results}).encode())
+
+
+@pytest.fixture
+def fake_worker(tmp_path) -> FakeD1Worker:
+    conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
+    conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+    return FakeD1Worker(conn)
+
+
+@pytest.fixture
+def fake_vectorize() -> FakeVectorizeWorker:
+    return FakeVectorizeWorker()
+
+
+@pytest.fixture
+def lagging_vectorize() -> FakeVectorizeWorker:
+    return FakeVectorizeWorker(settle_immediately=False)
+
+
+def _cf_db(
+    worker: FakeD1Worker,
+    vectorize: FakeVectorizeWorker | None,
+    *,
+    embedding_dims: int = DIMS,
+    **kwargs,
+) -> MemoryDBCfBackend:
+    from mcp_core.storage.d1 import D1Backend
+    from mcp_core.storage.vectorize import VectorizeBackend
+
+    vectors = (
+        None
+        if vectorize is None
+        else VectorizeBackend(
+            base_url="http://vectorize.internal", idx="mnemo-test", http=vectorize
+        )
+    )
+    return MemoryDBCfBackend(
+        D1Backend(base_url="http://d1.internal", http=worker),
+        vectors=vectors,
+        embedding_dims=embedding_dims,
+        **kwargs,
+    )
+
+
+@pytest.fixture
+def cf_db(fake_worker, fake_vectorize) -> MemoryDBCfBackend:
+    return _cf_db(fake_worker, fake_vectorize)
+
+
+@pytest.fixture
+def captured_logs() -> Generator[list[dict]]:
+    """Collect loguru records; loguru does not route through pytest's caplog."""
+    records: list[dict] = []
+    sink_id = logger.add(
+        lambda message: records.append(
+            {
+                "level": message.record["level"].name,
+                "message": message.record["message"],
+            }
+        ),
+        level="WARNING",
+        format="{message}",
+    )
+    yield records
+    logger.remove(sink_id)
+
+
+def _messages(records: list[dict], level: str) -> str:
+    return "\n".join(r["message"] for r in records if r["level"] == level)
+
+
+class TestFakeVectorizeFidelity:
+    """The double is only evidence if it matches the Worker it replaces."""
+
+    def test_fake_worker_matches_worker_ts(self):
+        """``vectorizeOutbound`` serves exactly these three POST routes."""
+        source = _WORKER_TS.read_text(encoding="utf-8")
+        handler = source.split("const vectorizeOutbound", 1)[1].split("\nconst ", 1)[0]
+        routes = set(re.findall(r"url\.pathname === '([^']+)'", handler))
+        assert routes == {"/upsert", "/query", "/deleteByIds"}, (
+            f"src/worker.ts vectorizeOutbound now serves {routes}; "
+            "FakeVectorizeWorker and MemoryDBCfBackend need updating together"
+        )
+        assert "status: 404" in handler
+
+    def test_ready_probe_is_unconditional_in_the_worker(self):
+        """The readiness GET reports nothing about whether an upsert landed.
+
+        This pins the reason ``MemoryDBCfBackend`` never calls
+        ``VectorizeBackend.wait_until_indexed()``: the Worker answers every GET
+        with ``{ready: true}`` regardless of index state, so waiting on it would
+        return an "indexed" signal that means only "the handler is wired". If
+        this assertion ever fails because the Worker grew a real mutation probe,
+        the read-after-write behaviour documented in ``db_cf`` can be revisited.
+        """
+        source = _WORKER_TS.read_text(encoding="utf-8")
+        handler = source.split("const vectorizeOutbound", 1)[1].split("\nconst ", 1)[0]
+        assert (
+            "if (request.method === 'GET') return Response.json({ ready: true })"
+            in handler
+        )
+
+    def test_ready_probe_lies_about_pending_upserts(self, lagging_vectorize):
+        """The same thing, demonstrated on the double rather than by reading."""
+        from mcp_core.storage.vectorize import VectorizeBackend
+
+        backend = VectorizeBackend(
+            base_url="http://vectorize.internal", idx="i", http=lagging_vectorize
+        )
+        backend.upsert([{"id": "a", "values": _unit(0)}])
+        assert backend.wait_until_indexed(poll_interval=0, max_wait=0.1) is True
+        assert lagging_vectorize.visible == {}, (
+            "wait_until_indexed() returned True while nothing was queryable"
+        )
+
+
+class TestVectorWiring:
+    """A vector handed to the store reaches the index, and comes back."""
+
+    def test_add_upserts_the_vector_under_the_memory_id(self, cf_db, fake_vectorize):
+        mid = cf_db.add("Python is a programming language", embedding=_unit(0))
+        assert fake_vectorize.visible == {mid: _unit(0)}
+
+    def test_search_finds_a_memory_by_vector_alone(self, cf_db):
+        """Text the FTS index cannot match; only the vector arm can answer.
+
+        Both rows come back -- a nearest-neighbour query ranks the whole index
+        rather than filtering it, on Vectorize as on ``sqlite-vec``. Their fused
+        scores tie (each is rank 1 in one arm and rank 2 in the other), and the
+        order is still deterministic *here* because ``_vector_candidates``
+        preserves Vectorize's ranking, which the stable sort then keeps. That is
+        the property under test; the parity suite deliberately does not assert
+        it across backends.
+        """
+        mid = cf_db.add("Python is a programming language", embedding=_unit(0))
+        other = cf_db.add("Remember to buy groceries", embedding=_unit(1))
+
+        hits = cf_db.search("zzzz-unmatchable-token", embedding=_unit(0))
+        assert [h["id"] for h in hits] == [mid, other]
+
+    def test_add_with_context_type_upserts_too(self, cf_db, fake_vectorize):
+        mid = cf_db.add_with_context_type(
+            "User prefers dark mode", context_type="preference", embedding=_unit(2)
+        )
+        assert fake_vectorize.visible[mid] == _unit(2)
+
+    def test_hybrid_search_fuses_both_arms(self, cf_db):
+        """Both arms contribute; the fused list is the borrowed RRF's output."""
+        text_only = cf_db.add("Python is a programming language", embedding=_unit(3))
+        vector_only = cf_db.add("totally unrelated wording", embedding=_unit(0))
+
+        hits = cf_db.search("Python programming", embedding=_unit(0), limit=5)
+        found = {h["id"] for h in hits}
+        assert text_only in found, "FTS arm did not contribute"
+        assert vector_only in found, "vector arm did not contribute"
+
+    def test_row_survives_a_failed_vector_write(self, cf_db, fake_vectorize):
+        """D1 is written first, so a Vectorize outage cannot orphan a vector.
+
+        The failure is raised, not swallowed; what it leaves behind is a row with
+        no vector -- text-searchable now, repaired by a reindex -- rather than a
+        vector pointing at a row that was never written.
+        """
+        fake_vectorize.request = lambda *a, **k: (503, b"unavailable")
+        with pytest.raises(RuntimeError, match="upsert failed"):
+            cf_db.add("ordering check", embedding=_unit(0))
+        assert [h["id"] for h in cf_db.search("ordering check")] != []
+
+    def test_wire_carries_full_width_vector(self, fake_worker, fake_vectorize):
+        """768 is what the live store's ``store_meta`` records."""
+        db = _cf_db(fake_worker, fake_vectorize, embedding_dims=768)
+        mid = db.add("real-width vector", embedding=[0.5] * 768)
+        assert len(fake_vectorize.visible[mid]) == 768
+
+    def test_oversized_vector_is_reshaped_like_sqlite(self, cf_db, fake_vectorize):
+        """``db._serialize_f32`` truncates/pads; parity means doing the same."""
+        long_id = cf_db.add("too long", embedding=[1.0] * (DIMS + 4))
+        short_id = cf_db.add("too short", embedding=[1.0, 1.0])
+        assert fake_vectorize.visible[long_id] == [1.0] * DIMS
+        assert fake_vectorize.visible[short_id] == [1.0, 1.0] + [0.0] * (DIMS - 2)
+
+    def test_vec_enabled_reflects_the_attached_index(self, cf_db, fake_worker):
+        assert cf_db.vec_enabled is True
+        assert cf_db.stats()["vec_enabled"] is True
+        text_only = _cf_db(fake_worker, None, embedding_dims=0)
+        assert text_only.vec_enabled is False
+        assert text_only.stats()["vec_enabled"] is False
+
+    def test_transport_failure_is_not_swallowed(self, cf_db, fake_vectorize):
+        """``MemoryDB.search`` logs its vector branch's errors at debug and
+        carries on; against a network backend that turns an outage into an
+        FTS-only result set that looks healthy."""
+        cf_db.add("Python is a programming language", embedding=_unit(0))
+        fake_vectorize.request = lambda *a, **k: (503, b"unavailable")
+        with pytest.raises(RuntimeError, match="query failed"):
+            cf_db.search("Python", embedding=_unit(0))
+
+
+class TestNoIndexAttached:
+    """``embedding_dims=0`` means text-only, and says so when handed a vector."""
+
+    @pytest.mark.parametrize("method", ["add", "add_with_context_type"])
+    def test_write_with_embedding_raises(self, fake_worker, method):
+        db = _cf_db(fake_worker, None, embedding_dims=0)
+        with pytest.raises(NotImplementedError, match="embedding_dims=0"):
+            getattr(db, method)("content", embedding=_unit(0))
+
+    def test_update_with_embedding_raises(self, fake_worker):
+        db = _cf_db(fake_worker, None, embedding_dims=0)
+        mid = db.add("content")
+        with pytest.raises(NotImplementedError, match="embedding_dims=0"):
+            db.update(mid, content="new", embedding=_unit(0))
+
+    def test_search_with_embedding_raises(self, fake_worker):
+        db = _cf_db(fake_worker, None, embedding_dims=0)
+        db.add("Python is a programming language")
+        with pytest.raises(NotImplementedError, match="embedding_dims=0"):
+            db.search("Python", embedding=_unit(0))
+
+    def test_text_only_search_still_works(self, fake_worker):
+        db = _cf_db(fake_worker, None, embedding_dims=0)
+        mid = db.add("Python is a programming language")
+        assert [h["id"] for h in db.search("Python")] == [mid]
+
+    def test_attaching_an_index_to_a_text_only_store_is_rejected(
+        self, fake_worker, fake_vectorize
+    ):
+        with pytest.raises(ValueError, match="embedding_dims=0"):
+            _cf_db(fake_worker, fake_vectorize, embedding_dims=0)
+
+    def test_missing_index_name_names_the_variable(self, fake_worker, monkeypatch):
+        """A bare ``KeyError('MCP_VECTORIZE_IDX')`` explains nothing."""
+        monkeypatch.delenv("MCP_VECTORIZE_IDX", raising=False)
+        with pytest.raises(RuntimeError, match="MCP_VECTORIZE_IDX is not set"):
+            _cf_db(fake_worker, None, embedding_dims=DIMS)
+
+    def test_reindex_without_an_index_raises(self, fake_worker):
+        db = _cf_db(fake_worker, None, embedding_dims=0)
+        with pytest.raises(NotImplementedError, match="no Vectorize index"):
+            db._drop_vectors_for_reindex()
+
+
+class TestTopKCeiling:
+    """Hard spot 1: Cloudflare serves at most 50 candidates, silently."""
+
+    def test_mcp_core_clamps_without_a_word(self, fake_vectorize):
+        """The premise this whole class exists for, pinned on the real client.
+
+        If ``mcp_core`` ever grows a warning or an exception here, this fails and
+        the local announcement can be reconsidered.
+        """
+        from mcp_core.storage.vectorize import VectorizeBackend
+
+        backend = VectorizeBackend(
+            base_url="http://vectorize.internal", idx="i", http=fake_vectorize
+        )
+        backend.query(_unit(0), top_k=500)
+        _, _, payload = fake_vectorize.requests[-1]
+        assert payload["topK"] == VECTORIZE_MAX_TOP_K
+
+    def test_truncation_is_recorded_and_warned(self, cf_db, captured_logs):
+        """``limit=10`` asks for a pool of 100 and can only get 50."""
+        cf_db.add("Python is a programming language", embedding=_unit(0))
+
+        cf_db.search("Python", embedding=_unit(0), limit=10)
+
+        assert cf_db.last_vector_cap == VectorCandidateCap(requested=100, served=50)
+        assert cf_db.last_vector_cap.truncated is True
+        warning = _messages(captured_logs, "WARNING")
+        assert "100" in warning and "50" in warning, warning
+
+    def test_default_limit_is_not_truncated(self, cf_db, captured_logs):
+        """``limit=5`` -> pool of exactly 50: both arms see the same depth."""
+        cf_db.add("Python is a programming language", embedding=_unit(0))
+
+        cf_db.search("Python", embedding=_unit(0))
+
+        assert cf_db.last_vector_cap == VectorCandidateCap(requested=50, served=50)
+        assert cf_db.last_vector_cap.truncated is False
+        assert "Vectorize" not in _messages(captured_logs, "WARNING")
+
+    def test_truncation_actually_drops_candidates(self, cf_db):
+        """Not just bookkeeping: the 51st-best vector match never arrives.
+
+        60 memories, all vector-matched, none text-matched. A pool of 100 would
+        rank all 60; the ceiling means the vector arm ranks 50.
+        """
+        ids = [
+            cf_db.add(
+                f"row number {i}", embedding=[1.0, float(i) / 100, 0, 0, 0, 0, 0, 0]
+            )
+            for i in range(60)
+        ]
+        assert len(ids) == 60
+
+        hits = cf_db.search(
+            "zzzz-unmatchable-token", embedding=_unit(0), candidate_pool=100
+        )
+
+        assert cf_db.last_vector_cap == VectorCandidateCap(requested=100, served=50)
+        assert len(hits) == VECTORIZE_MAX_TOP_K, (
+            "60 rows match the query vector and a pool of 100 was requested, but "
+            "only 50 can ever come back from Vectorize"
+        )
+
+    def test_explicit_small_pool_is_honoured_unclamped(self, cf_db, captured_logs):
+        cf_db.add("Python is a programming language", embedding=_unit(0))
+        cf_db.search("Python", embedding=_unit(0), candidate_pool=20)
+        assert cf_db.last_vector_cap == VectorCandidateCap(requested=20, served=20)
+        assert "Vectorize" not in _messages(captured_logs, "WARNING")
+
+    def test_cap_is_not_recorded_when_the_vector_arm_did_not_run(self, cf_db):
+        cf_db.add("Python is a programming language")
+        cf_db.search("Python", limit=10)
+        assert cf_db.last_vector_cap is None
+
+
+class TestEventualConsistency:
+    """Hard spot 2: D1 is immediate, Vectorize is not -- documented, not hidden."""
+
+    @pytest.fixture
+    def lagging_db(self, fake_worker, lagging_vectorize) -> MemoryDBCfBackend:
+        return _cf_db(fake_worker, lagging_vectorize)
+
+    def test_new_memory_is_text_searchable_immediately(self, lagging_db):
+        mid = lagging_db.add("Python is a programming language", embedding=_unit(0))
+        hits = lagging_db.search("Python", embedding=_unit(0))
+        assert [h["id"] for h in hits] == [mid], (
+            "D1 is strongly consistent; the row must be findable by text at once"
+        )
+
+    def test_new_memory_is_not_yet_vector_searchable(
+        self, lagging_db, lagging_vectorize
+    ):
+        """The documented gap, asserted rather than retried away.
+
+        A query only the vector arm can answer returns nothing until Vectorize
+        indexes the upsert. Papering over this with a silent retry loop is what
+        the docstring in ``db_cf`` refuses to do.
+        """
+        lagging_db.add("Python is a programming language", embedding=_unit(0))
+
+        assert lagging_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
+
+        lagging_vectorize.settle()
+        hits = lagging_db.search("zzzz-unmatchable-token", embedding=_unit(0))
+        assert len(hits) == 1
+
+    def test_backend_never_polls_the_ready_endpoint(
+        self, lagging_db, lagging_vectorize
+    ):
+        """``wait_until_indexed`` cannot mean what its name says here.
+
+        ``vectorizeOutbound`` answers every GET with ``{ready: true}``, so polling
+        it after an upsert would produce a confident "indexed" that is really
+        "the handler is reachable" -- a manufactured success signal. The backend
+        must therefore issue no GET at all.
+        """
+        lagging_db.add("Python is a programming language", embedding=_unit(0))
+        lagging_db.search("Python", embedding=_unit(0))
+        assert [m for m, _, _ in lagging_vectorize.requests if m == "GET"] == []
+
+    def test_lag_does_not_suppress_the_row_itself(self, lagging_db):
+        """The row is fully readable while only its vector is in flight."""
+        mid = lagging_db.add("Python is a programming language", embedding=_unit(0))
+        assert lagging_db.get(mid)["content"] == "Python is a programming language"
+        assert [r["id"] for r in lagging_db.list_memories()] == [mid]
+
+
+class TestSupersededRowsStayGone:
+    """Hard spot 3: a closed row must never come back through the vector arm."""
+
+    def test_delete_removes_the_vector(self, cf_db, fake_vectorize):
+        mid = cf_db.add("Python is a programming language", embedding=_unit(0))
+        assert cf_db.delete(mid) is True
+        assert fake_vectorize.visible == {}
+
+    def test_deleted_row_is_absent_from_vector_search(self, cf_db):
+        mid = cf_db.add("Python is a programming language", embedding=_unit(0))
+        cf_db.delete(mid)
+        assert cf_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
+
+    def test_deleted_row_stays_gone_even_with_its_vector_still_indexed(
+        self, cf_db, fake_vectorize, captured_logs
+    ):
+        """The load-bearing test: the read-side filter, with the write side broken.
+
+        ``fail_delete`` makes ``/deleteByIds`` return 500, so the vector survives
+        the delete exactly as it would if the call had failed or not yet
+        propagated. Search must still not return the row, because every Vectorize
+        hit is re-checked against D1's ``valid_to IS NULL``.
+        """
+        mid = cf_db.add("Python is a programming language", embedding=_unit(0))
+        fake_vectorize.fail_delete = True
+
+        assert cf_db.delete(mid) is True
+        assert mid in fake_vectorize.visible, "precondition: the vector must survive"
+        assert "[AUDIT]" in _messages(captured_logs, "ERROR")
+
+        assert cf_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
+        assert cf_db.search("Python", embedding=_unit(0)) == []
+
+    def test_update_returns_the_successor_not_the_predecessor(self, cf_db):
+        old_id = cf_db.add("Python is a programming language", embedding=_unit(0))
+        new_id = cf_db.update(old_id, content="Python is a great language")
+
+        hits = cf_db.search("Python", embedding=_unit(0))
+        found = {h["id"] for h in hits}
+        assert old_id not in found
+        assert found == {new_id}
+
+    def test_superseded_row_stays_gone_with_its_vector_still_indexed(
+        self, cf_db, fake_vectorize
+    ):
+        """Same as the delete case, for the id ``update`` closes."""
+        old_id = cf_db.add("Python is a programming language", embedding=_unit(0))
+        fake_vectorize.fail_delete = True
+        new_id = cf_db.update(old_id, content="Python is a great language")
+
+        assert old_id in fake_vectorize.visible, "precondition: the vector survives"
+        assert new_id is not None
+        assert cf_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
+
+    def test_update_with_an_embedding_vectorises_the_successor(
+        self, cf_db, fake_vectorize
+    ):
+        old_id = cf_db.add("Python is a programming language", embedding=_unit(0))
+        new_id = cf_db.update(old_id, content="Python rules", embedding=_unit(1))
+
+        assert fake_vectorize.visible == {new_id: _unit(1)}
+        hits = cf_db.search("zzzz-unmatchable-token", embedding=_unit(1))
+        assert [h["id"] for h in hits] == [new_id]
+
+    def test_metadata_only_update_says_the_successor_lost_its_vector(
+        self, cf_db, fake_vectorize, captured_logs
+    ):
+        """SQLite carries the vector forward; Vectorize cannot be read back.
+
+        The successor is unvectorised until something re-embeds it, and that is
+        announced rather than left to show up as recall that quietly got worse.
+        """
+        old_id = cf_db.add("Python is a programming language", embedding=_unit(0))
+        new_id = cf_db.update(old_id, category="tech")
+
+        assert fake_vectorize.visible == {}
+        warning = _messages(captured_logs, "WARNING")
+        assert new_id in warning and "no vector" in warning, warning
+
+        # Still reachable by text -- the degradation is bounded and stated.
+        assert [h["id"] for h in cf_db.search("Python")] == [new_id]
+
+    def test_archived_row_is_excluded_from_the_vector_arm(self, cf_db):
+        """The re-authorisation applies every caller filter, not just valid_to."""
+        mid = cf_db.add("Python is a programming language", embedding=_unit(0))
+        cf_db._backend.execute(
+            "UPDATE memories SET archived_at = ? WHERE id = ?", ["2020-01-01", mid]
+        )
+        assert cf_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
+        hits = cf_db.search(
+            "zzzz-unmatchable-token", embedding=_unit(0), include_archived=True
+        )
+        assert [h["id"] for h in hits] == [mid]
+
+    def test_category_filter_applies_to_the_vector_arm(self, cf_db):
+        cf_db.add(
+            "Python is a programming language", category="tech", embedding=_unit(0)
+        )
+        personal = cf_db.add("buy groceries", category="personal", embedding=_unit(0))
+        hits = cf_db.search(
+            "zzzz-unmatchable-token", embedding=_unit(0), category="personal"
+        )
+        assert [h["id"] for h in hits] == [personal]
+
+
+class TestReindexDropsVectors:
+    """Hard spot 4: ``REINDEX_ON_MODEL_CHANGE`` has something to drop now."""
+
+    def test_model_change_without_reindex_still_raises(
+        self, fake_worker, fake_vectorize
+    ):
+        _cf_db(fake_worker, fake_vectorize, embedding_model="model-a")
+        with pytest.raises(EmbeddingModelMismatch):
+            _cf_db(fake_worker, fake_vectorize, embedding_model="model-b")
+
+    def test_reindex_deletes_every_vector(self, fake_worker, fake_vectorize):
+        db = _cf_db(fake_worker, fake_vectorize, embedding_model="model-a")
+        db.add("Python is a programming language", embedding=_unit(0))
+        db.add("Remember to buy groceries", embedding=_unit(1))
+        assert len(fake_vectorize.visible) == 2
+
+        reindexed = _cf_db(
+            fake_worker,
+            fake_vectorize,
+            embedding_model="model-b",
+            reindex_on_model_change=True,
+        )
+
+        assert fake_vectorize.visible == {}
+        assert reindexed.get_store_meta("embedding_model") == "model-b"
+
+    def test_reindex_keeps_the_rows(self, fake_worker, fake_vectorize):
+        """Only vectors are destroyed; the rows re-embed on the next pass."""
+        db = _cf_db(fake_worker, fake_vectorize, embedding_model="model-a")
+        mid = db.add("Python is a programming language", embedding=_unit(0))
+
+        reindexed = _cf_db(
+            fake_worker,
+            fake_vectorize,
+            embedding_model="model-b",
+            reindex_on_model_change=True,
+        )
+        row = reindexed.get(mid)
+        assert row is not None, "the reindex destroyed the row, not just its vector"
+        assert row["content"] == "Python is a programming language"
+
+    def test_failed_reindex_raises_and_keeps_the_old_stamp(
+        self, fake_worker, fake_vectorize
+    ):
+        """A half-done reindex must not re-stamp the new model.
+
+        Re-stamping over an index still holding the old model's vectors is the
+        mixed-vector-space corruption the identity guard exists to prevent -- and
+        at equal width it degrades search with no error anywhere. The guard
+        stamps only after this returns, so raising leaves the old identity in
+        place and the next boot retries.
+        """
+        db = _cf_db(fake_worker, fake_vectorize, embedding_model="model-a")
+        db.add("Python is a programming language", embedding=_unit(0))
+        fake_vectorize.fail_delete = True
+
+        with pytest.raises(RuntimeError, match="deleteByIds failed"):
+            _cf_db(
+                fake_worker,
+                fake_vectorize,
+                embedding_model="model-b",
+                reindex_on_model_change=True,
+            )
+
+        assert db.get_store_meta("embedding_model") == "model-a"
+        assert len(fake_vectorize.visible) == 1
+
+
+class TestReplaceImportClearsVectors:
+    """``import_jsonl(mode='replace')`` must not leave the old vectors behind."""
+
+    def test_replace_import_deletes_vectors(self, cf_db, fake_vectorize):
+        cf_db.add("Python is a programming language", embedding=_unit(0))
+        cf_db.import_jsonl(
+            json.dumps({"id": "fresh", "content": "a fresh row"}), mode="replace"
+        )
+        assert fake_vectorize.visible == {}
+        assert [r["id"] for r in cf_db.list_memories()] == ["fresh"]
+
+    def test_merge_import_keeps_vectors(self, cf_db, fake_vectorize):
+        mid = cf_db.add("Python is a programming language", embedding=_unit(0))
+        cf_db.import_jsonl(json.dumps({"id": "extra", "content": "another row"}))
+        assert fake_vectorize.visible == {mid: _unit(0)}
+
+
+class TestVectorParityWithSqlite:
+    """The same vector scenario on both backends, results compared.
+
+    ``tests/test_db_cf.py``'s ``either_db`` runs the text-only surface against
+    both stores. This is the vector counterpart: it cannot compare scores (one
+    ranks by ``sqlite-vec`` distance, the other by Vectorize similarity) but it
+    can compare which memories come back and, where the fused scores differ at
+    all, in what order.
+
+    Exactly-tied fused scores are deliberately not compared. Two candidates that
+    are (FTS rank 1, vector rank 2) and (FTS rank 2, vector rank 1) get identical
+    RRF sums, and the stable sort then settles them on insertion order -- which
+    is Vectorize's ranking here but SQLite's table order there, because
+    ``MemoryDB.search`` re-reads its vector matches with ``WHERE id IN (...)``.
+    Asserting an order that neither backend defines would be a test of
+    coincidence. See ``MemoryDBCfBackend._vector_candidates``.
+    """
+
+    @pytest.fixture(params=["sqlite", "cf-d1"])
+    def either_vec_db(self, request, tmp_path, fake_worker, fake_vectorize):
+        if request.param == "sqlite":
+            db = MemoryDB(tmp_path / "memories.db", embedding_dims=DIMS)
+            yield db
+            db.close()
+        else:
+            db = _cf_db(fake_worker, fake_vectorize)
+            yield db
+            db.close()
+
+    def test_vector_only_recall_agrees(self, either_vec_db):
+        """Rows the FTS arm cannot reach are reached, on both backends."""
+        mid = either_vec_db.add("Python is a programming language", embedding=_unit(0))
+        other = either_vec_db.add("Remember to buy groceries", embedding=_unit(1))
+
+        assert either_vec_db.search("zzzz-unmatchable-token") == [], (
+            "precondition: the query text must be unreachable by FTS alone"
+        )
+        hits = either_vec_db.search("zzzz-unmatchable-token", embedding=_unit(0))
+        assert {h["id"] for h in hits} == {mid, other}
+
+    def test_untied_ranking_agrees(self, either_vec_db):
+        """Where the fused scores actually differ, both backends order alike.
+
+        ``mid`` is first in both arms -- it is the only text match and the exact
+        vector match -- so its RRF sum strictly beats ``other``'s and the result
+        does not depend on either backend's tie-break.
+        """
+        mid = either_vec_db.add("Python is a programming language", embedding=_unit(0))
+        other = either_vec_db.add("Remember to buy groceries", embedding=_unit(1))
+
+        hits = either_vec_db.search("Python programming", embedding=_unit(0))
+        assert [h["id"] for h in hits] == [mid, other]
+
+    def test_deleted_memory_disappears_from_both(self, either_vec_db):
+        mid = either_vec_db.add("Python is a programming language", embedding=_unit(0))
+        assert either_vec_db.delete(mid) is True
+        assert either_vec_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
+
+    def test_superseded_version_never_returns_on_either(self, either_vec_db):
+        old_id = either_vec_db.add("Python is a language", embedding=_unit(0))
+        new_id = either_vec_db.update(old_id, content="Python is a great language")
+
+        hits = either_vec_db.search("Python", embedding=_unit(0))
+        assert [h["id"] for h in hits] == [new_id]
+
+    def test_hybrid_search_returns_both_arms_on_both(self, either_vec_db):
+        text_only = either_vec_db.add(
+            "Python is a programming language", embedding=_unit(3)
+        )
+        vector_only = either_vec_db.add("totally unrelated wording", embedding=_unit(0))
+
+        found = {
+            h["id"]
+            for h in either_vec_db.search("Python programming", embedding=_unit(0))
+        }
+        assert found == {text_only, vector_only}
+
+    def test_vec_enabled_agrees(self, either_vec_db):
+        assert either_vec_db.vec_enabled is True

--- a/tests/test_db_cf_vectors.py
+++ b/tests/test_db_cf_vectors.py
@@ -750,6 +750,23 @@ class TestVectorParityWithSqlite:
     def either_vec_db(self, request, tmp_path, fake_worker, fake_vectorize):
         if request.param == "sqlite":
             db = MemoryDB(tmp_path / "memories.db", embedding_dims=DIMS)
+            if not db.vec_enabled:
+                # macOS hosted runners build Python without
+                # --enable-loadable-sqlite-extensions, so sqlite-vec cannot load
+                # and MemoryDB has no vector arm to compare against (see
+                # tests/test_db_vec_coverage.py, which documents the same
+                # constraint). Skipped rather than asserted around: forcing
+                # `_vec_enabled = True` over a stand-in table, as that file does
+                # for branch coverage, would compare this backend against a fake
+                # ranking and call the result parity. The cf-d1 half of this
+                # class still runs here; the parity claim itself rests on the
+                # runners where sqlite-vec is real.
+                db.close()
+                pytest.skip(
+                    "sqlite-vec is unavailable on this interpreter "
+                    "(sqlite3 built without loadable-extension support), so "
+                    "there is no SQLite vector arm to compare against"
+                )
             yield db
             db.close()
         else:


### PR DESCRIPTION
## What

S2 Task 4. `MemoryDBCfBackend` stored no vectors -- `add` / `add_with_context_type` / `search` / `update` raised `NotImplementedError` on any embedding, and `_drop_vectors_for_reindex` had nothing to drop. Vectors now live in a Cloudflare Vectorize index reached through `src/worker.ts`'s `vectorizeOutbound`, and `search` is hybrid FTS5(D1) + Vectorize.

Fusion is unchanged: `_compute_hybrid_scores` (RRF k=60, then `rrf_norm*0.7 + recency*0.2 + freq*0.1`) stays borrowed from `MemoryDB`, so only the *source* of the vector ranking differs and the two backends cannot drift on ranking.

`src/worker.ts` and the three `wrangler*.jsonc` files are untouched.

## The four hard spots, and what each does

**1. Vectorize serves at most 50 candidates.** `search` asks for `max(limit * 10, 50)`, so any `limit > 5` fuses a full-width FTS ranking against a 50-deep vector one. `mcp_core` 1.21.0 clamps with a bare `top_k = min(top_k, 50)` -- no exception, no warning, nothing. `_vector_candidates` compares the two numbers itself, logs a WARNING naming both, and records `last_vector_cap: VectorCandidateCap(requested, served)`.

**2. Read-after-write on the vector arm.** D1 is strongly consistent; Vectorize is not. `wait_until_indexed()` is deliberately **not** called -- it polls `GET {base}`, and `vectorizeOutbound` answers *every* GET with `{ready: true}` unconditionally, so it reports that the handler is wired, never that a mutation landed. Calling it would manufacture a false "indexed" signal. The gap is documented and asserted: a new memory is text-searchable immediately and joins the semantic ranking once Vectorize indexes it. No retry loop.

**3. Superseded rows.** Write side: `delete` / `update` delete the closed id's vector. Read side (authoritative): every id Vectorize returns is re-fetched from D1 through the same `_build_filter_sql` tail the FTS arm uses, whose first fragment is `AND m.valid_to IS NULL`. The read-side filter holds even when the write-side delete failed, which is what the correctness claim rests on -- there is a test that breaks the write side on purpose and proves the row still cannot come back.

**4. `_drop_vectors_for_reindex`** deletes real vectors now (ids read from D1, batched through `/deleteByIds`) and **propagates** failure, unlike the delete path: the guard stamps only after it returns, so raising leaves the old identity in place and the next boot retries, instead of re-stamping the new model over an index still holding the old model's vectors.

## Deliberate divergences from SQLite, all documented in docstrings

- A metadata-only `update` cannot carry the old vector forward -- Vectorize has no read-by-id, `VectorizeBackend` exposes no getter, `vectorizeOutbound` routes no such path. The successor is left unvectorised and a WARNING names the id and the reason. (`server._handle_update` re-embeds whenever `content` changes, so this is the metadata-only case.)
- A failed `/deleteByIds` after a committed D1 close logs `[AUDIT]` at ERROR and lets the row change stand, rather than reporting a delete that did take effect as failed. The orphaned vector cannot surface (see 3); it is a cleanup cost, not a correctness one.
- Vector transport errors propagate. `MemoryDB.search` wraps its vector branch in `except Exception: logger.debug(...)`, which against a network backend turns an outage into an FTS-only result set that looks healthy.
- Exactly-tied fused scores may order differently across backends: this backend preserves Vectorize's ranking as the tie-break, while `MemoryDB.search` re-reads matches with `WHERE id IN (...)` and gets table order. Only ties differ; any pair whose scores actually differ ranks the same. Fixing it would mean changing SQLite's output, so it is documented instead.
- No metadata filter is sent to Vectorize. It would need metadata indexes declared at index-creation time in wrangler and still would not be authoritative about supersession, which only D1 knows. The recall cost of filtering after the fact is stated in `_vector_candidates`.

## Notes for review

- `VectorizeBackend` (mcp_core 1.21.0) ships no delete method even though `vectorizeOutbound` routes `/deleteByIds`. `_vectorize_delete_by_ids` reuses the backend's own `_http` transport and auth headers rather than opening a second client, so the injected `http=` seam still covers every request the store makes.
- `vectorize_backend_from_env()` reads `MCP_VECTORIZE_IDX` with `[]`; the bare `KeyError` is turned into a `RuntimeError` naming the variable and the `EMBEDDING_DIMS=0` alternative.
- `tests/test_db_cf.py`'s `TestVectorPathIsLoud` previously asserted `match="Task 4"`. Those tests now assert the same loudness for the still-real text-only case (`embedding_dims=0`); the wired path is `tests/test_db_cf_vectors.py`.

## Tests

`tests/test_db_cf_vectors.py` (new, 56 tests) with a `FakeVectorizeWorker` transcribing `vectorizeOutbound` route for route, pinned against the real file by `test_fake_worker_matches_worker_ts`. It adds a two-stage index so eventual consistency is exercised deterministically instead of by sleeping, and a `fail_delete` switch so the read-side supersession filter can be tested with the write side deliberately broken. `TestVectorParityWithSqlite` runs the vector scenarios against both backends.

Full suite: 1586 passed, 5 skipped. `ruff check`, `ruff format --check`, `ty check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
