### PR TITLE
fix: name the store the startup log counted, not the SQLite path

### DIFF
--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -283,8 +283,11 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
         reindex_on_model_change=settings.reindex_on_model_change,
     )
     stats = db.stats()
+    # The store that answered, not the SQLite path the config asked for: the
+    # count beside it comes from whatever open_memory_db selected, so under
+    # cf-d1 db_path names a container file holding none of these memories.
     logger.info(
-        f"Database: {db_path} ({stats['total_memories']} memories, "
+        f"Database: {stats['db_path']} ({stats['total_memories']} memories, "
         f"vec={'on' if db.vec_enabled else 'off'})"
     )
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,11 +1,24 @@
 """Tests for server lifespan management."""
 
 import asyncio
+import pathlib
+import sqlite3
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from loguru import logger
+
+# The Cloudflare doubles live with the suites that pin them against
+# ``src/worker.ts``; importing them here keeps one description of the Worker.
+from test_db_cf import FakeD1Worker
+from test_db_cf_vectors import FakeVectorizeWorker
 
 from mnemo_mcp.server import lifespan
+
+_MIGRATION = (
+    pathlib.Path(__file__).resolve().parent.parent / "migrations" / "0001_init.sql"
+)
 
 
 @pytest.fixture
@@ -30,7 +43,13 @@ def mock_db():
     # site to intercept.
     with patch("mnemo_mcp.server.open_memory_db") as m:
         db_instance = MagicMock()
-        db_instance.stats.return_value = {"total_memories": 10, "vec_enabled": True}
+        # db_path is part of what stats() always returns, on both backends; the
+        # startup banner reads it, so a stub without it describes no real store.
+        db_instance.stats.return_value = {
+            "total_memories": 10,
+            "vec_enabled": True,
+            "db_path": "test.db",
+        }
         db_instance.vec_enabled = True
         m.return_value = db_instance
         yield m
@@ -193,3 +212,116 @@ async def test_lifespan_all_backends_fail(
 
     # Should still init DB
     mock_db.return_value.stats.assert_called()
+
+
+@pytest.fixture
+def startup_logs() -> Generator[list[str]]:
+    """Collect loguru messages; loguru does not route through pytest's caplog."""
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]),
+        level="INFO",
+        format="{message}",
+    )
+    yield messages
+    logger.remove(sink_id)
+
+
+@pytest.fixture
+def real_store_settings(mock_settings):
+    """``mock_settings`` with the values ``open_memory_db`` really consumes.
+
+    The other tests here never build a store, so the MagicMock defaults are
+    enough for them; a real one divides by ``recency_half_life_days`` and
+    stamps ``embedding_primary()`` into the store, neither of which survives
+    being a MagicMock.
+    """
+    mock_settings.recency_half_life_days = 7.0
+    mock_settings.reindex_on_model_change = False
+    mock_settings.embedding_primary.return_value = "test-model"
+    return mock_settings
+
+
+def _banner(messages: list[str]) -> str:
+    return next(m for m in messages if m.startswith("Database: "))
+
+
+class TestStartupLogNamesTheStoreItRead:
+    """The startup banner must name the store its memory count came from.
+
+    It printed ``settings.get_db_path()`` next to counts read from whichever
+    backend ``MEMORY_DB_BACKEND`` selected, so a D1 deployment announced a
+    SQLite file inside its container. This is the first line anyone reads when
+    asking "where is my data", which is the worst place to be wrong.
+
+    Both tests let ``open_memory_db`` run for real -- a mocked ``stats()`` would
+    only prove the log prints whatever the mock was told to say.
+    """
+
+    @pytest.fixture
+    def cf_d1_store(self, tmp_path, monkeypatch) -> Generator[None]:
+        """Point ``MEMORY_DB_BACKEND=cf-d1`` at the in-process D1 double."""
+        from mcp_core.storage.d1 import D1Backend
+        from mcp_core.storage.vectorize import VectorizeBackend
+
+        conn = sqlite3.connect(
+            tmp_path / "d1.sqlite", isolation_level=None, check_same_thread=False
+        )
+        conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+        monkeypatch.setenv("MEMORY_DB_BACKEND", "cf-d1")
+        monkeypatch.setattr(
+            "mnemo_mcp.db_cf.d1_backend_from_env",
+            lambda: D1Backend(base_url="http://d1.internal", http=FakeD1Worker(conn)),
+        )
+        monkeypatch.setattr(
+            "mnemo_mcp.db_cf._vectorize_from_env",
+            lambda: VectorizeBackend(
+                base_url="http://vectorize.internal",
+                idx="mnemo-test",
+                http=FakeVectorizeWorker(),
+            ),
+        )
+        yield
+        conn.close()
+
+    async def test_cf_d1_startup_log_does_not_name_the_sqlite_file(
+        self,
+        real_store_settings,
+        cf_d1_store,
+        mock_embedder,
+        mock_sync,
+        startup_logs,
+    ):
+        # The path the Cloudflare container is configured with and never opens.
+        sqlite_path = pathlib.Path("/data/memories.db")
+        real_store_settings.get_db_path.return_value = sqlite_path
+
+        async with lifespan(MagicMock()):
+            pass
+
+        banner = _banner(startup_logs)
+        assert "cf-d1:http://d1.internal" in banner
+        assert str(sqlite_path) not in banner
+
+    async def test_sqlite_startup_log_names_the_sqlite_file(
+        self,
+        real_store_settings,
+        tmp_path,
+        monkeypatch,
+        mock_embedder,
+        mock_sync,
+        startup_logs,
+    ):
+        """The other half of the guard: SQLite must still name its file.
+
+        Reading the store's own answer has to stay honest in both directions --
+        a fix that only ever printed the D1 URL would pass the test above.
+        """
+        monkeypatch.delenv("MEMORY_DB_BACKEND", raising=False)
+        sqlite_path = tmp_path / "memories.db"
+        real_store_settings.get_db_path.return_value = sqlite_path
+
+        async with lifespan(MagicMock()):
+            pass
+
+        assert str(sqlite_path) in _banner(startup_logs)


### PR DESCRIPTION
## The bug

Follow-up to #1055, same class of lie one layer earlier. `lifespan` logs:

```python
db_path = settings.get_db_path()
db = open_memory_db(db_path, ...)
stats = db.stats()
logger.info(f"Database: {db_path} ({stats['total_memories']} memories, ...")
```

The count comes from whichever store `open_memory_db` selected; the path comes
from settings and is always the SQLite one. On the deployed `MEMORY_DB_BACKEND=cf-d1`
container that reads:

```
Database: /data/memories.db (286 memories, vec=on)
```

about a file holding none of those 286. Startup logs are the first thing anyone
reads when asking "where is my data", so this one misleads at the worst possible
moment.

## The fix

`stats` is computed on the line immediately **above** the log -- verified in the
code, not assumed -- so no reordering is needed:

```python
f"Database: {stats['db_path']} ..."
```

`stats['db_path']` is the store's own answer: the SQLite path on `MemoryDB`,
`cf-d1:<base-url>` on `MemoryDBCfBackend`. `db_path` stays where it belongs, as
the argument `open_memory_db` selects from.

## Other sites of the same shape: none

`git grep -n "get_db_path" origin/main -- src/mnemo_mcp/` returns four call
sites; `server.py:274` was the only diagnostic. The rest name a real local file
and are correct as they are:

- `config.py:238` (`get_data_dir`) -- parent dir for tokens and passport exports
- `sync/gdrive.py:634` -- the SQLite file genuinely being pushed to / pulled from Drive
- `server.py:2190` (`get_data_dir`) -- the directory the passport is actually written to

`grep "Database:"` across `src/` finds one log line, the one fixed here.
`cli.py` never touches the db path.

## Tests

Red before the fix, and reproducing the production symptom literally:

```
FAILED tests/test_lifespan.py::TestStartupLogNamesTheStoreItRead::test_cf_d1_startup_log_does_not_name_the_sqlite_file
E   AssertionError: assert 'cf-d1:http://d1.internal' in 'Database: \data\memories.db (0 memories, vec=on)'
1 failed, 1 passed, 6 deselected
```

Both tests let `open_memory_db` run for real -- the cf-d1 one drives a genuine
`MemoryDBCfBackend` over the `FakeD1Worker` / `FakeVectorizeWorker` doubles that
are pinned against `src/worker.ts` in their own suites. Stubbing `stats()` would
only have proved the log prints whatever the stub was told to say.

The SQLite direction passes before the fix -- that is precisely where the old
code accidentally agreed with itself -- and is kept so that a "fix" which just
printed the D1 URL cannot pass.

The shared `mock_db` stub in this module gained `db_path`: `stats()` always
returns it on both backends, so a stub without it describes a store that does
not exist. Six existing tests in the file caught that immediately with
`KeyError: 'db_path'`, which is the stub being wrong rather than the code being
brittle -- no `.get()` default, since a default here is another value that lies.

After: `1619 passed, 4 skipped, 78 deselected` (pytest) and `15 passed` (vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
