### PR TITLE
fix: report the store config status actually read, not the SQLite path

### DIFF
--- a/src/mnemo_mcp/docs/config.md
+++ b/src/mnemo_mcp/docs/config.md
@@ -27,7 +27,8 @@ Returns database stats, embedding model info, and sync status.
 **Parameters:** None
 
 **Returns:**
-- `db_path`: Path to SQLite database
+- `path`: The store the counts were read from -- the SQLite file, or
+  `cf-d1:<base-url>` when `MEMORY_DB_BACKEND=cf-d1`
 - `total_memories`: Total memory count
 - `categories`: Memory count by category
 - `embedding`: Model name, dimensions, availability

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -1840,7 +1840,11 @@ async def _handle_config_status(ctx: Context | None) -> dict[str, typing.Any]:
     s = await asyncio.to_thread(db.stats)
     return {
         "database": {
-            "path": str(settings.get_db_path()),
+            # The store that answered, not the SQLite path config would use:
+            # under MEMORY_DB_BACKEND=cf-d1 the counts below come from D1 and
+            # settings.get_db_path() names a container file holding none of
+            # them. Same source as memory_stats, so the two cannot disagree.
+            "path": s["db_path"],
             "total_memories": s["total_memories"],
             "categories": s["categories"],
             "vec_enabled": s["vec_enabled"],

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -41,6 +41,7 @@ import re
 import sqlite3
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -98,8 +99,15 @@ def d1_conn(tmp_path) -> sqlite3.Connection:
     behaves: every statement is committed on its own and there is no
     client-side transaction to roll back. sqlite-vec is never loaded, matching
     D1's inability to load extensions.
+
+    ``check_same_thread=False`` because the real D1 is reached over HTTP and so
+    is thread-agnostic: server handlers call the store through
+    ``asyncio.to_thread``, and pysqlite's default thread check would fail the
+    double where the wire would not.
     """
-    conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
+    conn = sqlite3.connect(
+        tmp_path / "d1.sqlite", isolation_level=None, check_same_thread=False
+    )
     conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
     return conn
 
@@ -746,6 +754,57 @@ class TestBackendSelection:
             assert db._recency_half_life == 3.0
         finally:
             db.close()
+
+
+class TestStatusNamesTheStoreItRead:
+    """``config(action="status")`` must name the store it actually queried.
+
+    It used to print ``settings.get_db_path()`` -- the SQLite path -- whatever
+    ``MEMORY_DB_BACKEND`` selected, so a D1-backed deployment reported a file
+    inside its container while serving memories that live in D1. The field is a
+    diagnostic, so a backend-blind value sends the next investigation to the
+    wrong store.
+    """
+
+    @staticmethod
+    def _ctx(db):
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {
+            "db": db,
+            "embedding_model": None,
+            "embedding_dims": 0,
+        }
+        return ctx
+
+    async def test_sqlite_status_names_the_sqlite_file(self, sqlite_db, tmp_path):
+        from mnemo_mcp.server import _handle_config_status
+
+        status = await _handle_config_status(self._ctx(sqlite_db))
+        assert status["database"]["path"] == str(tmp_path / "memories.db")
+
+    async def test_cf_d1_status_names_d1_not_a_sqlite_file(self, cf_db):
+        from mnemo_mcp.config import settings
+        from mnemo_mcp.server import _handle_config_status
+
+        status = await _handle_config_status(self._ctx(cf_db))
+        assert status["database"]["path"] == "cf-d1:http://d1.internal"
+        # The regression this pins: the SQLite path from settings, which a D1
+        # deployment never opens.
+        assert status["database"]["path"] != str(settings.get_db_path())
+
+    async def test_status_and_memory_stats_cannot_disagree(self, either_db):
+        """The invariant the bug broke: one container, one answer.
+
+        ``memory_stats`` and ``config status`` read the same store in the same
+        process, so they may not name two different ones.
+        """
+        from mnemo_mcp.server import _handle_config_status, _handle_stats
+
+        ctx = self._ctx(either_db)
+        status = await _handle_config_status(ctx)
+        stats = await _handle_stats(ctx)
+        assert status["database"]["path"] == stats["db_path"]
+        assert status["database"]["total_memories"] == stats["total_memories"]
 
 
 def test_docs_db_backend_is_gone_from_the_repo():


### PR DESCRIPTION
## The bug, measured live

On `v2.8.0-beta.1` deployed to Cloudflare (`MEMORY_DB_BACKEND=cf-d1`), two tools
in the same container at the same moment:

- `memory_stats` -> `{"total_memories":286, ..., "db_path":"cf-d1:http://d1.internal"}`
- `config action=status` -> `{"database":{"path":"/data/memories.db","total_memories":286,...}}`

Both read D1 (the 286 agree), but `config status` named a SQLite file inside the
container that holds none of those memories. The cause is one line in
`_handle_config_status`:

```python
"path": str(settings.get_db_path()),
```

`settings.get_db_path()` returns the SQLite path regardless of
`MEMORY_DB_BACKEND` -- a constant dressed up as an observation. This field is a
diagnostic, so leaving it backend-blind sends the next investigation to the
wrong store.

## The fix

The handler already had the honest value in hand: it calls `db.stats()`, and
`stats()["db_path"]` is the SQLite path on `MemoryDB` (`db.py`) and
`cf-d1:<base-url>` on `MemoryDBCfBackend` (`db_cf.py`, which reuses
`MemoryDB.stats`). That is the same source `memory_stats` reports, so reading it
here makes the two tools structurally unable to disagree.

The key stays `path`. `git grep` found exactly one reader of
`database["path"]` -- `tests/test_server.py:396` -- and nothing in the docs, the
Worker TS, or the scripts, so a rename would have bought nothing and broken a
consumer for it.

## Tests

Red before, green after, and pinned in both directions -- one direction alone is
half a guard, since it stays green while the other side regresses:

- `test_sqlite_status_names_the_sqlite_file` -- under SQLite, `path` is the file
  the store opened.
- `test_cf_d1_status_names_d1_not_a_sqlite_file` -- under cf-d1, `path` is the D1
  URL and is not `settings.get_db_path()`.
- `test_status_and_memory_stats_cannot_disagree` (both backends) -- the invariant
  this bug broke: one container, one answer.

Before the fix, all four cases failed, e.g.

```
E   AssertionError: assert 'C:\Users\n...\memories.db' == 'cf-d1:http://d1.internal'
4 failed, 105 deselected
```

After: `1617 passed, 4 skipped, 78 deselected` (pytest) and `15 passed` (vitest).

The D1 double now opens its SQLite stand-in with `check_same_thread=False`: the
handlers reach the store through `asyncio.to_thread`, and the real D1 is an HTTP
hop with no thread affinity, so pysqlite's default check would fail the double
where the wire would not.

`src/mnemo_mcp/docs/config.md` documented the returned key as
"`db_path`: Path to SQLite database" -- wrong on both the name and the store, and
it is the doc for the action being fixed, so it now describes what the field
actually carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
