### PR TITLE
fix: block outbound network in tests and bound the embedding availability probe

### DIFF
--- a/src/mnemo_mcp/embedder.py
+++ b/src/mnemo_mcp/embedder.py
@@ -31,6 +31,18 @@ from loguru import logger
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.0  # seconds, doubles each retry
 
+# Wall-clock bound on the availability probe (``check_available``).
+# ``config(action="setup_complete")`` awaits that probe before it returns, so
+# without a bound a slow or blackholed provider makes the user's tool call hang
+# for as long as the provider takes. CI run 30755522961 lost its windows-latest
+# job to exactly that: the probe stalled reading response headers for longer
+# than the 30s pytest-timeout. litellm's own default is 600s, which is not a
+# bound anyone waits through interactively -- a probe only has to answer
+# "reachable?", so it gets a short one.
+# This bounds one attempt, not the whole probe: some provider SDKs retry
+# underneath litellm and start the clock again for each try.
+PROBE_TIMEOUT = 10.0  # seconds
+
 
 # Bolt Performance Optimization: Use module-level constant tuple to avoid
 # redundant list allocations during frequent calls, resulting in ~15% faster execution.
@@ -274,8 +286,12 @@ class CloudEmbeddingBackend:
         """Sync cloud path for ``check_available`` (sync mirror).
 
         Keep in sync with :meth:`_call_provider`: same model/api_base/api_key
-        resolution + ``_build_kwargs`` + ``_parse_embeddings``; only the
-        sync ``embedding`` vs async ``aembedding`` call differs.
+        resolution + ``_build_kwargs`` + ``_parse_embeddings``; only the sync
+        ``embedding`` vs async ``aembedding`` call and the ``timeout`` differ.
+        The timeout is deliberately one-sided: this path only ever serves the
+        availability probe, which must answer within ``PROBE_TIMEOUT``, while
+        :meth:`_call_provider` carries real batches whose legitimate duration
+        scales with the payload.
         """
         from mcp_core.llm import embedding
 
@@ -284,6 +300,7 @@ class CloudEmbeddingBackend:
             input=texts,
             api_base=self.api_base or os.getenv("EMBEDDING_API_BASE") or None,
             api_key=self.api_key or None,
+            timeout=PROBE_TIMEOUT,
             **self._build_kwargs(dimensions),
         )
         return _parse_embeddings(response)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@
 # module-level ``patch("importlib.metadata.version")``. Once fastmcp is
 # cached in sys.modules, later imports skip its ``__init__`` (which would
 # otherwise try to resolve its own version via the leaked mock).
+import ipaddress
+import os
+import socket
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -14,6 +17,142 @@ import pytest
 from mnemo_mcp.db import MemoryDB
 
 pytest_plugins = ["conftest_e2e"]
+
+# litellm downloads model_prices_and_context_window.json from raw.githubusercontent
+# the first time it is imported. It ships the same file inside the wheel and this
+# env var selects that copy, so the import stops depending on the network. Set at
+# module scope because litellm reads it during ``litellm.__init__``, which the
+# lazy imports in embedder.py can trigger from the first test that runs.
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+
+# ---------------------------------------------------------------------------
+# Outbound network guard
+# ---------------------------------------------------------------------------
+
+# Markers for tests that are allowed to reach the real internet. Every one of
+# them is deselected by ``addopts`` in pyproject.toml, but each must still run
+# when it is selected by hand (``pytest -m live`` and friends).
+_NETWORK_MARKERS = ("integration", "live", "full", "e2e")
+
+# Names that resolve to this machine. Numeric addresses are classified by
+# ``ipaddress`` rather than listed here.
+_LOOPBACK_HOSTNAMES = frozenset(
+    {"localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"}
+)
+
+
+class OutboundNetworkBlocked(BaseException):
+    """A test tried to open a connection that leaves this machine.
+
+    Derived from ``BaseException`` -- not ``Exception`` -- for the same reason
+    ``pytest.fail`` is: the leak this guard was written for runs inside two
+    nested ``except Exception`` handlers (``CloudEmbeddingBackend
+    .check_available`` returns 0, ``server._init_embedding_backend`` logs a
+    warning), and an ``Exception`` here is swallowed by both. The test then
+    passes while still having gone to the network, which is the failure mode
+    the guard exists to remove.
+    """
+
+
+def _host_text(host: object) -> str:
+    """Normalise a host as it may arrive at the socket layer.
+
+    anyio hands ``getaddrinfo`` an ASCII-encoded host, so ``bytes`` has to be
+    decoded rather than ``str()``-ed: ``str(b"127.0.0.1")`` is
+    ``"b'127.0.0.1'"``, which parses as no address at all and would get
+    loopback blocked on every async client in the suite.
+    """
+    if isinstance(host, bytes | bytearray):
+        host = bytes(host).decode("ascii", "replace")
+    return str(host).strip("[]")
+
+
+def _is_local_host(host: object) -> bool:
+    """True when ``host`` cannot address a peer outside this machine.
+
+    ``None`` and ``""`` are the wildcard forms passed when binding a listener,
+    and ``0.0.0.0`` / ``::`` are the unspecified addresses -- none of them name
+    a remote peer, so all stay allowed alongside the loopback range.
+    """
+    if host is None or host == "" or host == b"":
+        return True
+    text = _host_text(host)
+    if text in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        address = ipaddress.ip_address(text)
+    except ValueError:
+        return False
+    return address.is_loopback or address.is_unspecified
+
+
+def _blocked(host: object, port: object) -> OutboundNetworkBlocked:
+    return OutboundNetworkBlocked(
+        f"Blocked outbound network access to {_host_text(host)}:{port} "
+        "from a unit test.\n"
+        "Unit tests must not talk to the internet. Patch the boundary the "
+        "call crosses instead -- e.g. patch('mnemo_mcp.embedder.init_backend') "
+        "when a server action initialises an embedding backend, or "
+        "patch('mcp_core.llm.embedding') / patch('mcp_core.llm.aembedding') "
+        "for a direct litellm call. A test that genuinely needs the network "
+        "belongs behind one of the @pytest.mark."
+        f"{{{','.join(_NETWORK_MARKERS)}}} markers."
+    )
+
+
+@pytest.fixture(autouse=True)
+def _block_outbound_network(request, monkeypatch):
+    """Fail fast, on every OS, when a unit test reaches the real internet.
+
+    CI run 30755522961 lost its windows-latest job to the 30s pytest-timeout:
+    ``test_server_setup_actions.py::TestSetupComplete::test_refreshes_state``
+    drove ``config(action="setup_complete")`` through
+    ``_init_embedding_backend`` into ``CloudEmbeddingBackend.check_available``,
+    which issued a real HTTPS POST via litellm and then stalled reading the
+    response headers. ``_DEFAULT_EMBEDDING_CHAIN`` in config.py starts at a
+    ``jina_ai/`` model, so no env var is needed for a unit test to leave the
+    box. The same request failed fast on Linux, which is why a missing patch
+    looked like a Windows-only flake for as long as it did.
+
+    Blocking the syscall converts that whole class of leak into an immediate
+    and identical failure everywhere. Loopback stays open on purpose: tests
+    that stand up a local server (relay, OAuth callback) must keep working.
+    """
+    if any(request.node.get_closest_marker(m) for m in _NETWORK_MARKERS):
+        return
+
+    real_getaddrinfo = socket.getaddrinfo
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+
+    def _check_address(address: object) -> None:
+        # AF_UNIX addresses are str/bytes paths and never leave the machine.
+        if not isinstance(address, tuple) or not address:
+            return
+        host = address[0]
+        port = address[1] if len(address) > 1 else None
+        if not _is_local_host(host):
+            raise _blocked(host, port)
+
+    def guarded_getaddrinfo(host, port, *args, **kwargs):
+        # Resolution is guarded too, so the error can name the host the caller
+        # asked for rather than whichever address DNS happened to return.
+        if not _is_local_host(host):
+            raise _blocked(host, port)
+        return real_getaddrinfo(host, port, *args, **kwargs)
+
+    def guarded_connect(self, address, *args, **kwargs):
+        _check_address(address)
+        return real_connect(self, address, *args, **kwargs)
+
+    def guarded_connect_ex(self, address, *args, **kwargs):
+        _check_address(address)
+        return real_connect_ex(self, address, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", guarded_getaddrinfo)
+    monkeypatch.setattr(socket.socket, "connect", guarded_connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", guarded_connect_ex)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -209,7 +209,13 @@ class TestApiKeys:
 
     def test_multiple_keys(self):
         s = Settings(api_keys="GOOGLE_API_KEY:key1,OPENAI_API_KEY:key2")
-        result = s.setup_api_keys()
+        # patch.dict for the same reason as the neighbours: setup_api_keys
+        # exports into the real os.environ, and a GOOGLE_API_KEY left behind
+        # here aliases to GEMINI_API_KEY, so every later test whose subject
+        # skips when no LLM provider is configured instead resolves one and
+        # calls the provider for real.
+        with patch.dict(os.environ):
+            result = s.setup_api_keys()
         assert len(result) == 2
         assert "GOOGLE_API_KEY" in result
         assert "OPENAI_API_KEY" in result
@@ -233,14 +239,16 @@ class TestApiKeys:
 
     def test_whitespace_handling(self):
         s = Settings(api_keys="  GOOGLE_API_KEY : key1 , OPENAI_API_KEY : key2  ")
-        result = s.setup_api_keys()
+        with patch.dict(os.environ):
+            result = s.setup_api_keys()
         assert "GOOGLE_API_KEY" in result
         assert result["GOOGLE_API_KEY"] == ["key1"]
 
     def test_colon_in_key_value(self):
         """API keys can contain colons (e.g., base64-encoded keys)."""
         s = Settings(api_keys="GOOGLE_API_KEY:abc:def:ghi")
-        result = s.setup_api_keys()
+        with patch.dict(os.environ):
+            result = s.setup_api_keys()
         assert result["GOOGLE_API_KEY"] == ["abc:def:ghi"]
 
     def test_alias_google_to_gemini(self):

--- a/tests/test_credential_state_multi_user.py
+++ b/tests/test_credential_state_multi_user.py
@@ -8,6 +8,7 @@ counts toward the default coverage gate.
 from __future__ import annotations
 
 import hashlib
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -110,6 +111,11 @@ def test_save_credentials_multi_user_triggers_gdrive_per_sub(tmp_path, monkeypat
         return _FakeResponse()
 
     monkeypatch.setattr("httpx.post", _fake_post)
+    # Only the device-code request goes through httpx.post. On a 200 the flow
+    # also spawns a daemon thread that polls Google's token endpoint over its
+    # own AsyncClient, which outlives this test and reaches the real internet;
+    # stub the thread the way the single-user tests already do.
+    monkeypatch.setattr("threading.Thread", MagicMock())
 
     from mnemo_mcp.credential_state import save_credentials
 

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -5,11 +5,16 @@ patch ``mcp_core.llm.aembedding``; ``check_available`` (sync) patches the sync
 mirror ``mcp_core.llm.embedding``.
 """
 
+import socket
+import threading
+import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from mnemo_mcp import embedder
 from mnemo_mcp.embedder import (
     CloudEmbeddingBackend,
     LiteLLMBackend,
@@ -18,6 +23,38 @@ from mnemo_mcp.embedder import (
     get_backend,
     init_backend,
 )
+
+
+@contextmanager
+def _stalled_endpoint():
+    """Serve a loopback address that accepts connections and never replies.
+
+    This is the shape of provider outage the availability probe has to survive:
+    the TCP handshake succeeds, so nothing fails fast, and the client then waits
+    on response headers that never arrive.
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(8)
+    accepted: list[socket.socket] = []
+
+    def _accept_and_ignore() -> None:
+        while True:
+            try:
+                conn, _ = listener.accept()
+            except OSError:
+                return
+            accepted.append(conn)
+
+    thread = threading.Thread(target=_accept_and_ignore, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{listener.getsockname()[1]}"
+    finally:
+        listener.close()
+        for conn in accepted:
+            conn.close()
+        thread.join(timeout=5)
 
 
 def _resp(*vectors):
@@ -110,6 +147,50 @@ class TestCloudEmbeddingBackend:
         with patch("mcp_core.llm.embedding", mock):
             backend = CloudEmbeddingBackend(api_key="key")
             assert backend.check_available() == 0
+
+    def test_check_available_passes_probe_timeout(self):
+        """The probe hands litellm an explicit bound instead of its 600s default."""
+        mock = MagicMock(return_value=_resp([0.1, 0.2]))
+        with patch("mcp_core.llm.embedding", mock):
+            backend = CloudEmbeddingBackend(api_key="key")
+            assert backend.check_available() == 2
+        assert mock.call_args.kwargs["timeout"] == embedder.PROBE_TIMEOUT
+
+    def test_check_available_gives_up_on_a_stalled_provider(self, monkeypatch):
+        """The probe returns instead of hanging when the provider never answers.
+
+        Regression cover for the hang in CI run 30755522961: check_available
+        called litellm with no timeout, so a provider that accepted the socket
+        and then went quiet held the caller -- and, through
+        config(action="setup_complete"), the user's tool call -- open
+        indefinitely. The server here is the minimal reproduction of that: it
+        completes the TCP handshake and sends nothing back, ever.
+        """
+        # vet_api_base only permits a loopback api_base outside multi-user mode.
+        monkeypatch.delenv("PUBLIC_URL", raising=False)
+        monkeypatch.setattr(embedder, "PROBE_TIMEOUT", 1.0)
+
+        # litellm's first import in a process costs ~10s and would otherwise be
+        # charged to the measurement below.
+        import litellm  # noqa: F401
+
+        with _stalled_endpoint() as api_base:
+            backend = CloudEmbeddingBackend(
+                model="openai/text-embedding-3-small",
+                api_base=api_base,
+                api_key="key",
+            )
+            started = time.monotonic()
+            dims = backend.check_available()
+            elapsed = time.monotonic() - started
+
+        assert dims == 0
+        # Generous next to the 1.0s bound because the provider SDK retries the
+        # attempt, and each retry gets its own timeout -- see the note on
+        # PROBE_TIMEOUT. The point being pinned is the order of magnitude:
+        # without any timeout the call sits on litellm's 600s default, which
+        # the 30s pytest-timeout turns into the same red job this fix is for.
+        assert elapsed < 10, f"probe ran for {elapsed:.1f}s"
 
     def test_litellm_backward_compat_alias(self):
         """LiteLLMBackend is an alias for CloudEmbeddingBackend."""

--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -1,0 +1,101 @@
+"""Tests for the autouse outbound-network guard in ``conftest.py``.
+
+The guard is the reason a unit test can no longer stall on a real HTTPS
+request (CI run 30755522961). It only pays for itself if it keeps blocking
+what leaves the machine and keeps allowing what does not, so both halves are
+pinned here -- a guard that quietly starts rejecting loopback would break the
+tests that stand up a local relay / OAuth-callback server.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from contextlib import contextmanager
+
+import anyio
+import pytest
+from conftest import OutboundNetworkBlocked, _is_local_host
+
+
+@contextmanager
+def _listener():
+    """A loopback listener that accepts one connection and closes it."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+
+    def _accept() -> None:
+        try:
+            conn, _ = server.accept()
+            conn.close()
+        except OSError:
+            pass
+
+    thread = threading.Thread(target=_accept, daemon=True)
+    thread.start()
+    try:
+        yield server.getsockname()[1]
+    finally:
+        server.close()
+        thread.join(timeout=5)
+
+
+class TestBlocksOutbound:
+    def test_getaddrinfo_of_a_remote_name_is_blocked(self):
+        with pytest.raises(OutboundNetworkBlocked) as exc:
+            socket.getaddrinfo("api.jina.ai", 443)
+        assert "api.jina.ai" in str(exc.value)
+
+    def test_connect_to_a_remote_address_is_blocked(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            with pytest.raises(OutboundNetworkBlocked) as exc:
+                sock.connect(("140.82.121.4", 443))
+        assert "140.82.121.4" in str(exc.value)
+
+    def test_message_names_the_host_and_how_to_fix_it(self):
+        with pytest.raises(OutboundNetworkBlocked) as exc:
+            socket.getaddrinfo("oauth2.googleapis.com", 443)
+        message = str(exc.value)
+        assert "oauth2.googleapis.com:443" in message
+        assert "patch(" in message
+        assert "integration" in message
+
+
+class TestAllowsLoopback:
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",
+            "127.0.0.53",
+            "::1",
+            "localhost",
+            b"127.0.0.1",
+            b"localhost",
+            None,
+            "",
+        ],
+    )
+    def test_local_hosts_classify_as_local(self, host):
+        assert _is_local_host(host) is True
+
+    @pytest.mark.parametrize("host", ["api.jina.ai", "8.8.8.8", b"api.jina.ai"])
+    def test_remote_hosts_classify_as_remote(self, host):
+        assert _is_local_host(host) is False
+
+    def test_sync_connect_to_loopback_succeeds(self):
+        with _listener() as port:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.connect(("127.0.0.1", port))
+
+    async def test_async_connect_to_loopback_succeeds(self):
+        """anyio ASCII-encodes a hostname before resolving it.
+
+        ``str(b"localhost")`` is ``"b'localhost'"``, so a guard that stringifies
+        instead of decoding blocks every async loopback client that connects by
+        name -- which is what httpx and the relay tests do -- while still
+        looking correct against the IP literals above.
+        """
+        with _listener() as port:
+            stream = await anyio.connect_tcp("localhost", port)
+            await stream.aclose()

--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -42,22 +42,29 @@ def _listener():
 
 
 class TestBlocksOutbound:
+    # Asserted with startswith rather than `in`: the host has to be the one the
+    # caller asked for and it has to be where the message says it is. A
+    # containment check would also pass on a message that merely mentioned the
+    # host somewhere, and CodeQL reads that shape as URL sanitization.
     def test_getaddrinfo_of_a_remote_name_is_blocked(self):
         with pytest.raises(OutboundNetworkBlocked) as exc:
             socket.getaddrinfo("api.jina.ai", 443)
-        assert "api.jina.ai" in str(exc.value)
+        assert str(exc.value).startswith(
+            "Blocked outbound network access to api.jina.ai:443"
+        )
 
     def test_connect_to_a_remote_address_is_blocked(self):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             with pytest.raises(OutboundNetworkBlocked) as exc:
                 sock.connect(("140.82.121.4", 443))
-        assert "140.82.121.4" in str(exc.value)
+        assert str(exc.value).startswith(
+            "Blocked outbound network access to 140.82.121.4:443"
+        )
 
-    def test_message_names_the_host_and_how_to_fix_it(self):
+    def test_message_says_how_to_fix_it(self):
         with pytest.raises(OutboundNetworkBlocked) as exc:
-            socket.getaddrinfo("oauth2.googleapis.com", 443)
+            socket.getaddrinfo("dns.google", 443)
         message = str(exc.value)
-        assert "oauth2.googleapis.com:443" in message
         assert "patch(" in message
         assert "integration" in message
 

--- a/tests/test_per_plugin_storage_migration.py
+++ b/tests/test_per_plugin_storage_migration.py
@@ -20,6 +20,8 @@ invisible to the other -- silently breaking 6 unrelated tests in
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 
 def test_loads_from_new_path(tmp_path, monkeypatch):
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
@@ -50,7 +52,12 @@ def test_save_writes_to_new_path(tmp_path, monkeypatch):
     # Simulate calling save_credentials from the local OAuth form
     import mnemo_mcp.credential_state as cs
 
-    cs.save_credentials({"GEMINI_API_KEY": "saved-key"}, {})
+    # save_credentials also kicks off the GDrive Device Code flow, which POSTs
+    # to oauth2.googleapis.com whenever GOOGLE_DRIVE_CLIENT_ID/SECRET happen to
+    # be set in the environment. This test is about the storage path, so the
+    # flow is stubbed to keep it off the network and identical on every machine.
+    with patch.object(cs, "_trigger_gdrive_flow", return_value=None):
+        cs.save_credentials({"GEMINI_API_KEY": "saved-key"}, {})
 
     from mcp_core.storage.per_plugin_store import PerPluginStore
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -566,10 +566,21 @@ class TestEnrichMemory:
         """Cover lines 384-386: importance scoring error is non-blocking."""
         ctx, db = ctx_with_db
         mid = db.add("test memory")
-        with patch(
-            "mnemo_mcp.graph.score_importance",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("api error"),
+        with (
+            patch(
+                "mnemo_mcp.graph.score_importance",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("api error"),
+            ),
+            # The importance failure is swallowed and _enrich_memory carries on
+            # into extraction, so that leg needs a stand-in too -- unpatched it
+            # issues a live LLM request, exactly as the sibling tests below
+            # already assume.
+            patch(
+                "mnemo_mcp.graph.extract_entities",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
         ):
             # Should not raise
             await _enrich_memory(db, mid, "test memory")

--- a/tests/test_server_setup_actions.py
+++ b/tests/test_server_setup_actions.py
@@ -152,9 +152,19 @@ class TestSetupReset:
 
 
 class TestSetupComplete:
-    async def test_refreshes_state(self, ctx_with_db):
+    @patch("mnemo_mcp.embedder.init_backend")
+    async def test_refreshes_state(self, mock_init, ctx_with_db):
         """setup_complete re-resolves credential state."""
         ctx, _ = ctx_with_db
+
+        # A CONFIGURED state sends setup_complete through
+        # _init_embedding_backend, so init_backend has to be patched here for
+        # the same reason it is in test_reinits_embedding_when_configured
+        # below: unpatched, check_available issues a live HTTPS request to the
+        # first model of _DEFAULT_EMBEDDING_CHAIN.
+        mock_backend = MagicMock()
+        mock_backend.check_available.return_value = 768
+        mock_init.return_value = mock_backend
 
         with patch(
             "mnemo_mcp.credential_state.resolve_credential_state",


### PR DESCRIPTION
## What broke

CI run [30755522961](https://github.com/n24q02m/mnemo-mcp/actions/runs/30755522961) lost its `Lint & Test (windows-latest)` job to the 30s pytest-timeout. The stalled test was `tests/test_server_setup_actions.py::TestSetupComplete::test_refreshes_state`, and the traced chain is:

```
test_refreshes_state
  -> config(action="setup_complete")
  -> server.py  _handle_config_setup_complete: state == CONFIGURED and ctx is not None
  -> server.py  _init_embedding_backend
  -> embedder.py  check_available()
  -> embedder.py  _call_provider_sync(["test"])
  -> mcp_core/llm/dispatch.py  litellm.embedding(...)
  -> a real HTTPS POST
  -> stalled in httpcore _receive_response_headers  (>30s)
```

`config.py` `_DEFAULT_EMBEDDING_CHAIN` starts at `jina_ai/jina-embeddings-v5-text-small`, so no env var is needed for a unit test to reach the internet. On Linux that request failed fast and CI stayed green, which is why the leak read as a Windows-only flake rather than a missing patch.

## Layer 1 -- unit tests reached the real internet

`test_refreshes_state` now patches `mnemo_mcp.embedder.init_backend`, matching `test_reinits_embedding_when_configured` in the same class, which already did so for this exact reason.

The general fix is an autouse guard in `tests/conftest.py` that blocks `socket.socket.connect`, `connect_ex` and `socket.getaddrinfo` for any non-loopback host:

- **Loopback stays open.** `127.0.0.0/8`, `::1`, `localhost`, the unspecified addresses and AF_UNIX paths are all allowed, so tests that stand up a local server keep working. `tests/test_network_guard.py` pins both directions rather than assuming them.
- **`integration` / `live` / `full` / `e2e` are exempt.** All four are deselected by `addopts` but must still run when selected by hand. `e2e` is included on the same reasoning as the other three.
- **It derives from `BaseException`.** An `Exception` here is swallowed by `check_available` (returns 0) and again by `_init_embedding_backend` (logs a warning), so the test passes while still having gone to the network. This is the same reason `pytest.fail` raises a `BaseException`.
- **The message names the blocked host and what to patch**, since the next person to read it is the person hitting it.
- **litellm's bundled cost map is selected** via `LITELLM_LOCAL_MODEL_COST_MAP`, so `import litellm` stops fetching `model_prices_and_context_window.json` from raw.githubusercontent.

The guard then found four more leaks of the same class, all fixed here:

| Test | Leak |
|---|---|
| `test_config.py` `TestApiKeys` (x3) | `setup_api_keys()` exported fake `GOOGLE_API_KEY` (aliased to `GEMINI_API_KEY`) into the real `os.environ` and left it there. Every later provider-gated test then resolved a provider and called it for real -- this is what made `test_memory_compress_no_provider_returns_skipped` reach Google. |
| `test_server.py::TestEnrichMemory::test_enrich_importance_error` | Patched `score_importance` but not `extract_entities`, which `_enrich_memory` calls next. |
| `test_per_plugin_storage_migration.py::test_save_writes_to_new_path` | `save_credentials` fires the GDrive device-code POST to `oauth2.googleapis.com` whenever `GOOGLE_DRIVE_CLIENT_ID`/`SECRET` are in the environment. |
| `test_credential_state_multi_user.py::test_save_credentials_multi_user_triggers_gdrive_per_sub` | Mocked the device-code POST but not the daemon thread it spawns, which polled Google's token endpoint on its own `AsyncClient` and outlived the test. |

## Layer 2 -- the production probe had no time limit

`_call_provider_sync` called `embedding(...)` with no `timeout`, so it inherited litellm's 600s default. `config(action="setup_complete")` awaits that probe directly, so a slow or blackholed provider hangs the user's tool call.

It now passes `PROBE_TIMEOUT` (10s). The `embedding()` signature was checked against the installed wheel at `.venv/Lib/site-packages/mcp_core/llm/dispatch.py`, not the dev source tree: it forwards `**kwargs` to `litellm.embedding`, whose `timeout` parameter defaults to 600.

`_call_provider_sync`'s docstring promises to stay in sync with `_call_provider`, so it now records the one deliberate difference: only the sync path serves the probe, while the async twin carries real batches whose duration legitimately scales with the payload. `_call_provider` is left unchanged.

## Verification

Each property was shown red before green; full output is in the PR thread.

1. **Guard has teeth** -- with `test_refreshes_state` still unpatched it fails immediately (17s, of which ~11s is litellm's first import) instead of hanging, pointing at `embedder.py:410` -> `dispatch.py:216` -> `conftest.py guarded_getaddrinfo`.
2. **`pytest tests/test_server_setup_actions.py -v`** -- 17 passed.
3. **Full default run** -- 1613 passed, 4 skipped, 78 deselected, 0 failed. No residual guard hits and no unhandled-thread warnings. Runtime dropped from 295s to 179s once the leaked network calls stopped.
4. **Timeout has teeth** -- `test_check_available_gives_up_on_a_stalled_provider` points the probe at a loopback listener that completes the handshake and never answers. With the fix it returns 0 in a bounded time; with `timeout=PROBE_TIMEOUT` removed it hangs in `_receive_response_headers` -> `_sock.recv` -- the same frame as the CI incident -- until pytest-timeout kills it at 30s.

## Notes

- `PROBE_TIMEOUT` bounds one attempt, not the whole probe: some provider SDKs retry underneath litellm and restart the clock per try. Documented at the constant. Bounded either way, which is the property the incident needed.
- No `.jules/sentinel.md` entry: every entry there carries a `**Vulnerability:**` field and the file is a security-finding ledger. This is a reliability and test-hygiene fix, so filing it there would miscategorise it. Happy to add one if you read the remit differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
