### PR TITLE
fix: serialize all 19 memories columns from one shared list

### DIFF
--- a/src/mnemo_mcp/db.py
+++ b/src/mnemo_mcp/db.py
@@ -31,6 +31,84 @@ _ALEMBIC_SCRIPT_LOCATION = Path(__file__).resolve().parent / "alembic"
 
 _STRUCT_CACHE: dict[int, struct.Struct] = {}
 
+# ---------------------------------------------------------------------------
+# The `memories` column set -- one list, shared by every path that serializes a
+# row.
+#
+# Before this existed there were three hand-written lists of different lengths
+# (export 9, import 10, sync/delta 15) against a 19-column table, so
+# `export_memories` -> `import_memories` silently dropped ten columns and still
+# reported success. The lists are gone; these constants replace all of them.
+#
+# Order and membership must equal `PRAGMA table_info(memories)` on a store built
+# by `_init_schema` + the Alembic lineage. That is asserted by
+# `tests/test_column_fidelity.py`, which fails when a migration adds a column
+# without updating this tuple -- the drift that caused the original defect.
+# `tests/test_d1_migrations.py` separately pins `migrations/0001_init.sql`
+# against the same lineage, so the D1 backend inherits the guarantee.
+#
+# Kept explicit rather than introspected from the open connection. Introspection
+# would make the serialized column set a property of whichever database happens
+# to be open: a store still missing a column would export without it and import
+# clean into a store that has it, which is the same silent data loss one layer
+# down. An explicit tuple gives the schema a second opinion to disagree with,
+# which is what makes a drift test possible at all. It also keeps
+# `_IMPORT_ROWS_PER_STATEMENT` in `db_cf` a module constant instead of coupling
+# D1 statement sizing to connection state, and avoids asking D1 -- which serves
+# a fixed SQLite subset -- for `PRAGMA table_info` at runtime.
+MEMORY_COLUMNS: tuple[str, ...] = (
+    "id",
+    "content",
+    "category",
+    "tags",
+    "source",
+    "created_at",
+    "updated_at",
+    "access_count",
+    "last_accessed",
+    "importance",
+    "context_type",
+    "archived_at",
+    "text_raw",
+    "compressed",
+    "compression_provider",
+    "commit_sha",
+    "valid_from",
+    "valid_to",
+    "superseded_by",
+)
+
+# What the importer writes when a JSONL record omits a column. Mirrors the
+# schema's own DEFAULT clauses so an import is indistinguishable from an insert
+# that never mentioned the column. `id`, `content` and `tags` are handled
+# separately (generated / validated / re-encoded), and the three timestamps
+# default to "now", which is not a constant.
+_IMPORT_TIMESTAMP_COLUMNS = frozenset({"created_at", "updated_at", "last_accessed"})
+_IMPORT_DERIVED_COLUMNS = frozenset({"id", "content", "tags"})
+_IMPORT_DEFAULTS: dict[str, object] = {
+    "category": "general",
+    "source": None,
+    "access_count": 0,
+    "importance": 0.5,
+    "context_type": "conversation",
+    "archived_at": None,
+    "text_raw": None,
+    "compressed": 0,
+    "compression_provider": None,
+    "commit_sha": None,
+    "valid_from": None,
+    "valid_to": None,
+    "superseded_by": None,
+}
+
+# `tags` holds a JSON array as TEXT. Emitting it through `json()` makes the
+# exported record carry a real array instead of a quoted string, which is the
+# shape the importer and every existing consumer expect.
+_EXPORT_JSON_OBJECT_ARGS = ", ".join(
+    f"'{column}', json({column})" if column == "tags" else f"'{column}', {column}"
+    for column in MEMORY_COLUMNS
+)
+
 # ``MemoryDB.update`` supersedes a row with a single ``UPDATE ... RETURNING *``
 # so the read and the write cannot be split by a competing writer. RETURNING
 # landed in SQLite 3.35.0 (https://sqlite.org/lang_returning.html). A Python
@@ -1436,18 +1514,12 @@ class MemoryDB:
         """
         # Bolt Performance Optimization: Offload JSON construction to SQLite.
         # Avoids O(N) Python dict creations and json.dumps calls, resulting in ~78% faster exports.
-        query = """
-            SELECT json_object(
-                'id', id,
-                'content', content,
-                'category', category,
-                'tags', json(tags),
-                'source', source,
-                'created_at', created_at,
-                'updated_at', updated_at,
-                'access_count', access_count,
-                'last_accessed', last_accessed
-            ) as json_data
+        #
+        # The argument list is generated from MEMORY_COLUMNS so the export cannot
+        # fall behind the schema; it is built once at import time from our own
+        # identifiers and never sees caller input.
+        query = f"""
+            SELECT json_object({_EXPORT_JSON_OBJECT_ARGS}) as json_data
             FROM memories
             ORDER BY created_at
         """
@@ -1516,21 +1588,16 @@ class MemoryDB:
                     else (json.dumps(tags) if isinstance(tags, list) else tags)
                 )
 
-                importance = mem.get("importance", 0.5)
-                to_insert.append(
-                    (
-                        memory_id,
-                        content,
-                        mem.get("category", "general"),
-                        tags_json,
-                        mem.get("source"),
-                        mem.get("created_at", now),
-                        mem.get("updated_at", now),
-                        mem.get("access_count", 0),
-                        mem.get("last_accessed", now),
-                        importance,
-                    )
-                )
+                derived = {"id": memory_id, "content": content, "tags": tags_json}
+                row = []
+                for column in MEMORY_COLUMNS:
+                    if column in _IMPORT_DERIVED_COLUMNS:
+                        row.append(derived[column])
+                    elif column in _IMPORT_TIMESTAMP_COLUMNS:
+                        row.append(mem.get(column, now))
+                    else:
+                        row.append(mem.get(column, _IMPORT_DEFAULTS[column]))
+                to_insert.append(tuple(row))
             except Exception:
                 rejected += 1
                 continue
@@ -1543,12 +1610,13 @@ class MemoryDB:
         if not to_insert:
             return 0, 0
         cursor = self._conn.cursor()
-        sql = """INSERT OR {} INTO memories
-                 (id, content, category, tags, source,
-                  created_at, updated_at, access_count, last_accessed, importance)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+        # Column list and placeholders come from MEMORY_COLUMNS, never from the
+        # imported records, so the statement carries no caller-controlled text.
+        columns = ", ".join(MEMORY_COLUMNS)
+        placeholders = ", ".join("?" for _ in MEMORY_COLUMNS)
         op = "REPLACE" if mode == "replace" else "IGNORE"
-        cursor.executemany(sql.format(op), to_insert)
+        sql = f"INSERT OR {op} INTO memories ({columns}) VALUES ({placeholders})"
+        cursor.executemany(sql, to_insert)
         imported = cursor.rowcount
         skipped = len(to_insert) - imported if mode != "replace" else 0
         return imported, skipped

--- a/src/mnemo_mcp/db_cf.py
+++ b/src/mnemo_mcp/db_cf.py
@@ -107,7 +107,13 @@ from loguru import logger
 from mcp_core.storage.d1 import D1Backend, d1_backend_from_env
 from mcp_core.storage.vectorize import VectorizeBackend, vectorize_backend_from_env
 
-from mnemo_mcp.db import MAX_CONTENT_LENGTH, MAX_TAGS_FILTER, MemoryDB, _now_iso
+from mnemo_mcp.db import (
+    MAX_CONTENT_LENGTH,
+    MAX_TAGS_FILTER,
+    MEMORY_COLUMNS,
+    MemoryDB,
+    _now_iso,
+)
 
 # Cloudflare D1 rejects a query carrying more than this many bound parameters.
 # https://developers.cloudflare.com/d1/platform/limits/
@@ -153,20 +159,18 @@ REQUIRED_TABLES = (
 )
 
 # Columns written by the bulk-import path, in the order `_process_import_batch`
-# emits them. Kept as a constant so the generated multi-row INSERT never
-# interpolates anything caller-controlled.
-_IMPORT_COLUMNS = (
-    "id",
-    "content",
-    "category",
-    "tags",
-    "source",
-    "created_at",
-    "updated_at",
-    "access_count",
-    "last_accessed",
-    "importance",
-)
+# emits them -- which is `MEMORY_COLUMNS`, the one list every serializer shares.
+# This used to be a hand-written copy that had fallen nine columns behind the
+# table; re-exporting the constant keeps the D1 INSERT and the SQLite one
+# writing the same row, and still interpolates nothing caller-controlled.
+_IMPORT_COLUMNS = MEMORY_COLUMNS
+
+# Rows per multi-row INSERT, sized so one statement stays inside D1's cap of 100
+# bound parameters. This divides rather than assumes: at the current 19 columns
+# it yields 5 rows (95 params). It cannot reach 0 -- that would need more than
+# `D1_MAX_BOUND_PARAMS` columns in `memories`, i.e. a table 100+ columns wide,
+# at which point a single row could not be inserted in one statement at all.
+# `tests/test_column_fidelity.py` asserts both the floor and the cap.
 _IMPORT_ROWS_PER_STATEMENT = D1_MAX_BOUND_PARAMS // len(_IMPORT_COLUMNS)
 
 _NO_VECTOR_INDEX = (

--- a/src/mnemo_mcp/sync/delta.py
+++ b/src/mnemo_mcp/sync/delta.py
@@ -16,8 +16,11 @@ row we compare ``remote.updated_at`` against ``local.updated_at``:
 
 * ``local >= remote`` -> keep local; record an audit row in
   ``sync_overrides`` so the user can inspect divergence.
-* ``local < remote`` -> upsert the remote row (compressed text + raw +
-  context_type + importance + archived_at all preserved).
+* ``local < remote`` -> upsert the remote row, every column of it: the
+  upsert writes ``db.MEMORY_COLUMNS``, so compressed text + raw +
+  context_type + importance + archived_at and the bitemporal columns
+  (``commit_sha`` / ``valid_from`` / ``valid_to`` / ``superseded_by``) all
+  survive the hop.
 * ``local missing`` -> insert the remote row.
 
 The orchestrator never blocks on conflict; LWW is automatic per row so
@@ -33,6 +36,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from mnemo_mcp.db import MEMORY_COLUMNS
 from mnemo_mcp.sync.bundle import decode_bundle, encode_bundle
 
 if TYPE_CHECKING:
@@ -175,23 +179,15 @@ async def build_full_bundle(db: MemoryDB, passphrase: str) -> bytes:
 # ---------------------------------------------------------------------------
 
 
-_INSERT_COLS = (
-    "id",
-    "content",
-    "category",
-    "tags",
-    "source",
-    "created_at",
-    "updated_at",
-    "access_count",
-    "last_accessed",
-    "importance",
-    "context_type",
-    "archived_at",
-    "text_raw",
-    "compressed",
-    "compression_provider",
-)
+# The bundle's SELECT is `SELECT *`, so a remote row arrives with every column;
+# this is the list the upsert writes back. It used to be a hand-written copy
+# that stopped at `compression_provider`, dropping the four bitemporal columns
+# `mem_003_temporal` added. That mattered more than it looks: every read path
+# starts from `AND m.valid_to IS NULL` (`db.py::_build_filter_sql`), so a
+# superseded row that arrived without its `valid_to` came back to life on the
+# receiving machine. Sharing `MEMORY_COLUMNS` keeps sync, export/import and the
+# schema on one list.
+_INSERT_COLS = MEMORY_COLUMNS
 
 
 def _ensure_overrides_table(db: MemoryDB) -> None:

--- a/tests/test_column_fidelity.py
+++ b/tests/test_column_fidelity.py
@@ -1,0 +1,384 @@
+"""Column fidelity across every path that serializes a ``memories`` row.
+
+``memories`` has 19 columns. Three separate hand-written column lists used to
+serialize it -- ``db.py::export_jsonl`` (9), the ``db.py`` /
+``db_cf.py`` import pair (10) and ``sync/delta.py::_INSERT_COLS`` (15) -- and
+none of them matched the table. Exporting and re-importing through the product's
+own tools therefore dropped columns and still answered ``{"imported": N}``.
+
+Two independent alarms live here, and both must fire when a future migration
+adds a column:
+
+* :class:`TestSerializerColumnsTrackTheSchema` compares the single
+  ``db.MEMORY_COLUMNS`` tuple that all serializers now share against the live
+  schema of a freshly built ``MemoryDB``.
+* :data:`FULL_ROW` -- the round-trip fixture -- is itself checked for
+  completeness against that same schema, so the round trip cannot silently stop
+  covering a column it never learned about.
+
+``tests/test_d1_migrations.py`` already pins ``migrations/0001_init.sql``
+against the SQLite lineage, so "schema" means the same thing on both backends
+and is not re-derived here.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import pathlib
+import sqlite3
+
+import pytest
+
+# Re-use the D1 doubles rather than describing a second, possibly different
+# Worker; `test_db_cf` imports `FakeVectorizeWorker` from its neighbour the same
+# way.
+from test_db_cf import FakeD1Worker, _cf_db
+
+from mnemo_mcp import db as db_module
+from mnemo_mcp import db_cf as db_cf_module
+from mnemo_mcp.db import MemoryDB
+from mnemo_mcp.db_cf import D1_MAX_BOUND_PARAMS
+from mnemo_mcp.sync import delta as delta_module
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
+
+
+def _schema_table_info() -> list[tuple]:
+    """``PRAGMA table_info(memories)`` as a fresh store actually builds it.
+
+    ``MemoryDB`` runs ``_init_schema`` and then walks Alembic to head, so this
+    is the end state of the whole lineage rather than any one revision.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db = MemoryDB(pathlib.Path(tmp) / "schema-probe.db", embedding_dims=0)
+        try:
+            rows = db._conn.execute("PRAGMA table_info(memories)").fetchall()
+        finally:
+            db.close()
+    return [tuple(r) for r in rows]
+
+
+def _schema_columns() -> tuple[str, ...]:
+    """Column names of ``memories``, in declaration order."""
+    return tuple(r[1] for r in _schema_table_info())
+
+
+def _parse_sql_literal(raw: str | None) -> object:
+    """Decode a ``PRAGMA table_info`` ``dflt_value`` into a Python value."""
+    if raw is None:
+        return None
+    text = raw.strip()
+    if text.upper() == "NULL":
+        return None
+    if len(text) >= 2 and text.startswith("'") and text.endswith("'"):
+        return text[1:-1].replace("''", "'")
+    for cast in (int, float):
+        try:
+            return cast(text)
+        except ValueError:
+            continue
+    return text
+
+
+def _schema_defaults() -> dict[str, object]:
+    """Each column's schema DEFAULT, decoded. ``None`` where there is none."""
+    return {r[1]: _parse_sql_literal(r[4]) for r in _schema_table_info()}
+
+
+# A memory whose every column holds a value distinguishable from that column's
+# schema default. A round trip that drops a column therefore shows up as a
+# concrete mismatch rather than as a value that happens to equal the default.
+#
+# `tags` is stored as TEXT holding JSON; `export_jsonl` emits it via `json(tags)`
+# as a real array and the importer re-encodes it, so its *text* is allowed to
+# change (separator whitespace) while its parsed value is not. Every other
+# column must survive byte-for-byte.
+FULL_ROW_ID = "fidelity-001"
+FULL_ROW: dict[str, object] = {
+    "id": FULL_ROW_ID,
+    "content": "every column of this row carries a non-default value",
+    "category": "archaeology",
+    "tags": '["alpha","beta"]',
+    "source": "column-fidelity-test",
+    "created_at": "2020-01-02T03:04:05+00:00",
+    "updated_at": "2021-02-03T04:05:06+00:00",
+    "access_count": 42,
+    "last_accessed": "2022-03-04T05:06:07+00:00",
+    "importance": 0.875,
+    "context_type": "decision",
+    "archived_at": "2023-04-05T06:07:08+00:00",
+    "text_raw": "the uncompressed original text",
+    "compressed": 1,
+    "compression_provider": "zstd-test",
+    "commit_sha": "0f1e2d3c4b5a69788796a5b4c3d2e1f001234567",
+    "valid_from": "2024-05-06T07:08:09+00:00",
+    "valid_to": "2025-06-07T08:09:10+00:00",
+    "superseded_by": "fidelity-002",
+}
+
+_JSON_VALUED_COLUMNS = frozenset({"tags"})
+
+
+@pytest.fixture(params=["sqlite", "cf-d1"])
+def db_factory(request, tmp_path):
+    """Build independent stores of one backend kind, on demand.
+
+    A round trip needs two: the store that exports and a fresh one that
+    imports. The parametrisation runs the whole scenario once per backend.
+    """
+    created = []
+    counter = itertools.count()
+
+    def make():
+        n = next(counter)
+        if request.param == "sqlite":
+            db = MemoryDB(tmp_path / f"memories-{n}.db", embedding_dims=0)
+        else:
+            conn = sqlite3.connect(tmp_path / f"d1-{n}.sqlite", isolation_level=None)
+            conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+            db = _cf_db(FakeD1Worker(conn))
+        created.append(db)
+        return db
+
+    yield make
+    for db in created:
+        db.close()
+
+
+def _insert_full_row(db, row: dict) -> None:
+    """Write ``row`` with plain SQL, bypassing ``add()``.
+
+    ``add()`` stamps its own timestamps and leaves the newer columns at their
+    defaults, which is precisely the state this test must not start from.
+    """
+    cols = ", ".join(row)
+    placeholders = ", ".join("?" for _ in row)
+    db._conn.execute(
+        f"INSERT INTO memories ({cols}) VALUES ({placeholders})",
+        tuple(row.values()),
+    )
+    db._conn.commit()
+
+
+def _read_row(db, memory_id: str) -> dict:
+    """Read a row back as a plain dict, unfiltered.
+
+    Deliberately not ``db.get()``: the read paths seed every query with
+    ``AND m.valid_to IS NULL``, and this row carries a ``valid_to``.
+    """
+    cursor = db._conn.execute("SELECT * FROM memories WHERE id = ?", (memory_id,))
+    row = cursor.fetchone()
+    assert row is not None, f"row {memory_id} missing"
+    return dict(row)
+
+
+def _diff_columns(before: dict, after: dict) -> list[str]:
+    """Names of columns whose value did not survive, most useful first."""
+    mismatched = []
+    for col, want in before.items():
+        got = after.get(col)
+        if col in _JSON_VALUED_COLUMNS:
+            same = json.loads(want) == json.loads(got) if got is not None else False
+        else:
+            same = got == want
+        if not same:
+            mismatched.append(f"{col}: exported {want!r} -> imported {got!r}")
+    return mismatched
+
+
+class TestRoundTripPreservesEveryColumn:
+    """``export_memories`` then ``import_memories`` must be lossless."""
+
+    def test_fixture_covers_every_column(self):
+        """The round-trip fixture itself must not drift behind the schema.
+
+        Without this, a migration that adds a column would leave the round trip
+        quietly untested for it.
+        """
+        schema = set(_schema_columns())
+        assert set(FULL_ROW) == schema, (
+            "FULL_ROW no longer matches the `memories` schema; "
+            f"missing from fixture: {sorted(schema - set(FULL_ROW))}, "
+            f"unknown to schema: {sorted(set(FULL_ROW) - schema)}"
+        )
+
+    def test_export_then_import_preserves_all_columns(self, db_factory):
+        source = db_factory()
+        _insert_full_row(source, FULL_ROW)
+
+        payload, count = source.export_jsonl()
+        assert count == 1
+
+        target = db_factory()
+        result = target.import_jsonl(payload, mode="merge")
+        assert result["imported"] == 1, result
+
+        mismatched = _diff_columns(FULL_ROW, _read_row(target, FULL_ROW_ID))
+        assert not mismatched, (
+            f"{len(mismatched)} of {len(FULL_ROW)} columns lost in the "
+            "export -> import round trip:\n  " + "\n  ".join(mismatched)
+        )
+
+    def test_exported_json_carries_every_column(self, db_factory):
+        """The dropped columns must be absent from the payload, not just the
+        target row -- otherwise the loss is blamed on the importer alone."""
+        source = db_factory()
+        _insert_full_row(source, FULL_ROW)
+
+        payload, _ = source.export_jsonl()
+        record = json.loads(payload.splitlines()[0])
+
+        missing = sorted(set(FULL_ROW) - set(record))
+        assert not missing, f"export_jsonl omitted {len(missing)} columns: {missing}"
+
+
+class TestSerializerColumnsTrackTheSchema:
+    """The drift alarm.
+
+    This is the test that stops the defect class from coming back: a migration
+    that adds a column to ``memories`` turns it red until ``MEMORY_COLUMNS``
+    and the importer's default for the new column are supplied.
+    """
+
+    def test_memory_columns_match_the_live_schema(self):
+        schema = _schema_columns()
+        assert db_module.MEMORY_COLUMNS == schema, (
+            "db.MEMORY_COLUMNS drifted from the `memories` schema.\n"
+            f"  in the schema but not serialized: {[c for c in schema if c not in db_module.MEMORY_COLUMNS]}\n"
+            f"  serialized but not in the schema: {[c for c in db_module.MEMORY_COLUMNS if c not in schema]}\n"
+            "Add the column to MEMORY_COLUMNS (same order as the table) and give "
+            "it an entry in db._IMPORT_DEFAULTS."
+        )
+
+    def test_every_serializer_uses_the_one_list(self):
+        """No path may keep a private copy -- that is what drifted before."""
+        assert db_cf_module._IMPORT_COLUMNS is db_module.MEMORY_COLUMNS
+        assert delta_module._INSERT_COLS is db_module.MEMORY_COLUMNS
+
+    def test_export_sql_selects_every_column(self):
+        """``export_jsonl`` builds its ``json_object`` from the shared list."""
+        args = db_module._EXPORT_JSON_OBJECT_ARGS
+        for column in db_module.MEMORY_COLUMNS:
+            assert f"'{column}'" in args, f"export omits {column}"
+        assert "'tags', json(tags)" in args, "tags must export as a JSON array"
+
+    def test_every_column_has_exactly_one_import_rule(self):
+        """A new column must not silently fall through to a KeyError at import.
+
+        The three rule sets have to partition ``MEMORY_COLUMNS``: derived
+        (generated or validated), timestamp (defaults to "now"), or a static
+        default.
+        """
+        derived = db_module._IMPORT_DERIVED_COLUMNS
+        timestamps = db_module._IMPORT_TIMESTAMP_COLUMNS
+        defaults = set(db_module._IMPORT_DEFAULTS)
+
+        covered = derived | timestamps | defaults
+        assert covered == set(db_module.MEMORY_COLUMNS), (
+            f"no import rule for: {sorted(set(db_module.MEMORY_COLUMNS) - covered)}; "
+            f"rule for unknown column: {sorted(covered - set(db_module.MEMORY_COLUMNS))}"
+        )
+        overlaps = (
+            (derived & timestamps) | (derived & defaults) | (timestamps & defaults)
+        )
+        assert not overlaps, f"columns claimed by two import rules: {sorted(overlaps)}"
+
+    def test_import_defaults_match_the_schema_defaults(self):
+        """An omitted column must land on the value the schema would have used.
+
+        Keeps the hand-written default table honest: change a DEFAULT clause in
+        a migration and this fails rather than letting imports write a value the
+        table never would.
+        """
+        schema_defaults = _schema_defaults()
+        wrong = {
+            column: (expected, schema_defaults[column])
+            for column, expected in db_module._IMPORT_DEFAULTS.items()
+            if schema_defaults[column] != expected
+        }
+        assert not wrong, (
+            "db._IMPORT_DEFAULTS disagrees with the schema DEFAULT clauses "
+            f"(column: importer -> schema): {wrong}"
+        )
+
+
+class TestD1StatementSizing:
+    """``_IMPORT_ROWS_PER_STATEMENT`` is ``100 // len(MEMORY_COLUMNS)``.
+
+    It recomputes itself when a column is added, but "recomputes" is not the
+    same as "stays valid", so both ends are pinned.
+    """
+
+    def test_rows_per_statement_cannot_reach_zero(self):
+        """Zero rows per statement would make ``import_jsonl`` a silent no-op.
+
+        Reaching it needs ``len(MEMORY_COLUMNS) > D1_MAX_BOUND_PARAMS`` -- a
+        `memories` table more than 100 columns wide, where a single row could
+        not be inserted in one statement either. Asserted on the real value and
+        on the headroom, so a column-adding migration that approaches the cliff
+        fails here first.
+        """
+        assert db_cf_module._IMPORT_ROWS_PER_STATEMENT >= 1
+        assert len(db_module.MEMORY_COLUMNS) <= D1_MAX_BOUND_PARAMS, (
+            f"`memories` now has {len(db_module.MEMORY_COLUMNS)} columns, more than D1's "
+            f"{D1_MAX_BOUND_PARAMS}-bound-parameter cap; a single-row INSERT no "
+            "longer fits in one statement and the bulk import needs rethinking"
+        )
+
+    def test_widest_statement_stays_within_the_cap(self):
+        widest = db_cf_module._IMPORT_ROWS_PER_STATEMENT * len(db_module.MEMORY_COLUMNS)
+        assert widest <= D1_MAX_BOUND_PARAMS, (
+            f"{db_cf_module._IMPORT_ROWS_PER_STATEMENT} rows x "
+            f"{len(db_module.MEMORY_COLUMNS)} columns = {widest} bound parameters, over "
+            f"D1's cap of {D1_MAX_BOUND_PARAMS}"
+        )
+
+
+class TestDeltaSyncPreservesBitemporalColumns:
+    """``sync/delta.py`` dropped the four ``mem_003_temporal`` columns.
+
+    Every read path starts from ``AND m.valid_to IS NULL``, so a superseded row
+    that crossed the wire without its ``valid_to`` came back to life on the
+    receiving machine.
+    """
+
+    def test_superseded_row_stays_superseded_after_sync(self, tmp_path):
+        local = MemoryDB(tmp_path / "local.db", embedding_dims=0)
+        try:
+            memory_id = local.add("a claim about resurrection", category="general")
+            local._conn.execute(
+                "UPDATE memories SET updated_at = ? WHERE id = ?",
+                ("2020-01-01T00:00:00+00:00", memory_id),
+            )
+            local._conn.commit()
+
+            # The same row as another machine has it: superseded, and newer.
+            remote = dict(_read_row(local, memory_id))
+            remote.update(
+                {
+                    "updated_at": "2030-01-01T00:00:00+00:00",
+                    "valid_to": "2030-01-01T00:00:00+00:00",
+                    "superseded_by": "successor-row",
+                    "commit_sha": "a" * 40,
+                    "valid_from": "2019-01-01T00:00:00+00:00",
+                }
+            )
+
+            assert delta_module._upsert_row_lww(local, remote) == "updated"
+
+            applied = _read_row(local, memory_id)
+            assert applied["valid_to"] == "2030-01-01T00:00:00+00:00"
+            assert applied["superseded_by"] == "successor-row"
+            assert applied["commit_sha"] == "a" * 40
+            assert applied["valid_from"] == "2019-01-01T00:00:00+00:00"
+
+            hits = local.search("resurrection")
+            assert [h["id"] for h in hits] == [], (
+                "a superseded row resurfaced in search after sync"
+            )
+        finally:
+            local.close()


### PR DESCRIPTION
## The defect

`memories` has 19 columns. Three separate hand-written column lists serialized it, each a different length, and none matched the table:

| Location | Columns |
|---|---|
| `migrations/0001_init.sql` table def | **19** (the truth) |
| `db.py::export_jsonl` (`json_object(...)`) | 9 |
| `db.py::_process_import_batch` + `_execute_import_batch` | 10 |
| `db_cf.py::_IMPORT_COLUMNS` | 10 |
| `sync/delta.py::_INSERT_COLS` | 15 |

A user who ran the product's own `export_memories` and then `import_memories` lost **10 of 19 columns** and got `{"imported": N}` back.

On the sync path the four bitemporal columns were dropped on the *insert* side only -- the bundle's SELECT is `SELECT *`, so the data crossed the wire and was discarded on arrival. That is worse than it looks: `db.py::_build_filter_sql` seeds every query with an unconditional `AND m.valid_to IS NULL`, so a superseded row that landed without its `valid_to` **came back to life** on the receiving machine. `sync/delta.py`'s module docstring meanwhile claimed "context_type + importance + archived_at all preserved".

## The fix

The root cause is drift between hand-maintained lists and the schema, so this is one list rather than three corrections. `db.MEMORY_COLUMNS` is the single source of truth:

- `export_jsonl` generates its `json_object` argument list from it
- the importer builds both its row tuples and its `INSERT` from it
- `db_cf._IMPORT_COLUMNS` and `sync/delta._INSERT_COLS` re-export it instead of keeping copies (asserted by identity, not equality)
- `_IMPORT_DEFAULTS` gives each column the value the schema's own `DEFAULT` clause would have used when a record omits it -- and that table is itself checked against `PRAGMA table_info`, so changing a `DEFAULT` in a migration fails the suite rather than letting imports write a value the table never would

### Why an explicit tuple and not schema introspection

Introspection (`PRAGMA table_info` at open time) was the obvious alternative and is rejected for four reasons:

1. **It relocates the bug rather than removing it.** Introspection makes the serialized column set a property of whichever database happens to be open. A store still missing a column would export without it and import perfectly cleanly into a store that has it -- the same silent data loss, one layer down, now invisible because both ends "agree".
2. **It is untestable for drift.** The whole point of the drift test is to have two independent statements of the truth that can disagree. Introspection has only one, so the test would be comparing the schema against itself.
3. **`_IMPORT_ROWS_PER_STATEMENT` must stay a module constant.** Deriving the column count from a live connection would couple D1 statement sizing to connection state.
4. **D1 serves a fixed SQLite subset.** Asking it for `PRAGMA table_info` at runtime adds a per-backend code path -- reintroducing exactly the divergence being removed.

## The drift test

`tests/test_column_fidelity.py`. A test that merely passes today is not worth writing, so I verified it fires by adding a throwaway Alembic migration (`retention_policy`) and running the suite. **Three alarms went red**, each with an actionable message:

```
E  AssertionError: db.MEMORY_COLUMNS drifted from the `memories` schema.
E      in the schema but not serialized: ['retention_policy']
E      serialized but not in the schema: []
E    Add the column to MEMORY_COLUMNS (same order as the table) and give it an entry in db._IMPORT_DEFAULTS.

E  AssertionError: FULL_ROW no longer matches the `memories` schema; missing from fixture: ['retention_policy'], unknown to schema: []

E  AssertionError: memories drifted from db.py / Alembic; update migrations/0001_init.sql   <- pre-existing test_d1_migrations check
```

And with the column added to `MEMORY_COLUMNS` but no default registered:

```
E  AssertionError: no import rule for: ['retention_policy']; rule for unknown column: []
```

The probe was reverted; `git status --porcelain` is clean.

## D1 bound-parameter arithmetic

`_IMPORT_ROWS_PER_STATEMENT = D1_MAX_BOUND_PARAMS // len(_IMPORT_COLUMNS)` recomputes itself, but "recomputes" is not "stays valid", so both ends are now pinned:

```
len(MEMORY_COLUMNS)          = 19
D1_MAX_BOUND_PARAMS          = 100
_IMPORT_ROWS_PER_STATEMENT   = 100 // 19 = 5
widest statement             = 5 * 19 = 95 params (cap 100)
```

**It cannot reach 0.** That would require `len(MEMORY_COLUMNS) > 100`, i.e. a `memories` table more than 100 columns wide -- at which point a *single* row could not be inserted in one statement either, and the bulk import needs rethinking rather than a smaller chunk. `test_rows_per_statement_cannot_reach_zero` asserts the floor and that headroom, so a column-adding migration approaching the cliff fails here first.

The existing `test_import_respects_d1_bound_parameter_cap` **passes unchanged** -- I did not have to touch it, because it asserts a bound (`widest <= 100`) rather than an exact width.

## Evidence

RED, with `git diff origin/main --stat -- src/` empty (source byte-identical to main), both backends:

```
tests/.../test_export_then_import_preserves_all_columns[sqlite] FAILED
tests/.../test_export_then_import_preserves_all_columns[cf-d1]  FAILED
tests/.../test_exported_json_carries_every_column[sqlite]       FAILED
tests/.../test_exported_json_carries_every_column[cf-d1]        FAILED

E  AssertionError: 10 of 19 columns lost in the export -> import round trip:
E      importance: exported 0.875 -> imported 0.5
E      context_type: exported 'decision' -> imported 'conversation'
E      archived_at: exported '2023-04-05T06:07:08+00:00' -> imported None
E      text_raw: exported 'the uncompressed original text' -> imported None
E      compressed: exported 1 -> imported 0
E      compression_provider: exported 'zstd-test' -> imported None
E      commit_sha: exported '0f1e2d3c4b5a69788796a5b4c3d2e1f001234567' -> imported None
E      valid_from: exported '2024-05-06T07:08:09+00:00' -> imported None
E      valid_to: exported '2025-06-07T08:09:10+00:00' -> imported None
E      superseded_by: exported 'fidelity-002' -> imported None

E  AssertionError: export_jsonl omitted 10 columns: ['archived_at', 'commit_sha',
   'compressed', 'compression_provider', 'context_type', 'importance',
   'superseded_by', 'text_raw', 'valid_from', 'valid_to']
```

The round-trip tests resolve implementation constants through their module rather than importing them at module scope, specifically so this file still collects against the pre-fix tree and the RED above is reproducible with a `git stash` of `src/`.

GREEN, same tests: **13 passed**, including the sync scenario `test_superseded_row_stays_superseded_after_sync`, which asserts a superseded row does not resurface in `search()` after a delta-sync hop.

Full suite, both backends exercised via the `sqlite` / `cf-d1` parametrisation:

```
origin/main baseline:  1586 passed, 5 skipped, 78 deselected
this branch:           1599 passed, 5 skipped, 78 deselected
```

+13 is exactly the 13 new tests. No pre-existing test changed or broke. `ruff check`, `ruff format --check` and `ty check` all clean; all 14 pre-commit hooks passed.

## Scope

Four files: `db.py`, `db_cf.py`, `sync/delta.py`, and the new test. `worker.ts` and the wrangler files untouched. The `sync/delta.py` docstring that falsely claimed preservation is corrected in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
