### PR TITLE
fix: isolate Cloudflare memory state per subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,6 @@ wrangler.deploy.jsonc
 .wrangler/
 .wrangler-dryrun/
 scripts/.mnemo_cf_token
+scripts/.wet_cf_token
 node_modules/
 package-lock.json

--- a/migrations/0002_per_sub_isolation.sql
+++ b/migrations/0002_per_sub_isolation.sql
@@ -1,0 +1,219 @@
+-- 0002_per_sub_isolation.sql -- add request-sub tenancy to the D1 schema.
+--
+-- 0001 is already live in some databases. SQLite cannot add a composite
+-- primary key with ALTER TABLE, so this migration rebuilds the affected tables
+-- into temporary tables, copies every existing row into the explicit legacy
+-- scope `default`, and recreates the FTS/index contract.
+
+DROP TRIGGER IF EXISTS memories_ai;
+DROP TRIGGER IF EXISTS memories_ad;
+DROP TRIGGER IF EXISTS memories_au;
+DROP TABLE IF EXISTS memories_fts;
+
+CREATE TABLE memories_v2 (
+    sub TEXT NOT NULL DEFAULT 'default',
+    id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    category TEXT NOT NULL DEFAULT 'general',
+    tags TEXT NOT NULL DEFAULT '[]',
+    source TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT NOT NULL,
+    importance REAL NOT NULL DEFAULT 0.5,
+    context_type TEXT NOT NULL DEFAULT 'conversation',
+    archived_at DATETIME,
+    text_raw TEXT,
+    compressed BOOLEAN NOT NULL DEFAULT 0,
+    compression_provider TEXT,
+    commit_sha TEXT,
+    valid_from DATETIME,
+    valid_to DATETIME,
+    superseded_by TEXT,
+    PRIMARY KEY (sub, id)
+);
+
+INSERT INTO memories_v2 (
+    sub, id, content, category, tags, source, created_at, updated_at,
+    access_count, last_accessed, importance, context_type, archived_at,
+    text_raw, compressed, compression_provider, commit_sha, valid_from,
+    valid_to, superseded_by
+)
+SELECT
+    'default', id, content, category, tags, source, created_at, updated_at,
+    access_count, last_accessed, importance, context_type, archived_at,
+    text_raw, compressed, compression_provider, commit_sha, valid_from,
+    valid_to, superseded_by
+FROM memories;
+
+CREATE TABLE archived_memories_v2 (
+    sub TEXT NOT NULL DEFAULT 'default',
+    id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    category TEXT NOT NULL DEFAULT 'general',
+    tags TEXT NOT NULL DEFAULT '[]',
+    source TEXT,
+    importance REAL NOT NULL DEFAULT 0.5,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed TEXT NOT NULL,
+    archived_at TEXT NOT NULL,
+    PRIMARY KEY (sub, id)
+);
+
+INSERT INTO archived_memories_v2 (
+    sub, id, content, category, tags, source, importance, created_at,
+    updated_at, access_count, last_accessed, archived_at
+)
+SELECT
+    'default', id, content, category, tags, source, importance, created_at,
+    updated_at, access_count, last_accessed, archived_at
+FROM archived_memories;
+
+CREATE TABLE memory_entities_v2 (
+    sub TEXT NOT NULL DEFAULT 'default',
+    id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (sub, id)
+);
+
+INSERT INTO memory_entities_v2 (
+    sub, id, name, entity_type, created_at, updated_at
+)
+SELECT 'default', id, name, entity_type, created_at, updated_at
+FROM memory_entities;
+
+CREATE TABLE memory_edges_v2 (
+    sub TEXT NOT NULL DEFAULT 'default',
+    id TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    target_id TEXT NOT NULL,
+    relation_type TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    memory_id TEXT,
+    valid_from DATETIME,
+    valid_to DATETIME,
+    PRIMARY KEY (sub, id),
+    FOREIGN KEY (sub, source_id)
+        REFERENCES memory_entities_v2(sub, id) ON DELETE CASCADE,
+    FOREIGN KEY (sub, target_id)
+        REFERENCES memory_entities_v2(sub, id) ON DELETE CASCADE
+);
+
+INSERT INTO memory_edges_v2 (
+    sub, id, source_id, target_id, relation_type, created_at, memory_id,
+    valid_from, valid_to
+)
+SELECT
+    'default', id, source_id, target_id, relation_type, created_at, memory_id,
+    valid_from, valid_to
+FROM memory_edges;
+
+CREATE TABLE memory_entity_links_v2 (
+    sub TEXT NOT NULL DEFAULT 'default',
+    memory_id TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    PRIMARY KEY (sub, memory_id, entity_id),
+    FOREIGN KEY (sub, memory_id)
+        REFERENCES memories_v2(sub, id) ON DELETE CASCADE,
+    FOREIGN KEY (sub, entity_id)
+        REFERENCES memory_entities_v2(sub, id) ON DELETE CASCADE
+);
+
+INSERT INTO memory_entity_links_v2 (sub, memory_id, entity_id)
+SELECT 'default', memory_id, entity_id
+FROM memory_entity_links;
+
+CREATE TABLE store_meta_v2 (
+    sub TEXT NOT NULL DEFAULT 'default',
+    key TEXT NOT NULL,
+    value TEXT,
+    PRIMARY KEY (sub, key)
+);
+
+INSERT INTO store_meta_v2 (sub, key, value)
+SELECT 'default', key, value
+FROM store_meta;
+
+DROP TABLE memory_entity_links;
+DROP TABLE memory_edges;
+DROP TABLE memory_entities;
+DROP TABLE archived_memories;
+DROP TABLE memories;
+DROP TABLE store_meta;
+
+ALTER TABLE memories_v2 RENAME TO memories;
+ALTER TABLE archived_memories_v2 RENAME TO archived_memories;
+ALTER TABLE memory_entities_v2 RENAME TO memory_entities;
+ALTER TABLE memory_edges_v2 RENAME TO memory_edges;
+ALTER TABLE memory_entity_links_v2 RENAME TO memory_entity_links;
+ALTER TABLE store_meta_v2 RENAME TO store_meta;
+
+CREATE INDEX idx_memories_sub_category
+    ON memories(sub, category);
+CREATE INDEX idx_memories_sub_updated
+    ON memories(sub, updated_at);
+CREATE INDEX idx_memories_sub_accessed
+    ON memories(sub, last_accessed);
+CREATE INDEX idx_memories_sub_category_updated
+    ON memories(sub, category, updated_at DESC);
+
+CREATE INDEX idx_archived_memories_sub_archived_at
+    ON archived_memories(sub, archived_at DESC);
+
+CREATE UNIQUE INDEX idx_memory_entities_sub_name_type
+    ON memory_entities(sub, name, entity_type);
+
+CREATE INDEX idx_memory_edges_sub_source
+    ON memory_edges(sub, source_id);
+CREATE INDEX idx_memory_edges_sub_target
+    ON memory_edges(sub, target_id);
+CREATE UNIQUE INDEX idx_memory_edges_sub_unique
+    ON memory_edges(sub, source_id, target_id, relation_type);
+
+CREATE INDEX idx_memory_entity_links_sub_entity_id
+    ON memory_entity_links(sub, entity_id);
+
+CREATE TABLE sync_state (
+    sub TEXT NOT NULL DEFAULT 'default',
+    backend TEXT NOT NULL,
+    last_sync_at REAL,
+    last_commit_sha TEXT,
+    upload_cursor INTEGER,
+    PRIMARY KEY (sub, backend)
+);
+
+CREATE VIRTUAL TABLE memories_fts
+USING fts5(
+    id UNINDEXED,
+    content,
+    category UNINDEXED,
+    tags,
+    content=memories,
+    content_rowid=rowid,
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, id, content, tags)
+    VALUES (new.rowid, new.id, new.content, new.tags);
+END;
+
+CREATE TRIGGER memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, id, content, tags)
+    VALUES ('delete', old.rowid, old.id, old.content, old.tags);
+END;
+
+CREATE TRIGGER memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, id, content, tags)
+    VALUES ('delete', old.rowid, old.id, old.content, old.tags);
+    INSERT INTO memories_fts(rowid, id, content, tags)
+    VALUES (new.rowid, new.id, new.content, new.tags);
+END;
+
+INSERT INTO memories_fts(memories_fts) VALUES ('rebuild');

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -16,8 +16,8 @@ mnemo/imagine/email CF harnesses):
                        forwarded JINA from os.environ, so a real user must submit one.
                        The harness submits whatever key skret /wet-mcp/prod injects.
   4. token          -- POST /token (code + verifier) -> bearer JWT
-  5. tool call      -- config(status) + search(action="search"); assert the search
-                       path resolves real results (URLs) over the CF deployment.
+  5. tool call      -- config(status) + unique add/search/delete round-trip over
+                       the deployed D1/Vectorize path.
 
 Secrets from env: Gate A login password MCP_RELAY_PASSWORD (or RELAY_PW) from skret
 /oci-vm-prod/prod (infra-shared); >=1 provider key (JINA_AI_API_KEY preferred) from
@@ -29,8 +29,8 @@ Run modes:
                        (recreate-gate setup half of the state-survives-recreate test).
   --auth-only          replay the SAME token (same sub) and search again WITHOUT
                        re-saving (recreate-gate verify: the sub vault survived KV).
-  --two-sub-isolation  two distinct subs; assert each authorizes to a distinct sub
-                       (the relay-login mints a fresh random sub per /authorize).
+  --two-sub-isolation  two distinct subs; sub B must not find sub A's unique marker
+                       before B creates and searches its own marker.
 
 Examples:
   skret run -e prod --path=/oci-vm-prod/prod -- \
@@ -54,11 +54,13 @@ import secrets
 import sys
 import time
 import urllib.parse
+from dataclasses import dataclass
 from pathlib import Path
 
 DEFAULT_ENDPOINT = "https://mnemo.n24q02m.com"
 
-# A unique marker memory added then searched to exercise the D1 FTS round-trip.
+# Stable prefix retained for recognizable harness data; each probe appends a
+# cryptographically random suffix so independent runs cannot deduplicate.
 MARKER = "cf-canary-probe-mnemo"
 
 
@@ -215,19 +217,79 @@ async def _call(s, label, tool, args, *, retries=20, delay=8):
     return None
 
 
-def _assert_search_resolved(txt: str | None) -> None:
-    """A real round-trip returns the just-added marker memory. An error string
-    (D1 / Vectorize misconfig) surfaces here -- a genuine CF-deployment finding."""
-    assert txt is not None, (
-        "search_memory returned no payload (gave up while not ready)"
+@dataclass(frozen=True)
+class _SearchProbe:
+    marker: str
+    memory_id: str
+    search_text: str | None
+
+
+def _new_marker(scope: str = "roundtrip") -> str:
+    return f"{MARKER}-{scope}-{secrets.token_hex(8)}"
+
+
+def _tool_payload(txt: str | None, operation: str) -> dict:
+    assert txt is not None, f"{operation} returned no payload"
+    try:
+        payload = _json.loads(txt)
+    except _json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"{operation} returned non-JSON payload: {txt[:300]}"
+        ) from exc
+    assert isinstance(payload, dict), f"{operation} returned a non-object payload"
+    assert not payload.get("error"), f"{operation} returned an error: {txt[:300]}"
+    return payload
+
+
+def _memory_id(payload: dict, operation: str) -> str:
+    memory_id = payload.get("id") or payload.get("memory_id")
+    assert isinstance(memory_id, str) and memory_id, (
+        f"{operation} did not return an exact memory id"
     )
-    assert not txt.lower().startswith("error"), (
-        f"search_memory returned an error: {txt[:300]}"
+    return memory_id
+
+
+def _search_results(txt: str | None) -> list[dict]:
+    payload = _tool_payload(txt, "search_memory")
+    results = payload.get("results")
+    assert isinstance(results, list), "search_memory did not return a results list"
+    assert all(isinstance(result, dict) for result in results), (
+        "search_memory returned a non-object result"
     )
-    assert MARKER in txt, f"search_memory did not return the added marker: {txt[:300]}"
+    return results
+
+
+def _assert_search_resolved(
+    txt: str | None,
+    marker: str = MARKER,
+    memory_id: str | None = None,
+) -> None:
+    """Require the exact added memory and its unique marker in search results."""
+    results = _search_results(txt)
+    result_text = _json.dumps(results, ensure_ascii=False)
+    assert any(
+        (
+            memory_id is None
+            or result.get("id") == memory_id
+            or result.get("memory_id") == memory_id
+        )
+        and marker in _json.dumps(result, ensure_ascii=False)
+        for result in results
+    ), f"search_memory did not return the added marker/id: {result_text[:300]}"
     print(
         "ASSERT OK: add_memory -> search_memory round-trip resolved over the CF deployment."
     )
+
+
+def _assert_search_absent(txt: str | None, marker: str) -> None:
+    """Require that search results contain no trace of a marker."""
+    results = _search_results(txt)
+    result_text = _json.dumps(results, ensure_ascii=False)
+    assert marker not in result_text, (
+        "isolation failure: search_memory returned sub A marker for sub B: "
+        f"{result_text[:300]}"
+    )
+    print("ASSERT OK: sub B search did not return sub A marker.")
 
 
 async def _session(endpoint: str, token: str):
@@ -239,15 +301,62 @@ async def _session(endpoint: str, token: str):
     ), ClientSession
 
 
-async def _run_search(s) -> str | None:
-    # mnemo round-trip: add a marker memory, then search for it over D1 FTS.
-    await _call(
+async def _delete_memory(s, memory_id: str) -> None:
+    txt = await _call(
         s,
-        "ADD_MEMORY",
-        "add_memory",
-        {"content": f"protocol self-test memory {MARKER}"},
+        "DELETE_MEMORY",
+        "delete_memory",
+        {"memory_id": memory_id},
+        retries=5,
+        delay=2,
     )
-    return await _call(s, "SEARCH_MEMORY", "search_memory", {"query": MARKER})
+    payload = _tool_payload(txt, "delete_memory")
+    deleted_id = _memory_id(payload, "delete_memory")
+    assert payload.get("status") == "deleted" and deleted_id == memory_id, (
+        f"delete_memory did not delete exact memory id {memory_id!r}: {txt[:300]}"
+    )
+
+
+async def _run_search(
+    s,
+    *,
+    marker: str | None = None,
+    cleanup: bool = True,
+) -> _SearchProbe:
+    """Add and search one unique marker, cleaning the exact added id by default."""
+    marker = marker or _new_marker()
+    memory_id: str | None = None
+    try:
+        add_txt = await _call(
+            s,
+            "ADD_MEMORY",
+            "add_memory",
+            {"content": f"protocol self-test memory {marker}"},
+        )
+        add_payload = _tool_payload(add_txt, "add_memory")
+        memory_id = _memory_id(add_payload, "add_memory")
+        assert "dedup_warning" not in add_payload, (
+            "add_memory returned a duplicate warning; unique probe was not saved"
+        )
+        search_txt = await _call(
+            s,
+            "SEARCH_MEMORY",
+            "search_memory",
+            {"query": marker},
+        )
+        return _SearchProbe(marker, memory_id, search_txt)
+    except BaseException:
+        if not cleanup and memory_id is not None:
+            try:
+                await _delete_memory(s, memory_id)
+            except Exception as cleanup_exc:
+                raise RuntimeError(
+                    f"probe failed and cleanup failed for memory id {memory_id!r}"
+                ) from cleanup_exc
+        raise
+    finally:
+        if cleanup and memory_id is not None:
+            await _delete_memory(s, memory_id)
 
 
 def _token_file() -> Path:
@@ -263,8 +372,8 @@ async def run_full(endpoint: str) -> None:
         tools = await s.list_tools()
         print("TOOLS:", [t.name for t in tools.tools])
         await _call(s, "CONFIG_STATUS", "config", {"action": "status"})
-        txt = await _run_search(s)
-        _assert_search_resolved(txt)
+        probe = await _run_search(s)
+        _assert_search_resolved(probe.search_text, probe.marker, probe.memory_id)
     print("FULL FLOW PASS.")
 
 
@@ -293,8 +402,8 @@ async def run_auth_only(endpoint: str) -> None:
     transport, ClientSession = await _session(endpoint, token)
     async with transport as (r, w, _), ClientSession(r, w) as s:
         await s.initialize()
-        txt = await _run_search(s)
-        _assert_search_resolved(txt)
+        probe = await _run_search(s)
+        _assert_search_resolved(probe.search_text, probe.marker, probe.memory_id)
     print("AUTH-ONLY PASS: sub survived recreate (KV vault resolved, no re-save).")
 
 
@@ -308,13 +417,41 @@ async def run_two_sub_isolation(endpoint: str) -> None:
         raise SystemExit(
             f"ISOLATION INCONCLUSIVE: both flows share sub {sub_a} (cannot test bleed)."
         )
-    transport, ClientSession = await _session(endpoint, token_b)
-    async with transport as (r, w, _), ClientSession(r, w) as s:
-        await s.initialize()
-        txt = await _run_search(s)
-        _assert_search_resolved(txt)
+    print("TWO-SUB: distinct bearer subjects acquired; testing marker isolation.")
+    marker_a = _new_marker("isolation-a")
+    marker_b = _new_marker("isolation-b")
+
+    transport_a, ClientSession = await _session(endpoint, token_a)
+    async with transport_a as (r_a, w_a, _), ClientSession(r_a, w_a) as s_a:
+        await s_a.initialize()
+        probe_a = await _run_search(s_a, marker=marker_a, cleanup=False)
+        try:
+            _assert_search_resolved(
+                probe_a.search_text, probe_a.marker, probe_a.memory_id
+            )
+
+            transport_b, ClientSession = await _session(endpoint, token_b)
+            async with transport_b as (r_b, w_b, _), ClientSession(r_b, w_b) as s_b:
+                await s_b.initialize()
+                search_a_from_b = await _call(
+                    s_b,
+                    "SEARCH_MEMORY_A_FROM_B",
+                    "search_memory",
+                    {"query": probe_a.marker},
+                )
+                _assert_search_absent(search_a_from_b, probe_a.marker)
+
+                probe_b = await _run_search(s_b, marker=marker_b, cleanup=False)
+                try:
+                    _assert_search_resolved(
+                        probe_b.search_text, probe_b.marker, probe_b.memory_id
+                    )
+                finally:
+                    await _delete_memory(s_b, probe_b.memory_id)
+        finally:
+            await _delete_memory(s_a, probe_a.memory_id)
     print(
-        "TWO-SUB ISOLATION OK: distinct subs, sub B authorizes + searches independently."
+        "TWO-SUB ISOLATION OK: B could not find A marker and created/searched its own."
     )
 
 
@@ -342,7 +479,10 @@ def build_parser() -> argparse.ArgumentParser:
     mode.add_argument(
         "--two-sub-isolation",
         action="store_true",
-        help="Two distinct subs; assert sub B authorizes + searches independently.",
+        help=(
+            "Two distinct subs; B must not find A's marker before B creates "
+            "and searches its own."
+        ),
     )
     return p
 

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -21,9 +21,11 @@ from the repo root:
 The maintainer injects the token via ``skret`` (one option), e.g.:
     MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- python scripts/deploy_cf.py
 
-Requires: CLOUDFLARE_API_TOKEN in env, docker, and ``bunx wrangler``. The CF container
-registry only pulls from registry.cloudflare.com/<account>/... (not ghcr), so the
-local image is tagged to that path before ``wrangler containers push``.
+Requires: the CF token injected by skret as ``CF_DEV_TOKEN`` (or an existing
+``CLOUDFLARE_API_TOKEN``), docker, and ``bunx wrangler``. The harness maps the
+token only in Wrangler child environments. The CF container registry only
+pulls from registry.cloudflare.com/<account>/... (not ghcr), so the local image
+is tagged to that path before ``wrangler containers push``.
 
 Why the rollout wait: a heavy image (wet ~6GB) keeps serving OLD Durable Object
 instances for minutes after deploy (``containers list`` STATE=provisioning);
@@ -55,6 +57,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from pathlib import Path
 
 # Windows consoles default to cp1252; wrangler emits box-drawing chars (│) and
@@ -66,6 +69,8 @@ for _stream in (sys.stdout, sys.stderr):
 
 DEPLOY_CONFIG = "wrangler.deploy.jsonc"
 TEMPLATE_CONFIG = "wrangler.deploy.template.jsonc"
+_WRANGLER_TOKEN = "CLOUDFLARE_API_TOKEN"
+_SKRET_TOKEN = "CF_DEV_TOKEN"
 
 
 def render_template(path: str) -> str:
@@ -120,11 +125,48 @@ def _short_sha(repo: Path) -> str:
     ).stdout.strip()
 
 
-def _run(cmd: list[str], *, dry: bool, cwd: Path | None = None) -> None:
+def _wrangler_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Build Wrangler's child environment without mutating the parent.
+
+    ``skret`` exposes the local development credential as ``CF_DEV_TOKEN``;
+    Wrangler only reads ``CLOUDFLARE_API_TOKEN``. An explicitly supplied
+    Wrangler token wins, while the source alias is removed from the child
+    environment after mapping to reduce unnecessary secret exposure.
+    """
+    child_env = dict(os.environ if env is None else env)
+    token = child_env.get(_WRANGLER_TOKEN) or child_env.get(_SKRET_TOKEN)
+    if token:
+        child_env[_WRANGLER_TOKEN] = token
+    child_env.pop(_SKRET_TOKEN, None)
+    return child_env
+
+
+def _run(
+    cmd: list[str],
+    *,
+    dry: bool,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> None:
     print(f"  $ {' '.join(cmd)}")
     if dry:
         return
-    subprocess.run(cmd, cwd=str(cwd) if cwd else None, check=True)
+    subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        env=dict(env) if env is not None else None,
+        check=True,
+    )
+
+
+def _run_wrangler(args: list[str], *, dry: bool, cwd: Path | None = None) -> None:
+    """Run Wrangler with the single, centrally resolved authentication env."""
+    _run(
+        ["bunx", "wrangler", *args],
+        dry=dry,
+        cwd=cwd,
+        env=_wrangler_env(),
+    )
 
 
 def _image_parts(cfg: dict) -> tuple[str, str, str]:
@@ -179,6 +221,7 @@ def _wait_ready(worker: str, *, dry: bool, timeout_s: int = 600) -> None:
                 text=True,
                 encoding="utf-8",
                 errors="replace",
+                env=_wrangler_env(),
             ).stdout
             or ""
         )
@@ -319,8 +362,8 @@ def _rollback(repo: Path, worker: str, prev_ref: str, *, dry: bool) -> None:
     if dry:
         return
     _set_image_tag(repo, prev_ref)
-    _run(
-        ["bunx", "wrangler", "deploy", "--config", DEPLOY_CONFIG],
+    _run_wrangler(
+        ["deploy", "--config", DEPLOY_CONFIG],
         dry=False,
         cwd=repo,
     )
@@ -384,12 +427,16 @@ def main(argv: list[str] | None = None) -> int:
     print("[2/4] docker tag -> CF registry")
     _run(["docker", "tag", local, full], dry=args.dry_run)
     print("[3/4] wrangler containers push")
-    _run(["bunx", "wrangler", "containers", "push", full], dry=args.dry_run, cwd=repo)
+    _run_wrangler(
+        ["containers", "push", full],
+        dry=args.dry_run,
+        cwd=repo,
+    )
     print(f"[4/4] wrangler deploy --config {DEPLOY_CONFIG}")
     if not args.dry_run:
         _set_image_tag(repo, full)
-    _run(
-        ["bunx", "wrangler", "deploy", "--config", DEPLOY_CONFIG],
+    _run_wrangler(
+        ["deploy", "--config", DEPLOY_CONFIG],
         dry=args.dry_run,
         cwd=repo,
     )

--- a/src/mnemo_mcp/db_cf.py
+++ b/src/mnemo_mcp/db_cf.py
@@ -99,9 +99,10 @@ import functools
 import inspect
 import json
 import os
+import re
 import uuid
 from pathlib import Path
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple
 
 from loguru import logger
 from mcp_core.storage.d1 import D1Backend, d1_backend_from_env
@@ -112,6 +113,7 @@ from mnemo_mcp.db import (
     MAX_TAGS_FILTER,
     MEMORY_COLUMNS,
     MemoryDB,
+    _build_fts_queries,
     _now_iso,
 )
 
@@ -150,12 +152,13 @@ class VectorCandidateCap(NamedTuple):
 
 
 # Tables `MemoryDBCfBackend` reads or writes. wrangler owns schema creation via
-# `migrations/0001_init.sql`; this backend only asserts the migration ran.
+# the migration chain; this backend only asserts the migrations ran.
 REQUIRED_TABLES = (
     "memories",
     "memories_fts",
     "store_meta",
     "archived_memories",
+    "sync_state",
 )
 
 # Columns written by the bulk-import path, in the order `_process_import_batch`
@@ -181,6 +184,30 @@ _NO_VECTOR_INDEX = (
     "dimension of the active model (and MCP_VECTORIZE_IDX set) to enable vectors."
 )
 
+_SCOPED_TABLES = (
+    "memories",
+    "archived_memories",
+    "memory_entities",
+    "memory_edges",
+    "memory_entity_links",
+    "store_meta",
+    "sync_state",
+)
+_SCOPED_TABLE_RE = re.compile(
+    r"\b(?:FROM|JOIN|UPDATE|INTO|DELETE\s+FROM)\s+("
+    + "|".join(_SCOPED_TABLES)
+    + r")\b",
+    re.IGNORECASE,
+)
+_INSERT_COLUMNS_RE = re.compile(
+    r"\bINTO\s+(?P<table>" + "|".join(_SCOPED_TABLES) + r")\s*\((?P<columns>[^)]*)\)",
+    re.IGNORECASE,
+)
+_SQL_CLAUSE_RE = re.compile(
+    r"\b(?:ORDER\s+BY|GROUP\s+BY|LIMIT|RETURNING|UNION|ON\s+CONFLICT)\b",
+    re.IGNORECASE,
+)
+
 
 class _D1Row(dict):
     """A D1 result row that also answers positional lookups.
@@ -200,17 +227,24 @@ class _D1Row(dict):
 class _D1Cursor:
     """Result handle over a materialised D1 row set.
 
-    ``rowcount`` is deliberately absent: ``POST /query`` returns rows only, with
-    no "rows changed" counter, so anything that needs a write count uses
-    ``RETURNING`` explicitly rather than reading a fabricated number here.
+    ``POST /query`` returns rows only, with no "rows changed" counter. Normal
+    queries therefore expose ``rowcount = -1`` like an unknown DB-API count;
+    batched writes use the same sentinel unless the caller has an explicit
+    count from ``RETURNING``.
     """
 
-    def __init__(self, conn: _D1Connection, rows: list[_D1Row]) -> None:
+    def __init__(
+        self, conn: _D1Connection, rows: list[_D1Row], rowcount: int = -1
+    ) -> None:
         self._conn = conn
         self.rows = rows
+        self.rowcount = rowcount
 
     def execute(self, sql: str, params: Any = ()) -> _D1Cursor:
         return self._conn.execute(sql, params)
+
+    def executemany(self, sql: str, seq_of_params: Any) -> _D1Cursor:
+        return self._conn.executemany(sql, seq_of_params)
 
     def fetchall(self) -> list[_D1Row]:
         return self.rows
@@ -231,20 +265,125 @@ class _D1Connection:
     believe it had undone a write it could not undo.
     """
 
-    def __init__(self, backend: D1Backend) -> None:
+    def __init__(self, backend: D1Backend, sub: str = "default") -> None:
         self._backend = backend
+        self.sub = sub
         self._closed = False
         self.last_error: Exception | None = None
+
+    def _scope_sql(self, sql: str, params: Any) -> tuple[str, list[Any]]:
+        """Bind this connection's tenant to one-table runtime statements.
+
+        Compound statements (FTS and graph queries) carry their predicates in
+        their own SQL because a generic predicate would be ambiguous across
+        joins and recursive CTEs. Inserts that already name ``sub`` are also
+        left untouched; this is how the graph layer makes its tenant boundary
+        explicit.
+        """
+        params_list = list(params)
+        tables = _SCOPED_TABLE_RE.findall(sql)
+        if not tables:
+            return sql, params_list
+
+        if re.search(r"(?:\b[A-Za-z_]\w*\.)?sub\b", sql, re.IGNORECASE):
+            return sql, params_list
+
+        if len(tables) != 1:
+            raise RuntimeError(
+                "D1 scoped SQL must name an explicit sub predicate for compound "
+                f"statements touching {', '.join(tables)}."
+            )
+
+        insert = _INSERT_COLUMNS_RE.search(sql)
+        if insert:
+            columns = insert.group("columns").strip()
+            scoped_sql = (
+                sql[: insert.start("columns")]
+                + "sub, "
+                + columns
+                + sql[insert.end("columns") :]
+            )
+            values = re.search(r"\bVALUES\s*\(", scoped_sql, re.IGNORECASE)
+            if values is None:
+                raise RuntimeError("D1 scoped INSERT must use bound VALUES.")
+            at = values.end()
+            scoped_sql = scoped_sql[:at] + "?, " + scoped_sql[at:]
+            return scoped_sql, [self.sub, *params_list]
+
+        predicate = "sub = ?"
+        where = re.search(r"\bWHERE\b", sql, re.IGNORECASE)
+        if where:
+            clause = _SQL_CLAUSE_RE.search(sql, where.end())
+            at = clause.start() if clause else len(sql)
+            scoped_sql = sql[:at].rstrip() + f" AND {predicate} " + sql[at:].lstrip()
+            before_clause = sql[:at].count("?")
+            return scoped_sql, (
+                params_list[:before_clause] + [self.sub] + params_list[before_clause:]
+            )
+        else:
+            clause = _SQL_CLAUSE_RE.search(sql)
+            at = clause.start() if clause else len(sql)
+            scoped_sql = sql[:at].rstrip() + f" WHERE {predicate} " + sql[at:].lstrip()
+        before_clause = sql[:at].count("?")
+        return scoped_sql, (
+            params_list[:before_clause] + [self.sub] + params_list[before_clause:]
+        )
 
     def execute(self, sql: str, params: Any = ()) -> _D1Cursor:
         if self._closed:
             raise RuntimeError("Cannot operate on a closed MemoryDBCfBackend.")
+        sql, params = self._scope_sql(sql, params)
         try:
             rows = self._backend.fetchall(sql, list(params))
         except Exception as exc:
             self.last_error = exc
             raise
         return _D1Cursor(self, [_D1Row(r) for r in rows])
+
+    def executemany(self, sql: str, seq_of_params: Any) -> _D1Cursor:
+        if self._closed:
+            raise RuntimeError("Cannot operate on a closed MemoryDBCfBackend.")
+        rows = [list(params) for params in seq_of_params]
+        if not rows:
+            return _D1Cursor(self, [], rowcount=0)
+        scoped_sql, first = self._scope_sql(sql, rows[0])
+        if len(first) != len(rows[0]):
+            scoped_rows = [self._scope_sql(sql, params)[1] for params in rows]
+        else:
+            scoped_rows = rows
+        values = re.search(r"\bVALUES\s*(\([^)]*\))", scoped_sql, re.IGNORECASE)
+        if values:
+            rows_per_statement = min(
+                len(scoped_rows),
+                int(getattr(self._backend, "max_rows_per_insert", 100)),
+            )
+            for start in range(0, len(scoped_rows), rows_per_statement):
+                batch = scoped_rows[start : start + rows_per_statement]
+                batched_sql = (
+                    scoped_sql[: values.start(1)]
+                    + ", ".join([values.group(1)] * len(batch))
+                    + scoped_sql[values.end(1) :]
+                )
+                flat = [value for params in batch for value in params]
+                try:
+                    self._backend.fetchall(batched_sql, flat)
+                except Exception as exc:
+                    self.last_error = exc
+                    raise
+            return _D1Cursor(self, [], rowcount=-1)
+
+        # The Worker intentionally exposes only D1's query endpoint. Running
+        # one scoped statement per parameter set keeps this fallback on that
+        # supported route instead of reaching for an unavailable batch API.
+        for params in rows:
+            self.execute(sql, params)
+        return _D1Cursor(self, [], rowcount=-1)
+
+    def fetchall(self, sql: str, params: Any = ()) -> list[_D1Row]:
+        return self.execute(sql, params).fetchall()
+
+    def fetchone(self, sql: str, params: Any = ()) -> _D1Row | None:
+        return self.execute(sql, params).fetchone()
 
     def cursor(self) -> _D1Cursor:
         return _D1Cursor(self, [])
@@ -384,7 +523,6 @@ class MemoryDBCfBackend:
     get = MemoryDB.get
     stats = MemoryDB.stats
     export_jsonl = MemoryDB.export_jsonl
-    list_archived = MemoryDB.list_archived
     check_duplicate = MemoryDB.check_duplicate
     _parse_import_data = MemoryDB._parse_import_data
     _process_import_batch = MemoryDB._process_import_batch
@@ -403,6 +541,7 @@ class MemoryDBCfBackend:
         recency_half_life_days: float = 7.0,
         embedding_model: str = "",
         reindex_on_model_change: bool = False,
+        sub: str = "default",
     ) -> None:
         """Open the D1-backed store.
 
@@ -427,8 +566,8 @@ class MemoryDBCfBackend:
         Raises:
             ValueError: On an out-of-range ``embedding_dims``, or when
                 ``vectors`` is supplied for a store declared text-only.
-            RuntimeError: When the D1 database has not had
-                ``migrations/0001_init.sql`` applied, or when vectors are
+            RuntimeError: When the D1 database has not had the migration chain
+                (including ``0002_per_sub_isolation.sql``) applied, or when vectors are
                 requested without ``MCP_VECTORIZE_IDX``.
             EmbeddingModelMismatch: Same contract as :class:`MemoryDB`.
         """
@@ -446,9 +585,12 @@ class MemoryDBCfBackend:
                 "would attach a Vectorize index the store then refuses to write "
                 "to, so it is rejected rather than quietly ignored."
             )
+        if not isinstance(sub, str) or not sub.strip():
+            raise ValueError("sub must be a non-empty string")
 
         self._backend = backend if backend is not None else d1_backend_from_env()
-        self._conn = _D1Connection(self._backend)
+        self.sub = sub
+        self._conn = _D1Connection(self._backend, sub=sub)
         self._db_path = f"cf-d1:{self._backend.base_url}"
         self._embedding_dims = embedding_dims
         self._embedding_model = embedding_model
@@ -468,6 +610,19 @@ class MemoryDBCfBackend:
         self._require_schema()
         self._guard_embedding_identity()
 
+    def clone_for_sub(self, sub: str) -> MemoryDBCfBackend:
+        """Return a request-scoped view sharing transport clients, not SQL scope."""
+        if not isinstance(sub, str) or not sub.strip():
+            raise ValueError("sub must be a non-empty string")
+        if self._conn._closed:
+            raise RuntimeError("Cannot clone a closed MemoryDBCfBackend.")
+        clone = object.__new__(type(self))
+        clone.__dict__ = self.__dict__.copy()
+        clone.sub = sub
+        clone._conn = _D1Connection(self._backend, sub=sub)
+        clone.last_vector_cap = None
+        return clone
+
     def _require_schema(self) -> None:
         """Fail at open time when the D1 migration has not been applied.
 
@@ -475,7 +630,7 @@ class MemoryDBCfBackend:
         Worker, several calls away from the actual cause.
         """
         try:
-            rows = self._backend.fetchall(
+            rows = self._conn.fetchall(
                 "SELECT name FROM sqlite_master WHERE type = 'table'", []
             )
         except Exception as exc:
@@ -484,6 +639,7 @@ class MemoryDBCfBackend:
                 f"{self._backend.base_url}: {exc}"
             ) from exc
         present = {r["name"] for r in rows}
+        self._sync_state_supported = "sync_state" in present
         missing = [t for t in REQUIRED_TABLES if t not in present]
         if missing:
             raise RuntimeError(
@@ -491,6 +647,42 @@ class MemoryDBCfBackend:
                 f"{', '.join(missing)}. Apply the schema first: "
                 "`wrangler d1 migrations apply mnemo-memories`."
             )
+
+    def list_archived(self, limit: int = 20) -> list[dict]:
+        """List both archive stores without crossing the current tenant."""
+        if isinstance(limit, int):
+            limit = max(1, min(limit, 100))
+        rows = self._conn.fetchall(
+            """
+            SELECT id, content, category, tags, importance, archived_at
+            FROM (
+                SELECT id, content, category, tags, importance, archived_at
+                FROM memories
+                WHERE sub = ? AND archived_at IS NOT NULL
+                UNION ALL
+                SELECT id, content, category, tags, importance, archived_at
+                FROM archived_memories
+                WHERE sub = ?
+            )
+            ORDER BY archived_at DESC
+            LIMIT ?
+            """,
+            [self.sub, self.sub, limit],
+        )
+        merged = []
+        for row in rows:
+            tags_val = row[3]
+            merged.append(
+                {
+                    "id": row[0],
+                    "content": row[1][:200],
+                    "category": row[2],
+                    "tags": [] if tags_val == "[]" else json.loads(tags_val),
+                    "importance": row[4],
+                    "archived_at": row[5],
+                }
+            )
+        return merged
 
     @property
     def vec_enabled(self) -> bool:
@@ -526,7 +718,22 @@ class MemoryDBCfBackend:
     def _upsert_vector(self, memory_id: str, embedding: list[float]) -> None:
         """Write one vector, keyed by the memory id it belongs to."""
         vectors = self._require_vectors("_upsert_vector")
-        vectors.upsert([{"id": memory_id, "values": self._fit_dims(embedding)}])
+        vectors.upsert(
+            [
+                {
+                    "id": self._vectorize_id(memory_id),
+                    "values": self._fit_dims(embedding),
+                    "metadata": {"sub": self.sub},
+                }
+            ]
+        )
+
+    def _vectorize_id(self, memory_id: str) -> str:
+        return f"{self.sub}:{memory_id}"
+
+    def _logical_vector_id(self, vector_id: str) -> str | None:
+        prefix = f"{self.sub}:"
+        return vector_id[len(prefix) :] if vector_id.startswith(prefix) else None
 
     def _discard_vectors(self, ids: list[str], context: str) -> None:
         """Delete vectors whose rows are gone, without failing the row change.
@@ -543,7 +750,9 @@ class MemoryDBCfBackend:
         if self._vectors is None or not ids:
             return
         try:
-            _vectorize_delete_by_ids(self._vectors, ids)
+            _vectorize_delete_by_ids(
+                self._vectors, [self._vectorize_id(memory_id) for memory_id in ids]
+            )
         except Exception as exc:
             logger.error(
                 "[AUDIT] {} closed row(s) {} in D1 but could not delete their "
@@ -576,8 +785,8 @@ class MemoryDBCfBackend:
                 "REINDEX_ON_MODEL_CHANGE cannot be honoured: no Vectorize index "
                 f"is attached to this store. {_NO_VECTOR_INDEX}"
             )
-        rows = self._backend.fetchall("SELECT id FROM memories", [])
-        ids = [r["id"] for r in rows]
+        rows = self._conn.fetchall("SELECT id FROM memories", [])
+        ids = [self._vectorize_id(r["id"]) for r in rows]
         _vectorize_delete_by_ids(vectors, ids)
         logger.warning(
             "[AUDIT] reindex dropped {} vector(s) from the Vectorize index; they "
@@ -597,18 +806,103 @@ class MemoryDBCfBackend:
         if mode != "replace":
             return
         if self._vectors is not None:
-            rows = self._backend.fetchall("SELECT id FROM memories", [])
-            _vectorize_delete_by_ids(self._vectors, [r["id"] for r in rows])
-        self._backend.execute("DELETE FROM memories", [])
+            rows = self._conn.fetchall("SELECT id FROM memories", [])
+            _vectorize_delete_by_ids(
+                self._vectors, [self._vectorize_id(r["id"]) for r in rows]
+            )
+        self._conn.execute("DELETE FROM memories", [])
 
     # -- Search ------------------------------------------------------------
 
-    def _search_fts(self, *args, **kwargs) -> dict[str, dict]:
-        """Borrowed FTS search, with swallowed transport errors re-raised."""
+    def _search_fts(
+        self,
+        query: str,
+        category: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 5,
+        *,
+        context_type: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        min_importance: float = 0.0,
+        include_archived: bool = False,
+    ) -> dict[str, dict]:
+        """Run FTS against the current tenant, preserving duplicate logical ids."""
         self._conn.clear_error()
-        # cast: the borrow is structural -- the body only reaches for
-        # ``self._conn`` and the filter helpers, both of which exist here.
-        results = MemoryDB._search_fts(cast(MemoryDB, self), *args, **kwargs)
+        results: dict[str, dict] = {}
+        fts_queries = _build_fts_queries(query)
+        if not fts_queries:
+            return results
+
+        filter_fragments: list[str] = []
+        filter_params: list[Any] = []
+        if category:
+            filter_fragments.append("AND m.category = ?")
+            filter_params.append(category)
+        if tags:
+            filter_fragments.append(
+                "AND m.tags != '[]' AND json_valid(m.tags) AND EXISTS "
+                "(SELECT 1 FROM json_each(m.tags) WHERE value IN "
+                "(SELECT value FROM json_each(?)))"
+            )
+            filter_params.append(json.dumps(tags))
+
+        extra_sql, extra_params = self._build_filter_sql(
+            context_type=context_type,
+            since=since,
+            until=until,
+            min_importance=min_importance,
+            include_archived=include_archived,
+        )
+        if extra_sql:
+            filter_fragments.append(extra_sql)
+            filter_params.extend(extra_params)
+        filter_sql = " ".join(filter_fragments)
+
+        for fts_query in fts_queries:
+            query_params = [fts_query, self.sub] + filter_params + [limit * 3]
+            fts_sql = """
+                WITH best_tier AS (
+                    SELECT m.rowid AS memory_rowid,
+                           m.id,
+                           bm25(memories_fts, 0.0, 1.0, 0.0, 5.0) AS bm25_score
+                    FROM memories_fts f
+                    JOIN memories m ON f.rowid = m.rowid
+                    WHERE memories_fts MATCH ?
+                      AND m.sub = ? placeholder_filter_sql
+                    ORDER BY bm25_score
+                    LIMIT ?
+                )
+                SELECT m.*, b.bm25_score
+                FROM best_tier b
+                JOIN memories m ON m.rowid = b.memory_rowid
+                ORDER BY b.bm25_score
+            """.replace("placeholder_filter_sql", filter_sql)
+            try:
+                rows = self._conn.execute(fts_sql, query_params).fetchall()
+                if rows:
+                    for row in rows:
+                        mid = row["id"]
+                        results[mid] = {
+                            **dict(row),
+                            "fts_score": -row["bm25_score"],
+                            "vec_score": 0.0,
+                        }
+                    break
+            except Exception as exc:
+                logger.error(f"FTS search failed for tier '{fts_query}': {exc}")
+
+        fts_vals = [m["fts_score"] for m in results.values() if m["fts_score"] > 0]
+        if fts_vals:
+            min_f = min(fts_vals)
+            max_f = max(fts_vals)
+            rng = max_f - min_f
+            for memory in results.values():
+                if rng > 0 and memory["fts_score"] > 0:
+                    memory["fts_score"] = (memory["fts_score"] - min_f) / rng
+                elif memory["fts_score"] > 0:
+                    memory["fts_score"] = 1.0
+
         self._conn.raise_if_error("FTS5 search")
         return results
 
@@ -636,10 +930,9 @@ class MemoryDBCfBackend:
         Second, every returned id is re-fetched from D1 under the caller's
         filters -- whose ``_build_filter_sql`` tail always begins ``AND
         m.valid_to IS NULL``. That is what keeps a superseded or soft-deleted row
-        out of the results even when its vector is still in the index, and it is
-        also why no metadata filter is sent to Vectorize: filtering there would
-        need metadata indexes declared at index-creation time in wrangler, and
-        would still not be authoritative about supersession, which only D1 knows.
+        out of the results even when its vector is still in the index. The shared
+        Vectorize index also receives the caller's tenant metadata filter, but
+        D1 remains authoritative for supersession and all other row predicates.
         The cost is real and one-directional -- a narrow ``category`` filter can
         leave few of the 50 candidates standing -- so it is stated here rather
         than presented as a filtered top-50.
@@ -666,10 +959,13 @@ class MemoryDBCfBackend:
                 VECTORIZE_MAX_TOP_K,
             )
 
-        matches = vectors.query(self._fit_dims(embedding), top_k)
+        matches = vectors.query(
+            self._fit_dims(embedding), top_k, metadata_filter={"sub": self.sub}
+        )
         scores: dict[str, float] = {}
         for match in matches:
-            mid = match.get("id")
+            vector_id = match.get("id")
+            mid = self._logical_vector_id(vector_id) if vector_id is not None else None
             if mid is None:
                 continue
             # Vectorize returns a similarity score, where sqlite-vec returns a
@@ -679,8 +975,8 @@ class MemoryDBCfBackend:
         if not scores:
             return {}
 
-        fragments = ["WHERE m.id IN (SELECT value FROM json_each(?))"]
-        params: list = [json.dumps(list(scores))]
+        fragments = ["WHERE m.sub = ? AND m.id IN (SELECT value FROM json_each(?))"]
+        params: list = [self.sub, json.dumps(list(scores))]
         if category:
             fragments.append("AND m.category = ?")
             params.append(category)
@@ -696,7 +992,7 @@ class MemoryDBCfBackend:
             fragments.append(extra_sql)
             params.extend(extra_params)
 
-        rows = self._backend.fetchall(
+        rows = self._conn.fetchall(
             "SELECT m.* FROM memories m " + " ".join(fragments), params
         )
         # Re-keyed by Vectorize's ranking, not by whatever order D1 returned the
@@ -833,7 +1129,7 @@ class MemoryDBCfBackend:
         now = _now_iso()
         new_id = uuid.uuid4().hex
 
-        old_row = self._backend.fetchone(
+        old_row = self._conn.fetchone(
             "UPDATE memories SET valid_to = ?, superseded_by = ? "
             "WHERE id = ? AND valid_to IS NULL RETURNING *",
             [now, new_id, memory_id],
@@ -869,13 +1165,13 @@ class MemoryDBCfBackend:
         placeholders = ", ".join("?" for _ in columns)
 
         try:
-            self._backend.execute(
+            self._conn.execute(
                 f"INSERT INTO memories ({column_list}) VALUES ({placeholders})",
                 [new_row[c] for c in columns],
             )
         except Exception:
             try:
-                self._backend.execute(
+                self._conn.execute(
                     "UPDATE memories SET valid_to = NULL, superseded_by = NULL "
                     "WHERE id = ? AND superseded_by = ?",
                     [memory_id, new_id],
@@ -910,7 +1206,7 @@ class MemoryDBCfBackend:
 
     def delete(self, memory_id: str) -> bool:
         """Soft-close a memory and drop its vector. See :meth:`MemoryDB.delete`."""
-        rows = self._backend.fetchall(
+        rows = self._conn.fetchall(
             "UPDATE memories SET valid_to = ? WHERE id = ? AND valid_to IS NULL "
             "RETURNING id",
             [_now_iso(), memory_id],
@@ -924,7 +1220,7 @@ class MemoryDBCfBackend:
     def update_importance(self, memory_id: str, importance: float) -> bool:
         """Update the importance score. See :meth:`MemoryDB.update_importance`."""
         importance = max(0.0, min(1.0, importance))
-        rows = self._backend.fetchall(
+        rows = self._conn.fetchall(
             "UPDATE memories SET importance = ? WHERE id = ? RETURNING id",
             [importance, memory_id],
         )
@@ -934,7 +1230,7 @@ class MemoryDBCfBackend:
         self, days: int = 90, importance_threshold: float = 0.3
     ) -> int:
         """Soft-archive old, low-importance rows. See :meth:`MemoryDB`."""
-        rows = self._backend.fetchall(
+        rows = self._conn.fetchall(
             "UPDATE memories SET archived_at = ? "
             "WHERE archived_at IS NULL "
             "  AND last_accessed < datetime('now', ?) "
@@ -962,7 +1258,7 @@ class MemoryDBCfBackend:
                 archive_after_days = 90
         archive_after_days = max(1, int(archive_after_days))
 
-        rows = self._backend.fetchall(
+        rows = self._conn.fetchall(
             "UPDATE memories SET archived_at = ? "
             "WHERE archived_at IS NULL "
             "AND ( MAX(0.0, julianday('now') - julianday(updated_at)) / ? ) "
@@ -981,7 +1277,7 @@ class MemoryDBCfBackend:
     def restore_memory(self, memory_id: str) -> bool:
         """Restore an archived memory. See :meth:`MemoryDB.restore_memory`."""
         now = _now_iso()
-        rows = self._backend.fetchall(
+        rows = self._conn.fetchall(
             "UPDATE memories SET archived_at = NULL, last_accessed = ? "
             "WHERE id = ? AND archived_at IS NOT NULL RETURNING id",
             [now, memory_id],
@@ -990,12 +1286,12 @@ class MemoryDBCfBackend:
             logger.info(f"[AUDIT] restore id={memory_id} mode=soft")
             return True
 
-        legacy = self._backend.fetchone(
+        legacy = self._conn.fetchone(
             "SELECT * FROM archived_memories WHERE id = ?", [memory_id]
         )
         if not legacy:
             return False
-        self._backend.execute(
+        self._conn.execute(
             "INSERT OR REPLACE INTO memories "
             "(id, content, category, tags, source, importance, "
             " created_at, updated_at, access_count, last_accessed) "
@@ -1013,7 +1309,7 @@ class MemoryDBCfBackend:
                 now,
             ],
         )
-        self._backend.execute("DELETE FROM archived_memories WHERE id = ?", [memory_id])
+        self._conn.execute("DELETE FROM archived_memories WHERE id = ?", [memory_id])
         logger.info(f"[AUDIT] restore id={memory_id} mode=legacy")
         return True
 
@@ -1030,17 +1326,16 @@ class MemoryDBCfBackend:
             return 0, 0
         op = "REPLACE" if mode == "replace" else "IGNORE"
         column_list = ", ".join(_IMPORT_COLUMNS)
-        row_placeholder = "(" + ", ".join("?" for _ in _IMPORT_COLUMNS) + ")"
 
         imported = 0
         for i in range(0, len(to_insert), _IMPORT_ROWS_PER_STATEMENT):
             chunk = to_insert[i : i + _IMPORT_ROWS_PER_STATEMENT]
-            values_sql = ", ".join([row_placeholder] * len(chunk))
-            flat = [value for row in chunk for value in row]
-            rows = self._backend.fetchall(
-                f"INSERT OR {op} INTO memories ({column_list}) "
+            scoped_placeholder = "(?, " + ", ".join("?" for _ in _IMPORT_COLUMNS) + ")"
+            values_sql = ", ".join([scoped_placeholder] * len(chunk))
+            rows = self._conn.fetchall(
+                f"INSERT OR {op} INTO memories (sub, {column_list}) "
                 f"VALUES {values_sql} RETURNING id",
-                flat,
+                [value for row in chunk for value in (self.sub, *row)],
             )
             imported += len(rows)
 
@@ -1066,14 +1361,15 @@ class MemoryDBCfBackend:
             logger.info(f"[AUDIT] import count={imported} mode={mode}")
         return {"imported": imported, "skipped": skipped, "rejected": rejected}
 
-    # -- Not available on this backend -------------------------------------
-
     def get_sync_state(self, backend: str) -> dict | None:
-        raise NotImplementedError(
-            "sync_state is not part of migrations/0001_init.sql, so the D1 "
-            "database has no delta-sync cursor table. Add it in a follow-up "
-            "migration before running the sync pipeline against cf-d1."
+        if not self._sync_state_supported:
+            return None
+        row = self._conn.fetchone(
+            "SELECT backend, last_sync_at, last_commit_sha, upload_cursor "
+            "FROM sync_state WHERE sub = ? AND backend = ?",
+            [self.sub, backend],
         )
+        return dict(row) if row else None
 
     def upsert_sync_state(
         self,
@@ -1082,10 +1378,17 @@ class MemoryDBCfBackend:
         last_commit_sha: str | None = None,
         upload_cursor: int | None = None,
     ) -> None:
-        raise NotImplementedError(
-            "sync_state is not part of migrations/0001_init.sql, so the D1 "
-            "database has no delta-sync cursor table. Add it in a follow-up "
-            "migration before running the sync pipeline against cf-d1."
+        if not self._sync_state_supported:
+            return
+        self._conn.execute(
+            "INSERT INTO sync_state "
+            "(sub, backend, last_sync_at, last_commit_sha, upload_cursor) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(sub, backend) DO UPDATE SET "
+            "last_sync_at = COALESCE(excluded.last_sync_at, sync_state.last_sync_at), "
+            "last_commit_sha = COALESCE(excluded.last_commit_sha, sync_state.last_commit_sha), "
+            "upload_cursor = COALESCE(excluded.upload_cursor, sync_state.upload_cursor)",
+            [self.sub, backend, last_sync_at, last_commit_sha, upload_cursor],
         )
 
     def close(self) -> None:

--- a/src/mnemo_mcp/graph.py
+++ b/src/mnemo_mcp/graph.py
@@ -214,29 +214,56 @@ def upsert_entities(conn, entities: list[dict]) -> list[str]:
 
     # Use UPSERT (INSERT ... ON CONFLICT) for bulk write in one pass.
     # This eliminates N+1 SELECTs and conditional INSERT/UPDATE overhead.
-    upsert_data = [(str(uuid.uuid4()), key[0], key[1], now, now) for key in unique_keys]
-    conn.executemany(
-        "INSERT INTO memory_entities (id, name, entity_type, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?) "
-        "ON CONFLICT(name, entity_type) DO UPDATE SET updated_at = excluded.updated_at",
-        upsert_data,
-    )
+    sub = getattr(conn, "sub", None)
+    if sub is None:
+        upsert_data = [
+            (str(uuid.uuid4()), key[0], key[1], now, now) for key in unique_keys
+        ]
+        conn.executemany(
+            "INSERT INTO memory_entities (id, name, entity_type, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(name, entity_type) DO UPDATE SET updated_at = excluded.updated_at",
+            upsert_data,
+        )
+    else:
+        upsert_data = [
+            (sub, str(uuid.uuid4()), key[0], key[1], now, now) for key in unique_keys
+        ]
+        conn.executemany(
+            "INSERT INTO memory_entities "
+            "(sub, id, name, entity_type, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(sub, name, entity_type) "
+            "DO UPDATE SET updated_at = excluded.updated_at",
+            upsert_data,
+        )
 
     # Bolt Performance Optimization:
     # Use SQLite's json_each with json_extract for multi-column IN clauses.
     # This eliminates the need for Python-side string interpolation and looping
     # to batch parameters due to SQLITE_MAX_VARIABLE_NUMBER limits.
     json_payload = json.dumps(unique_keys)
-    rows = conn.execute(
-        "SELECT name, entity_type, id FROM memory_entities "
-        "WHERE (name, entity_type) IN ("
-        "  SELECT json_extract(value, '$[0]'), json_extract(value, '$[1]') "
-        "  FROM json_each(?)"
-        ")",
-        (json_payload,),
-    ).fetchall()
+    if sub is None:
+        rows = conn.execute(
+            "SELECT name, entity_type, id FROM memory_entities "
+            "WHERE (name, entity_type) IN ("
+            "  SELECT json_extract(value, '$[0]'), json_extract(value, '$[1]') "
+            "  FROM json_each(?)"
+            ")",
+            (json_payload,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT name, entity_type, id FROM memory_entities "
+            "WHERE sub = ? AND (name, entity_type) IN ("
+            "  SELECT json_extract(value, '$[0]'), json_extract(value, '$[1]') "
+            "  FROM json_each(?)"
+            ")",
+            (sub, json_payload),
+        ).fetchall()
 
-    for r_name, r_type, r_id in rows:
+    for row in rows:
+        r_name, r_type, r_id = row[0], row[1], row[2]
         unique_ents[(r_name, r_type)] = r_id
 
     return [unique_ents[key] for key in ordered_ents]
@@ -247,6 +274,7 @@ def create_relations(
 ) -> None:
     """Create relations between entities."""
     now = datetime.now(UTC).isoformat()
+    sub = getattr(conn, "sub", None)
     seen = set()
     to_insert = []
 
@@ -279,12 +307,21 @@ def create_relations(
         # backed by the `idx_memory_edges_unique` database index.
         # This reduces SQLite virtual machine overhead, providing up to ~4x speedup
         # for bulk graph relationship generation.
-        conn.executemany(
-            "INSERT OR IGNORE INTO memory_edges "
-            "(id, source_id, target_id, relation_type, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            to_insert,
-        )
+        if sub is None:
+            conn.executemany(
+                "INSERT OR IGNORE INTO memory_edges "
+                "(id, source_id, target_id, relation_type, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                to_insert,
+            )
+        else:
+            conn.executemany(
+                "INSERT INTO memory_edges "
+                "(sub, id, source_id, target_id, relation_type, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(sub, source_id, target_id, relation_type) DO NOTHING",
+                [(sub, *row) for row in to_insert],
+            )
 
 
 def link_memory_entities(conn, memory_id: str, entity_ids: list[str]) -> None:
@@ -298,11 +335,20 @@ def link_memory_entities(conn, memory_id: str, entity_ids: list[str]) -> None:
         # This reduces round-trips and improves bulk insert performance by ~60-65%
         # for batches of 100+ entities compared to individual execute calls.
         params = [(memory_id, eid) for eid in entity_ids]
-        conn.executemany(
-            "INSERT OR IGNORE INTO memory_entity_links (memory_id, entity_id) "
-            "VALUES (?, ?)",
-            params,
-        )
+        sub = getattr(conn, "sub", None)
+        if sub is None:
+            conn.executemany(
+                "INSERT OR IGNORE INTO memory_entity_links (memory_id, entity_id) "
+                "VALUES (?, ?)",
+                params,
+            )
+        else:
+            conn.executemany(
+                "INSERT INTO memory_entity_links (sub, memory_id, entity_id) "
+                "VALUES (?, ?, ?) "
+                "ON CONFLICT(sub, memory_id, entity_id) DO NOTHING",
+                [(sub, *row) for row in params],
+            )
     except Exception as e:
         logger.debug(f"Failed to link memory entities: {e}")
 
@@ -313,7 +359,9 @@ def find_related_memory_ids(conn, memory_id: str, max_depth: int = 2) -> list[st
     Uses a recursive CTE to traverse the knowledge graph in a single query,
     eliminating N+1 loop overhead and reducing database round-trips to O(1).
     """
-    query = """
+    sub = getattr(conn, "sub", None)
+    if sub is None:
+        query = """
         WITH RECURSIVE traverse(entity_id, depth) AS (
             -- Seed with initial entities linked to the memory
             SELECT entity_id, 1 FROM memory_entity_links WHERE memory_id = ?
@@ -338,7 +386,32 @@ def find_related_memory_ids(conn, memory_id: str, max_depth: int = 2) -> list[st
         SELECT DISTINCT memory_id
         FROM memory_entity_links
         WHERE memory_id != ? AND entity_id IN (SELECT entity_id FROM traverse)
-    """
-    rows = conn.execute(query, (memory_id, max_depth, max_depth, memory_id)).fetchall()
+        """
+        params = (memory_id, max_depth, max_depth, memory_id)
+    else:
+        query = """
+        WITH RECURSIVE traverse(entity_id, depth) AS (
+            SELECT entity_id, 1
+            FROM memory_entity_links
+            WHERE sub = ? AND memory_id = ?
+            UNION
+            SELECT r.target_id, t.depth + 1
+            FROM memory_edges r
+            JOIN traverse t ON r.source_id = t.entity_id
+            WHERE r.sub = ? AND t.depth < ?
+            UNION
+            SELECT r.source_id, t.depth + 1
+            FROM memory_edges r
+            JOIN traverse t ON r.target_id = t.entity_id
+            WHERE r.sub = ? AND t.depth < ?
+        )
+        SELECT DISTINCT memory_id
+        FROM memory_entity_links
+        WHERE sub = ?
+          AND memory_id != ?
+          AND entity_id IN (SELECT entity_id FROM traverse)
+        """
+        params = (sub, memory_id, sub, max_depth, sub, max_depth, sub, memory_id)
+    rows = conn.execute(query, params).fetchall()
 
     return [r[0] for r in rows]

--- a/src/mnemo_mcp/server.py
+++ b/src/mnemo_mcp/server.py
@@ -25,7 +25,7 @@ from mcp.types import ToolAnnotations
 
 from mnemo_mcp.config import settings
 from mnemo_mcp.db import MemoryDB
-from mnemo_mcp.db_cf import open_memory_db
+from mnemo_mcp.db_cf import MemoryDBCfBackend, open_memory_db
 
 # Resolved via importlib.metadata (not ``from mnemo_mcp import __version__``)
 # to avoid a circular import: ``mnemo_mcp/__init__`` imports ``server.main``.
@@ -368,9 +368,20 @@ mcp._mcp_server.version = __version__
 
 
 def _get_ctx(ctx: Context | None) -> tuple[MemoryDB, str | None, int]:
-    """Extract db, model, dims from context."""
+    """Extract request-scoped db, model, and dimensions from context."""
     lc = ctx.request_context.lifespan_context
-    return lc["db"], lc["embedding_model"], lc["embedding_dims"]
+    db = lc["db"]
+    if isinstance(db, MemoryDBCfBackend):
+        from mnemo_mcp.credential_state import get_current_sub
+
+        sub = get_current_sub()
+        if sub is None:
+            raise RuntimeError(
+                "JWT sub is required for Cloudflare D1 requests; refusing an "
+                "unscoped backend."
+            )
+        db = db.clone_for_sub(sub)
+    return db, lc["embedding_model"], lc["embedding_dims"]
 
 
 def _json(obj: object) -> str:

--- a/src/mnemo_mcp/setup_tool.py
+++ b/src/mnemo_mcp/setup_tool.py
@@ -104,11 +104,12 @@ async def run_warmup() -> dict:
     Returns a structured dict with warmup results:
     {
         "status": "ok" | "error",
-        "mode": "cloud" | "local",
+        "mode": "cloud" | "local" | "unavailable",
         "steps": [{"step": str, "status": str, ...}, ...],
     }
     """
     steps = []
+    local_disabled = getattr(settings, "disable_local_embed", False) is True
 
     # 1. Check cloud models if API keys are available
     keys = settings.setup_api_keys()
@@ -136,9 +137,27 @@ async def run_warmup() -> dict:
             {
                 "step": "cloud_embedding",
                 "status": "fallback",
-                "message": "Cloud models not available, falling back to local",
+                "message": (
+                    "Cloud models not available, local embedding is disabled"
+                    if local_disabled
+                    else "Cloud models not available, falling back to local"
+                ),
             }
         )
+
+    if local_disabled:
+        steps.append(
+            {
+                "step": "local_embedding",
+                "status": "skipped",
+                "message": "Local embedding disabled; embedding is unavailable",
+            }
+        )
+        return {
+            "status": "ok",
+            "mode": "unavailable",
+            "steps": steps,
+        }
 
     # 2. Download local embedding model
     embed_result = await asyncio.to_thread(_download_local_embedding, settings)

--- a/src/mnemo_mcp/temporal/store.py
+++ b/src/mnemo_mcp/temporal/store.py
@@ -101,9 +101,11 @@ def store_kg_with_memory_id(
             "WHERE source_id = ? AND target_id = ? AND relation_type = ?",
             params,
         )
-        # For UPDATE, executemany's rowcount is the sum of all affected rows.
-        # Bolt Performance Note: Using executemany eliminates N+1 updates.
-        edge_count = cursor.rowcount if cursor.rowcount != -1 else len(params)
+        # SQLite exposes affected-row count; D1 /query does not. The D1 adapter
+        # returns the unknown sentinel, so the prepared relation count is the
+        # safe contract for this idempotent update batch.
+        rowcount = getattr(cursor, "rowcount", -1)
+        edge_count = rowcount if rowcount != -1 else len(params)
         conn.commit()
 
     logger.debug(

--- a/tests/e2e_mcp_protocol_test.py
+++ b/tests/e2e_mcp_protocol_test.py
@@ -38,6 +38,43 @@ def generate_pkce() -> tuple[str, str]:
     return verifier, challenge
 
 
+async def _get_authorize_form(
+    http: httpx.AsyncClient, params: dict[str, str]
+) -> httpx.Response:
+    """Open the credential form, including the deployed relay-login gate."""
+    resp = await http.get(
+        f"{BASE_URL}/authorize", params=params, follow_redirects=False
+    )
+    print(f"[1] GET /authorize -> {resp.status_code}")
+
+    if resp.status_code == 302:
+        login_location = resp.headers.get("location")
+        assert login_location, "Relay login redirect is missing Location"
+        login_url = resp.url.join(login_location)
+        relay_password = os.environ.get("MCP_RELAY_PASSWORD") or os.environ.get(
+            "RELAY_PW"
+        )
+        assert relay_password, (
+            "GET /authorize redirected to /login; set MCP_RELAY_PASSWORD or RELAY_PW"
+        )
+        next_url = login_url.params.get("next", "/authorize")
+        resp = await http.post(
+            login_url,
+            data={"password": relay_password, "next": next_url},
+            follow_redirects=False,
+        )
+        print(f"[1] POST /login -> {resp.status_code}")
+        assert resp.status_code == 302, resp.text[:300]
+
+        next_location = resp.headers.get("location")
+        assert next_location, "Relay login response is missing next Location"
+        resp = await http.get(resp.url.join(next_location), follow_redirects=False)
+        print(f"[1] GET credential form -> {resp.status_code}")
+
+    assert resp.status_code == 200, resp.text[:300]
+    return resp
+
+
 async def obtain_jwt() -> str:
     verifier, challenge = generate_pkce()
     state = secrets.token_urlsafe(16)
@@ -45,9 +82,9 @@ async def obtain_jwt() -> str:
     client_id = "e2e-test"
 
     async with httpx.AsyncClient(timeout=60) as http:
-        resp = await http.get(
-            f"{BASE_URL}/authorize",
-            params={
+        resp = await _get_authorize_form(
+            http,
+            {
                 "client_id": client_id,
                 "redirect_uri": redirect_uri,
                 "state": state,
@@ -55,8 +92,6 @@ async def obtain_jwt() -> str:
                 "code_challenge_method": "S256",
             },
         )
-        print(f"[1] GET /authorize -> {resp.status_code}")
-        assert resp.status_code == 200, resp.text[:300]
 
         match = re.search(r"/authorize\?nonce=([A-Za-z0-9_\-]+)", resp.text)
         assert match, f"Nonce not found in HTML: {resp.text[:500]}"

--- a/tests/test_cf_full_flow.py
+++ b/tests/test_cf_full_flow.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_HARNESS_SPEC = spec_from_file_location(
+    "cf_full_flow",
+    Path(__file__).parents[1] / "scripts" / "cf_full_flow.py",
+)
+assert _HARNESS_SPEC is not None and _HARNESS_SPEC.loader is not None
+_HARNESS = module_from_spec(_HARNESS_SPEC)
+sys.modules[_HARNESS_SPEC.name] = _HARNESS
+_HARNESS_SPEC.loader.exec_module(_HARNESS)
+
+
+class _FakeSession:
+    def __init__(self, *, duplicate_warning: bool = False) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.next_id = 0
+        self.memories: dict[str, str] = {}
+        self.duplicate_warning = duplicate_warning
+
+    async def initialize(self) -> None:
+        return None
+
+    async def call_tool(self, name: str, arguments: dict):
+        self.calls.append((name, arguments))
+        if name == "add_memory":
+            self.next_id += 1
+            memory_id = f"memory-{self.next_id}"
+            marker = arguments["content"].rsplit(" ", 1)[-1]
+            self.memories[memory_id] = marker
+            payload = {
+                "id": memory_id,
+                "status": "created",
+                "category": "test",
+                "semantic": "test",
+            }
+            if self.duplicate_warning:
+                payload["dedup_warning"] = "duplicate"
+            return SimpleNamespace(
+                content=[SimpleNamespace(text=json.dumps(payload))],
+            )
+
+        if name == "search_memory":
+            marker = arguments["query"]
+            results = [
+                {"id": memory_id, "content": stored_marker}
+                for memory_id, stored_marker in self.memories.items()
+                if stored_marker == marker
+            ]
+            payload = {"count": len(results), "results": results}
+            return SimpleNamespace(
+                content=[SimpleNamespace(text=json.dumps(payload))],
+            )
+
+        if name == "delete_memory":
+            memory_id = arguments["memory_id"]
+            self.memories.pop(memory_id, None)
+            payload = {"status": "deleted", "id": memory_id}
+            return SimpleNamespace(
+                content=[SimpleNamespace(text=json.dumps(payload))],
+            )
+
+        raise AssertionError(f"unexpected tool: {name}")
+
+
+class _FakeTransport:
+    async def __aenter__(self):
+        return None, None, None
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+class _FakeClientSessionContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_run_search_uses_unique_marker_and_deletes_exact_memory():
+    session = _FakeSession()
+
+    first = await _HARNESS._run_search(session)
+    second = await _HARNESS._run_search(session)
+
+    assert first.marker != second.marker
+    assert first.memory_id == "memory-1"
+    assert second.memory_id == "memory-2"
+    assert [name for name, _ in session.calls] == [
+        "add_memory",
+        "search_memory",
+        "delete_memory",
+        "add_memory",
+        "search_memory",
+        "delete_memory",
+    ]
+    assert [
+        arguments["memory_id"]
+        for name, arguments in session.calls
+        if name == "delete_memory"
+    ] == [
+        "memory-1",
+        "memory-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_search_rejects_duplicate_warning_and_cleans_up_exact_memory():
+    session = _FakeSession(duplicate_warning=True)
+
+    with pytest.raises(AssertionError, match="duplicate warning"):
+        await _HARNESS._run_search(session)
+
+    assert [name for name, _ in session.calls] == [
+        "add_memory",
+        "delete_memory",
+    ]
+    assert session.calls[-1][1]["memory_id"] == "memory-1"
+
+
+def test_assert_search_absent_rejects_leaked_marker():
+    _HARNESS._assert_search_absent(
+        json.dumps({"count": 0, "results": []}),
+        "marker",
+    )
+
+    with pytest.raises(AssertionError, match="isolation failure"):
+        _HARNESS._assert_search_absent(
+            json.dumps({"count": 1, "results": [{"content": "marker"}]}),
+            "marker",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_two_sub_isolation_uses_distinct_markers_and_exact_cleanup(
+    monkeypatch,
+):
+    session_a = _FakeSession()
+    session_b = _FakeSession()
+    sessions = {"token-a": session_a, "token-b": session_b}
+    tokens = iter(("token-a", "token-b"))
+
+    monkeypatch.setattr(_HARNESS, "_creds", lambda: {"JINA_API_KEY": "jina"})
+    monkeypatch.setattr(
+        _HARNESS,
+        "get_token",
+        lambda endpoint, creds: next(tokens),
+    )
+    monkeypatch.setattr(
+        _HARNESS,
+        "_sub_of",
+        lambda token: {"token-a": "sub-a", "token-b": "sub-b"}[token],
+    )
+
+    async def fake_session(endpoint: str, token: str):
+        return _FakeTransport(), lambda read, write: _FakeClientSessionContext(
+            sessions[token]
+        )
+
+    monkeypatch.setattr(_HARNESS, "_session", fake_session)
+
+    await _HARNESS.run_two_sub_isolation("https://mnemo.test")
+
+    assert [name for name, _ in session_a.calls] == [
+        "add_memory",
+        "search_memory",
+        "delete_memory",
+    ]
+    assert [name for name, _ in session_b.calls] == [
+        "search_memory",
+        "add_memory",
+        "search_memory",
+        "delete_memory",
+    ]
+    marker_a = session_a.calls[0][1]["content"].rsplit(" ", 1)[-1]
+    marker_b = session_b.calls[1][1]["content"].rsplit(" ", 1)[-1]
+    assert "-isolation-a-" in marker_a
+    assert "-isolation-b-" in marker_b
+    assert marker_a != marker_b
+    assert session_b.calls[-1][1]["memory_id"] == "memory-1"

--- a/tests/test_column_fidelity.py
+++ b/tests/test_column_fidelity.py
@@ -43,6 +43,7 @@ from mnemo_mcp.sync import delta as delta_module
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 _MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
+_MIGRATION_2 = _REPO_ROOT / "migrations" / "0002_per_sub_isolation.sql"
 
 
 def _schema_table_info() -> list[tuple]:
@@ -140,6 +141,7 @@ def db_factory(request, tmp_path):
         else:
             conn = sqlite3.connect(tmp_path / f"d1-{n}.sqlite", isolation_level=None)
             conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+            conn.executescript(_MIGRATION_2.read_text(encoding="utf-8"))
             db = _cf_db(FakeD1Worker(conn))
         created.append(db)
         return db

--- a/tests/test_d1_isolation.py
+++ b/tests/test_d1_isolation.py
@@ -1,0 +1,210 @@
+"""Regression tests for the Cloudflare D1/Vectorize tenant contract."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sqlite3
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from mcp.server.fastmcp import Context
+from test_db_cf import FakeD1Worker
+from test_db_cf_vectors import DIMS, FakeVectorizeWorker
+
+from mnemo_mcp.credential_state import set_current_sub
+from mnemo_mcp.db_cf import MemoryDBCfBackend
+from mnemo_mcp.server import _get_ctx
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_MIGRATION_1 = _REPO_ROOT / "migrations" / "0001_init.sql"
+_MIGRATION_2 = _REPO_ROOT / "migrations" / "0002_per_sub_isolation.sql"
+
+
+def _apply_migrations(conn: sqlite3.Connection) -> None:
+    conn.executescript(_MIGRATION_1.read_text(encoding="utf-8"))
+    conn.executescript(_MIGRATION_2.read_text(encoding="utf-8"))
+
+
+def _memory_row(memory_id: str, content: str) -> dict[str, str]:
+    return {"id": memory_id, "content": content}
+
+
+def _make_backend(
+    conn: sqlite3.Connection,
+    vectors: FakeVectorizeWorker,
+    sub: str,
+) -> MemoryDBCfBackend:
+    from mcp_core.storage.d1 import D1Backend
+    from mcp_core.storage.vectorize import VectorizeBackend
+
+    return MemoryDBCfBackend(
+        D1Backend(base_url="http://d1.internal", http=FakeD1Worker(conn)),
+        vectors=VectorizeBackend(
+            base_url="http://vectorize.internal", idx="mnemo-test", http=vectors
+        ),
+        embedding_dims=DIMS,
+        sub=sub,
+    )
+
+
+def test_fresh_upgrade_schema_is_scoped_and_0001_stays_legacy(tmp_path):
+    """A fresh 0001 database becomes scoped only through the additive upgrade."""
+    conn = sqlite3.connect(tmp_path / "fresh.sqlite", isolation_level=None)
+    _apply_migrations(conn)
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(memories)").fetchall()}
+    assert "sub" in columns
+    assert (
+        conn.execute("SELECT sub FROM memories WHERE id = ?", ("missing",)).fetchone()
+        is None
+    )
+
+    conn.execute(
+        "INSERT INTO memories (sub, id, content, created_at, updated_at, last_accessed) "
+        "VALUES (?, ?, ?, datetime('now'), datetime('now'), datetime('now'))",
+        ("sub-a", "same-id", "A"),
+    )
+    conn.execute(
+        "INSERT INTO memories (sub, id, content, created_at, updated_at, last_accessed) "
+        "VALUES (?, ?, ?, datetime('now'), datetime('now'), datetime('now'))",
+        ("sub-b", "same-id", "B"),
+    )
+    assert conn.execute(
+        "SELECT sub, content FROM memories WHERE id = ? ORDER BY sub", ("same-id",)
+    ).fetchall() == [("sub-a", "A"), ("sub-b", "B")]
+
+
+def test_upgrade_preserves_0001_rows_under_default_sub(tmp_path):
+    """Rows present before 0002 remain readable and are explicitly default-scoped."""
+    conn = sqlite3.connect(tmp_path / "upgrade.sqlite", isolation_level=None)
+    conn.executescript(_MIGRATION_1.read_text(encoding="utf-8"))
+    conn.execute(
+        "INSERT INTO memories (id, content, created_at, updated_at, last_accessed) "
+        "VALUES (?, ?, datetime('now'), datetime('now'), datetime('now'))",
+        ("legacy-id", "legacy content"),
+    )
+    conn.executescript(_MIGRATION_2.read_text(encoding="utf-8"))
+
+    assert conn.execute(
+        "SELECT sub, content FROM memories WHERE id = ?", ("legacy-id",)
+    ).fetchone() == ("default", "legacy content")
+
+
+def test_d1_backend_cannot_read_another_subs_rows(tmp_path):
+    """D1 reads and Vectorize candidates are both restricted to the request sub."""
+    conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
+    _apply_migrations(conn)
+    vectors = FakeVectorizeWorker()
+    sub_a = _make_backend(conn, vectors, "sub-a")
+    sub_b = _make_backend(conn, vectors, "sub-b")
+
+    shared_a = sub_a.import_jsonl(json.dumps(_memory_row("same-id", "alpha secret")))
+    shared_b = sub_b.import_jsonl(json.dumps(_memory_row("same-id", "beta secret")))
+    assert shared_a["imported"] == 1
+    assert shared_b["imported"] == 1
+
+    a_id = sub_a.add("alpha vector secret", embedding=[1.0] + [0.0] * (DIMS - 1))
+    b_id = sub_b.add("beta vector secret", embedding=[0.0, 1.0] + [0.0] * (DIMS - 2))
+    vectors.settle()
+
+    row_a = sub_a.get("same-id")
+    row_b = sub_b.get("same-id")
+    assert row_a is not None
+    assert row_b is not None
+    assert row_a["content"] == "alpha secret"
+    assert row_b["content"] == "beta secret"
+    assert sub_a.get(b_id) is None
+    assert sub_b.get(a_id) is None
+    assert {row["content"] for row in sub_a.list_memories()} == {
+        "alpha secret",
+        "alpha vector secret",
+    }
+    assert {row["content"] for row in sub_b.list_memories()} == {
+        "beta secret",
+        "beta vector secret",
+    }
+    assert all(
+        row["content"] != "beta vector secret"
+        for row in sub_a.search(
+            "unmatched vector query", embedding=[0.0, 1.0] + [0.0] * (DIMS - 2)
+        )
+    )
+    assert all(
+        request[2].get("filter") == {"sub": "sub-a"}
+        for request in vectors.requests
+        if request[0] == "POST" and request[1] == "/query"
+    )
+
+
+def test_server_binds_request_sub_to_a_fresh_backend(monkeypatch, tmp_path):
+    """The HTTP request context, not Worker comments, chooses the D1 scope."""
+    conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
+    _apply_migrations(conn)
+    base = _make_backend(conn, FakeVectorizeWorker(), "default")
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context={
+                "db": base,
+                "embedding_model": None,
+                "embedding_dims": DIMS,
+            }
+        )
+    )
+    monkeypatch.setenv("PUBLIC_URL", "https://mnemo.example")
+
+    set_current_sub("sub-a")
+    try:
+        scoped, _, _ = _get_ctx(cast(Context, ctx))
+        assert scoped is not base
+        assert scoped.sub == "sub-a"
+    finally:
+        set_current_sub(None)
+
+    with pytest.raises(RuntimeError, match="JWT sub"):
+        _get_ctx(cast(Context, ctx))
+
+
+def test_temporal_graph_updates_use_the_d1_query_only_route(tmp_path):
+    """Bitemporal edge backfills stay on the Worker's supported /query route."""
+    from mnemo_mcp.temporal.store import store_kg_with_memory_id
+
+    conn = sqlite3.connect(tmp_path / "temporal.sqlite", isolation_level=None)
+    _apply_migrations(conn)
+    worker = FakeD1Worker(conn)
+    from mcp_core.storage.d1 import D1Backend
+    from mcp_core.storage.vectorize import VectorizeBackend
+
+    db = MemoryDBCfBackend(
+        D1Backend(base_url="http://d1.internal", http=worker),
+        vectors=VectorizeBackend(
+            base_url="http://vectorize.internal",
+            idx="mnemo-test",
+            http=FakeVectorizeWorker(),
+        ),
+        embedding_dims=DIMS,
+        sub="sub-a",
+    )
+
+    result = store_kg_with_memory_id(
+        db._conn,
+        "memory-temporal",
+        {
+            "entities": [
+                {"name": "Alice", "type": "person"},
+                {"name": "Mnemo", "type": "tool"},
+            ],
+            "relations": [{"source": "Alice", "target": "Mnemo", "type": "uses"}],
+        },
+    )
+
+    assert result == {"entities": 2, "edges": 1, "links": 2}
+    row = conn.execute("SELECT sub, memory_id, valid_from FROM memory_edges").fetchone()
+    assert row is not None
+    assert row[0:2] == ("sub-a", "memory-temporal")
+    assert row[2]
+    assert worker.requests
+    assert all(
+        method == "POST" and path == "/query" for method, path, _ in worker.requests
+    )

--- a/tests/test_d1_isolation.py
+++ b/tests/test_d1_isolation.py
@@ -138,6 +138,92 @@ def test_d1_backend_cannot_read_another_subs_rows(tmp_path):
     )
 
 
+def test_d1_vector_search_rejects_foreign_vector_id_with_matching_metadata(tmp_path):
+    """A matching Vectorize tenant filter cannot authorize a foreign ID prefix."""
+    conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
+    _apply_migrations(conn)
+    vectors = FakeVectorizeWorker()
+    db = _make_backend(conn, vectors, "sub-a")
+
+    assert (
+        db.import_jsonl(json.dumps(_memory_row("same-id", "alpha secret")))["imported"]
+        == 1
+    )
+    vectors.visible["sub-b:same-id"] = [1.0] + [0.0] * (DIMS - 1)
+    vectors.visible_metadata["sub-b:same-id"] = {"sub": "sub-a"}
+
+    assert (
+        db.search(
+            "unmatched vector query",
+            embedding=[1.0] + [0.0] * (DIMS - 1),
+            candidate_pool=1,
+        )
+        == []
+    )
+    conn.close()
+
+
+def test_d1_related_memory_ids_stay_within_sub(tmp_path):
+    """Recursive graph traversal must not follow another sub's same-ID edges."""
+    from mnemo_mcp.graph import (
+        create_relations,
+        find_related_memory_ids,
+        link_memory_entities,
+        upsert_entities,
+    )
+
+    conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
+    _apply_migrations(conn)
+    sub_a = _make_backend(conn, FakeVectorizeWorker(), "sub-a")
+    sub_b = _make_backend(conn, FakeVectorizeWorker(), "sub-b")
+
+    for db, source_id, related_id in (
+        (sub_a, "a-source", "a-related"),
+        (sub_b, "b-source", "b-related"),
+    ):
+        assert (
+            db.import_jsonl(json.dumps(_memory_row(source_id, source_id)))["imported"]
+            == 1
+        )
+        assert (
+            db.import_jsonl(json.dumps(_memory_row(related_id, related_id)))["imported"]
+            == 1
+        )
+
+    entity_ids = upsert_entities(
+        sub_a._conn,
+        [
+            {"name": "Alice", "type": "person"},
+            {"name": "Mnemo", "type": "tool"},
+        ],
+    )
+    for entity_id, name, entity_type in zip(
+        entity_ids,
+        ("Alice", "Mnemo"),
+        ("person", "tool"),
+        strict=True,
+    ):
+        sub_b._conn.execute(
+            "INSERT INTO memory_entities "
+            "(id, name, entity_type, created_at, updated_at) "
+            "VALUES (?, ?, ?, datetime('now'), datetime('now'))",
+            [entity_id, name, entity_type],
+        )
+
+    relations = [{"source": "Alice", "target": "Mnemo", "type": "uses"}]
+    entity_name_to_id = {"Alice": entity_ids[0], "Mnemo": entity_ids[1]}
+    create_relations(sub_a._conn, relations, entity_name_to_id)
+    create_relations(sub_b._conn, relations, entity_name_to_id)
+    link_memory_entities(sub_a._conn, "a-source", [entity_ids[0]])
+    link_memory_entities(sub_a._conn, "a-related", [entity_ids[1]])
+    link_memory_entities(sub_b._conn, "b-source", [entity_ids[0]])
+    link_memory_entities(sub_b._conn, "b-related", [entity_ids[1]])
+
+    assert find_related_memory_ids(sub_a._conn, "a-source") == ["a-related"]
+    assert find_related_memory_ids(sub_b._conn, "b-source") == ["b-related"]
+    conn.close()
+
+
 def test_server_binds_request_sub_to_a_fresh_backend(monkeypatch, tmp_path):
     """The HTTP request context, not Worker comments, chooses the D1 scope."""
     conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)

--- a/tests/test_db_cf.py
+++ b/tests/test_db_cf.py
@@ -13,7 +13,8 @@ How the D1 side is exercised
 implements that transport by transcribing ``src/worker.ts``'s ``d1Outbound``
 handler -- ``POST /query`` runs ``prepare(sql).bind(...params).all()`` and
 answers ``Response.json({ results })``; every other route 404s -- against a real
-SQLite database that has ``migrations/0001_init.sql`` applied.
+SQLite database that has ``migrations/0001_init.sql`` and the additive
+``migrations/0002_per_sub_isolation.sql`` applied.
 
 What that reproduces faithfully: the SQL text and bound parameters actually sent,
 the JSON request/response envelope, rows as JSON objects, one statement per
@@ -60,6 +61,7 @@ from mnemo_mcp.exceptions import EmbeddingModelMismatch
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 _MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
+_MIGRATION_2 = _REPO_ROOT / "migrations" / "0002_per_sub_isolation.sql"
 _WORKER_TS = _REPO_ROOT / "src" / "worker.ts"
 
 
@@ -109,6 +111,7 @@ def d1_conn(tmp_path) -> sqlite3.Connection:
         tmp_path / "d1.sqlite", isolation_level=None, check_same_thread=False
     )
     conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+    conn.executescript(_MIGRATION_2.read_text(encoding="utf-8"))
     return conn
 
 
@@ -597,22 +600,26 @@ class TestVectorPathIsLoud:
 
 
 class TestUnavailableSurface:
-    """Methods this backend cannot serve raise and say what is missing."""
+    """Exercise the deliberately unavailable D1 transaction surface."""
 
-    def test_get_sync_state_raises(self, cf_db):
-        with pytest.raises(NotImplementedError, match="sync_state"):
-            cf_db.get_sync_state("gdrive")
+    def test_get_sync_state_reads_the_scoped_row(self, cf_db):
+        assert cf_db.get_sync_state("gdrive") is None
 
-    def test_upsert_sync_state_raises(self, cf_db):
-        with pytest.raises(NotImplementedError, match="sync_state"):
-            cf_db.upsert_sync_state("gdrive", last_sync_at=1.0)
+    def test_upsert_sync_state_writes_the_scoped_row(self, cf_db):
+        cf_db.upsert_sync_state("gdrive", last_sync_at=1.0)
+        assert cf_db.get_sync_state("gdrive") == {
+            "backend": "gdrive",
+            "last_sync_at": 1.0,
+            "last_commit_sha": None,
+            "upload_cursor": None,
+        }
 
-    def test_sync_state_is_genuinely_absent_from_the_d1_schema(self, d1_conn):
-        """The NotImplementedError above states a fact; check the fact."""
+    def test_sync_state_is_present_in_the_d1_schema(self, d1_conn):
+        """The tenant-scoped migration owns the sync-state table."""
         names = {
             r[0] for r in d1_conn.execute("SELECT name FROM sqlite_master").fetchall()
         }
-        assert "sync_state" not in names
+        assert "sync_state" in names
         assert "memories" in names
 
     def test_rollback_is_not_silently_a_noop(self, cf_db):
@@ -784,9 +791,14 @@ class TestStatusNamesTheStoreItRead:
 
     async def test_cf_d1_status_names_d1_not_a_sqlite_file(self, cf_db):
         from mnemo_mcp.config import settings
+        from mnemo_mcp.credential_state import set_current_sub
         from mnemo_mcp.server import _handle_config_status
 
-        status = await _handle_config_status(self._ctx(cf_db))
+        set_current_sub("status-test")
+        try:
+            status = await _handle_config_status(self._ctx(cf_db))
+        finally:
+            set_current_sub(None)
         assert status["database"]["path"] == "cf-d1:http://d1.internal"
         # The regression this pins: the SQLite path from settings, which a D1
         # deployment never opens.
@@ -798,11 +810,20 @@ class TestStatusNamesTheStoreItRead:
         ``memory_stats`` and ``config status`` read the same store in the same
         process, so they may not name two different ones.
         """
+        from mnemo_mcp.credential_state import set_current_sub
+        from mnemo_mcp.db_cf import MemoryDBCfBackend
         from mnemo_mcp.server import _handle_config_status, _handle_stats
 
-        ctx = self._ctx(either_db)
-        status = await _handle_config_status(ctx)
-        stats = await _handle_stats(ctx)
+        is_cf = isinstance(either_db, MemoryDBCfBackend)
+        if is_cf:
+            set_current_sub("status-test")
+        try:
+            ctx = self._ctx(either_db)
+            status = await _handle_config_status(ctx)
+            stats = await _handle_stats(ctx)
+        finally:
+            if is_cf:
+                set_current_sub(None)
         assert status["database"]["path"] == stats["db_path"]
         assert status["database"]["total_memories"] == stats["total_memories"]
 

--- a/tests/test_db_cf_vectors.py
+++ b/tests/test_db_cf_vectors.py
@@ -36,7 +36,8 @@ of by sleeping, and a ``fail_delete`` switch so the read-side supersession filte
 can be tested with the write-side deliberately broken. What it does not
 reproduce: Cloudflare's actual ANN recall (the double is an exact cosine scan, so
 ranking is exact where production is approximate), real propagation timing, and
-metadata-filter behaviour -- which the backend never uses, by design.
+metadata-filter behaviour -- the latter is exercised by the tenant-isolation
+regression tests.
 """
 
 from __future__ import annotations
@@ -62,6 +63,7 @@ from mnemo_mcp.exceptions import EmbeddingModelMismatch
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 _MIGRATION = _REPO_ROOT / "migrations" / "0001_init.sql"
+_MIGRATION_2 = _REPO_ROOT / "migrations" / "0002_per_sub_isolation.sql"
 _WORKER_TS = _REPO_ROOT / "src" / "worker.ts"
 
 # Test vectors are 8-wide for readability. `test_wire_carries_full_width_vector`
@@ -99,6 +101,8 @@ class FakeVectorizeWorker:
     def __init__(self, *, settle_immediately: bool = True) -> None:
         self.visible: dict[str, list[float]] = {}
         self.pending: dict[str, list[float]] = {}
+        self.visible_metadata: dict[str, dict] = {}
+        self.pending_metadata: dict[str, dict] = {}
         self.settle_immediately = settle_immediately
         self.fail_delete = False
         self.requests: list[tuple[str, str, object]] = []
@@ -106,7 +110,9 @@ class FakeVectorizeWorker:
     def settle(self) -> None:
         """Make every pending upsert queryable, as Vectorize eventually does."""
         self.visible.update(self.pending)
+        self.visible_metadata.update(self.pending_metadata)
         self.pending.clear()
+        self.pending_metadata.clear()
 
     def request(self, method, url, data=None, headers=None):
         path = urlparse(url).path
@@ -116,20 +122,41 @@ class FakeVectorizeWorker:
             vectors = [json.loads(line) for line in data.decode().split("\n") if line]
             self.requests.append((method, path, vectors))
             target = self.visible if self.settle_immediately else self.pending
+            metadata_target = (
+                self.visible_metadata
+                if self.settle_immediately
+                else self.pending_metadata
+            )
             for vector in vectors:
                 target[vector["id"]] = vector["values"]
+                metadata_target[vector["id"]] = vector.get("metadata") or {}
             return (200, json.dumps({"mutationId": "m-upsert"}).encode())
 
         if method == "POST" and path == "/query":
             payload = json.loads(data.decode())
             self.requests.append((method, path, payload))
             vector, top_k = payload["vector"], payload["topK"]
+            metadata_filter = payload.get("filter") or {}
             ranked = sorted(
-                ((mid, _cosine(vector, v)) for mid, v in self.visible.items()),
+                (
+                    (mid, _cosine(vector, v))
+                    for mid, v in self.visible.items()
+                    if all(
+                        self.visible_metadata.get(mid, {}).get(key) == value
+                        for key, value in metadata_filter.items()
+                    )
+                ),
                 key=lambda kv: kv[1],
                 reverse=True,
             )
-            matches = [{"id": m, "score": s} for m, s in ranked[:top_k]]
+            matches = [
+                {
+                    "id": m,
+                    "score": s,
+                    "metadata": self.visible_metadata.get(m, {}),
+                }
+                for m, s in ranked[:top_k]
+            ]
             return (200, json.dumps({"matches": matches}).encode())
 
         if method == "POST" and path == "/deleteByIds":
@@ -140,6 +167,8 @@ class FakeVectorizeWorker:
             for mid in payload["ids"]:
                 self.visible.pop(mid, None)
                 self.pending.pop(mid, None)
+                self.visible_metadata.pop(mid, None)
+                self.pending_metadata.pop(mid, None)
             return (200, json.dumps({"mutationId": "m-delete"}).encode())
 
         self.requests.append((method, path, None))
@@ -175,6 +204,7 @@ class FakeD1Worker:
 def fake_worker(tmp_path) -> FakeD1Worker:
     conn = sqlite3.connect(tmp_path / "d1.sqlite", isolation_level=None)
     conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+    conn.executescript(_MIGRATION_2.read_text(encoding="utf-8"))
     return FakeD1Worker(conn)
 
 
@@ -290,7 +320,7 @@ class TestVectorWiring:
 
     def test_add_upserts_the_vector_under_the_memory_id(self, cf_db, fake_vectorize):
         mid = cf_db.add("Python is a programming language", embedding=_unit(0))
-        assert fake_vectorize.visible == {mid: _unit(0)}
+        assert fake_vectorize.visible == {cf_db._vectorize_id(mid): _unit(0)}
 
     def test_search_finds_a_memory_by_vector_alone(self, cf_db):
         """Text the FTS index cannot match; only the vector arm can answer.
@@ -313,7 +343,7 @@ class TestVectorWiring:
         mid = cf_db.add_with_context_type(
             "User prefers dark mode", context_type="preference", embedding=_unit(2)
         )
-        assert fake_vectorize.visible[mid] == _unit(2)
+        assert fake_vectorize.visible[cf_db._vectorize_id(mid)] == _unit(2)
 
     def test_hybrid_search_fuses_both_arms(self, cf_db):
         """Both arms contribute; the fused list is the borrowed RRF's output."""
@@ -341,14 +371,17 @@ class TestVectorWiring:
         """768 is what the live store's ``store_meta`` records."""
         db = _cf_db(fake_worker, fake_vectorize, embedding_dims=768)
         mid = db.add("real-width vector", embedding=[0.5] * 768)
-        assert len(fake_vectorize.visible[mid]) == 768
+        assert len(fake_vectorize.visible[db._vectorize_id(mid)]) == 768
 
     def test_oversized_vector_is_reshaped_like_sqlite(self, cf_db, fake_vectorize):
         """``db._serialize_f32`` truncates/pads; parity means doing the same."""
         long_id = cf_db.add("too long", embedding=[1.0] * (DIMS + 4))
         short_id = cf_db.add("too short", embedding=[1.0, 1.0])
-        assert fake_vectorize.visible[long_id] == [1.0] * DIMS
-        assert fake_vectorize.visible[short_id] == [1.0, 1.0] + [0.0] * (DIMS - 2)
+        assert fake_vectorize.visible[cf_db._vectorize_id(long_id)] == [1.0] * DIMS
+        assert fake_vectorize.visible[cf_db._vectorize_id(short_id)] == [
+            1.0,
+            1.0,
+        ] + [0.0] * (DIMS - 2)
 
     def test_vec_enabled_reflects_the_attached_index(self, cf_db, fake_worker):
         assert cf_db.vec_enabled is True
@@ -565,7 +598,9 @@ class TestSupersededRowsStayGone:
         fake_vectorize.fail_delete = True
 
         assert cf_db.delete(mid) is True
-        assert mid in fake_vectorize.visible, "precondition: the vector must survive"
+        assert cf_db._vectorize_id(mid) in fake_vectorize.visible, (
+            "precondition: the vector must survive"
+        )
         assert "[AUDIT]" in _messages(captured_logs, "ERROR")
 
         assert cf_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
@@ -588,7 +623,9 @@ class TestSupersededRowsStayGone:
         fake_vectorize.fail_delete = True
         new_id = cf_db.update(old_id, content="Python is a great language")
 
-        assert old_id in fake_vectorize.visible, "precondition: the vector survives"
+        assert cf_db._vectorize_id(old_id) in fake_vectorize.visible, (
+            "precondition: the vector survives"
+        )
         assert new_id is not None
         assert cf_db.search("zzzz-unmatchable-token", embedding=_unit(0)) == []
 
@@ -598,7 +635,7 @@ class TestSupersededRowsStayGone:
         old_id = cf_db.add("Python is a programming language", embedding=_unit(0))
         new_id = cf_db.update(old_id, content="Python rules", embedding=_unit(1))
 
-        assert fake_vectorize.visible == {new_id: _unit(1)}
+        assert fake_vectorize.visible == {cf_db._vectorize_id(new_id): _unit(1)}
         hits = cf_db.search("zzzz-unmatchable-token", embedding=_unit(1))
         assert [h["id"] for h in hits] == [new_id]
 
@@ -725,7 +762,7 @@ class TestReplaceImportClearsVectors:
     def test_merge_import_keeps_vectors(self, cf_db, fake_vectorize):
         mid = cf_db.add("Python is a programming language", embedding=_unit(0))
         cf_db.import_jsonl(json.dumps({"id": "extra", "content": "another row"}))
-        assert fake_vectorize.visible == {mid: _unit(0)}
+        assert fake_vectorize.visible == {cf_db._vectorize_id(mid): _unit(0)}
 
 
 class TestVectorParityWithSqlite:

--- a/tests/test_deploy_cf.py
+++ b/tests/test_deploy_cf.py
@@ -1,0 +1,150 @@
+"""Focused tests for the Cloudflare deployment harness."""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "deploy_cf.py"
+_SPEC = importlib.util.spec_from_file_location("deploy_cf", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+deploy_cf = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(deploy_cf)
+
+
+def test_wrangler_env_maps_dev_token_without_leaking_source_alias() -> None:
+    source = {
+        "PATH": "test-path",
+        "CF_DEV_TOKEN": "dev-token-value",
+    }
+
+    result = deploy_cf._wrangler_env(source)
+
+    assert result["CLOUDFLARE_API_TOKEN"] == "dev-token-value"
+    assert "CF_DEV_TOKEN" not in result
+    assert source == {
+        "PATH": "test-path",
+        "CF_DEV_TOKEN": "dev-token-value",
+    }
+
+
+def test_wrangler_env_preserves_explicit_api_token() -> None:
+    result = deploy_cf._wrangler_env(
+        {
+            "CLOUDFLARE_API_TOKEN": "explicit-token",
+            "CF_DEV_TOKEN": "fallback-token",
+        }
+    )
+
+    assert result["CLOUDFLARE_API_TOKEN"] == "explicit-token"
+    assert "CF_DEV_TOKEN" not in result
+
+
+def test_run_wrangler_passes_mapped_env_without_printing_token(capsys) -> None:
+    with (
+        patch.dict(
+            deploy_cf.os.environ,
+            {"CF_DEV_TOKEN": "secret-token"},
+            clear=True,
+        ),
+        patch.object(deploy_cf.subprocess, "run") as run,
+    ):
+        deploy_cf._run_wrangler(["deploy"], dry=False)
+
+    assert run.call_args.kwargs["env"]["CLOUDFLARE_API_TOKEN"] == "secret-token"
+    output = capsys.readouterr().out
+    assert "secret-token" not in output
+
+
+def test_wait_ready_passes_mapped_env_to_containers_list(monkeypatch) -> None:
+    monkeypatch.setenv("CF_DEV_TOKEN", "secret-token")
+    run = MagicMock(
+        return_value=subprocess.CompletedProcess(
+            args=["bunx", "wrangler", "containers", "list"],
+            returncode=0,
+            stdout="mnemo ready",
+        )
+    )
+    monkeypatch.setattr(deploy_cf.subprocess, "run", run)
+
+    deploy_cf._wait_ready("mnemo", dry=False, timeout_s=1)
+
+    assert run.call_args.kwargs["env"]["CLOUDFLARE_API_TOKEN"] == "secret-token"
+    assert "CF_DEV_TOKEN" not in run.call_args.kwargs["env"]
+
+
+def test_main_routes_push_and_deploy_through_wrangler_runner(monkeypatch) -> None:
+    cfg = {
+        "name": "mnemo",
+        "containers": [
+            {"image": "registry.cloudflare.com/0123456789abcdef/mnemo:previous"}
+        ],
+        "vars": {"PUBLIC_URL": "https://mnemo.example"},
+    }
+    run = MagicMock()
+    wrangler = MagicMock()
+    wait_ready = MagicMock()
+
+    monkeypatch.setenv("CF_DEV_TOKEN", "secret-token")
+    monkeypatch.setattr(deploy_cf, "_load_deploy_config", lambda repo: cfg)
+    monkeypatch.setattr(deploy_cf, "_run", run)
+    monkeypatch.setattr(deploy_cf, "_run_wrangler", wrangler)
+    monkeypatch.setattr(deploy_cf, "_wait_ready", wait_ready)
+    monkeypatch.setattr(deploy_cf, "_set_image_tag", MagicMock())
+
+    assert deploy_cf.main(["--skip-build", "--no-canary", "--tag", "b-test"]) == 0
+
+    assert wrangler.call_args_list == [
+        call(
+            [
+                "containers",
+                "push",
+                "registry.cloudflare.com/0123456789abcdef/mnemo:b-test",
+            ],
+            dry=False,
+            cwd=deploy_cf.Path(__file__).resolve().parent.parent,
+        ),
+        call(
+            ["deploy", "--config", deploy_cf.DEPLOY_CONFIG],
+            dry=False,
+            cwd=deploy_cf.Path(__file__).resolve().parent.parent,
+        ),
+    ]
+    wait_ready.assert_called_once_with("mnemo", dry=False)
+    run.assert_called_once_with(
+        [
+            "docker",
+            "tag",
+            "mnemo:b-test",
+            "registry.cloudflare.com/0123456789abcdef/mnemo:b-test",
+        ],
+        dry=False,
+    )
+
+
+def test_rollback_routes_deploy_through_wrangler_runner(monkeypatch) -> None:
+    set_image = MagicMock()
+    wrangler = MagicMock()
+    wait_ready = MagicMock()
+
+    monkeypatch.setattr(deploy_cf, "_set_image_tag", set_image)
+    monkeypatch.setattr(deploy_cf, "_run_wrangler", wrangler)
+    monkeypatch.setattr(deploy_cf, "_wait_ready", wait_ready)
+
+    deploy_cf._rollback(
+        deploy_cf.Path("C:/repo"),
+        "mnemo",
+        "registry.cloudflare.com/0123456789abcdef/mnemo:previous",
+        dry=False,
+    )
+
+    set_image.assert_called_once_with(
+        deploy_cf.Path("C:/repo"),
+        "registry.cloudflare.com/0123456789abcdef/mnemo:previous",
+    )
+    wrangler.assert_called_once_with(
+        ["deploy", "--config", deploy_cf.DEPLOY_CONFIG],
+        dry=False,
+        cwd=deploy_cf.Path("C:/repo"),
+    )
+    wait_ready.assert_called_once_with("mnemo", dry=False)

--- a/tests/test_e2e_protocol_auth_flow.py
+++ b/tests/test_e2e_protocol_auth_flow.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from urllib.parse import parse_qs, quote
+
+import httpx
+import pytest
+
+_HARNESS_SPEC = spec_from_file_location(
+    "e2e_mcp_protocol_test", Path(__file__).with_name("e2e_mcp_protocol_test.py")
+)
+assert _HARNESS_SPEC and _HARNESS_SPEC.loader
+harness = module_from_spec(_HARNESS_SPEC)
+_HARNESS_SPEC.loader.exec_module(harness)
+
+
+def _response(
+    request: httpx.Request,
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
+    json: object | None = None,
+    text: str | None = None,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        headers=headers,
+        json=json,
+        text=text,
+        request=request,
+    )
+
+
+@pytest.mark.parametrize("password_env", ["MCP_RELAY_PASSWORD", "RELAY_PW"])
+async def test_obtain_jwt_handles_relay_login_redirect(
+    monkeypatch: pytest.MonkeyPatch, password_env: str
+) -> None:
+    monkeypatch.setattr(harness, "BASE_URL", "https://mnemo.test")
+    monkeypatch.setenv(password_env, "test-relay-password")
+    if password_env == "MCP_RELAY_PASSWORD":
+        monkeypatch.delenv("RELAY_PW", raising=False)
+    else:
+        monkeypatch.delenv("MCP_RELAY_PASSWORD", raising=False)
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "GET" and request.url.path == "/authorize":
+            if "mcp_relay_session=fixture-session" not in request.headers.get(
+                "cookie", ""
+            ):
+                next_url = quote(str(request.url), safe="")
+                return _response(
+                    request,
+                    302,
+                    headers={"location": f"/login?next={next_url}"},
+                )
+            return _response(
+                request,
+                200,
+                text='<script>fetch("/authorize?nonce=redirect-nonce")</script>',
+            )
+
+        if request.method == "POST" and request.url.path == "/login":
+            form = parse_qs(request.content.decode())
+            assert form["password"] == ["test-relay-password"]
+            assert form["next"]
+            next_url = form["next"][0]
+            return _response(
+                request,
+                302,
+                headers={
+                    "location": next_url,
+                    "set-cookie": "mcp_relay_session=fixture-session; Path=/",
+                },
+            )
+
+        if request.method == "POST" and request.url.path == "/authorize":
+            assert request.url.params["nonce"] == "redirect-nonce"
+            assert json.loads(request.content) == {"JINA_AI_API_KEY": "fixture-key"}
+            return _response(
+                request,
+                200,
+                json={
+                    "redirect_url": "http://localhost:9999/cb?code=redirect-code&state=state"
+                },
+            )
+
+        if request.method == "POST" and request.url.path == "/token":
+            body = parse_qs(request.content.decode())
+            assert body["code"] == ["redirect-code"]
+            return _response(request, 200, json={"access_token": "fixture-jwt"})
+
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client_class = httpx.AsyncClient
+    with monkeypatch.context() as ctx:
+        ctx.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: client_class(transport=transport, **kwargs),
+        )
+        with pytest.MonkeyPatch.context() as config_patch:
+            config_patch.setattr(
+                "mcp_core.storage.config_file.read_config",
+                lambda _server_name: {"JINA_AI_API_KEY": "fixture-key"},
+            )
+            assert await harness.obtain_jwt() == "fixture-jwt"
+
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/authorize"),
+        ("POST", "/login"),
+        ("GET", "/authorize"),
+        ("POST", "/authorize"),
+        ("POST", "/token"),
+    ]
+
+
+async def test_obtain_jwt_preserves_direct_authorize_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(harness, "BASE_URL", "https://mnemo.test")
+    monkeypatch.delenv("MCP_RELAY_PASSWORD", raising=False)
+    monkeypatch.delenv("RELAY_PW", raising=False)
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "GET" and request.url.path == "/authorize":
+            return _response(
+                request,
+                200,
+                text='<script>fetch("/authorize?nonce=direct-nonce")</script>',
+            )
+        if request.method == "POST" and request.url.path == "/authorize":
+            assert request.url.params["nonce"] == "direct-nonce"
+            return _response(
+                request,
+                200,
+                json={
+                    "redirect_url": "http://localhost:9999/cb?code=direct-code&state=state"
+                },
+            )
+        if request.method == "POST" and request.url.path == "/token":
+            body = parse_qs(request.content.decode())
+            assert body["code"] == ["direct-code"]
+            return _response(request, 200, json={"access_token": "fixture-jwt"})
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client_class = httpx.AsyncClient
+    with monkeypatch.context() as ctx:
+        ctx.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kwargs: client_class(transport=transport, **kwargs),
+        )
+        with pytest.MonkeyPatch.context() as config_patch:
+            config_patch.setattr(
+                "mcp_core.storage.config_file.read_config",
+                lambda _server_name: {"JINA_AI_API_KEY": "fixture-key"},
+            )
+            assert await harness.obtain_jwt() == "fixture-jwt"
+
+    assert [request.url.path for request in requests] == [
+        "/authorize",
+        "/authorize",
+        "/token",
+    ]

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -19,6 +19,11 @@ from mnemo_mcp.server import lifespan
 _MIGRATION = (
     pathlib.Path(__file__).resolve().parent.parent / "migrations" / "0001_init.sql"
 )
+_MIGRATION_2 = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "migrations"
+    / "0002_per_sub_isolation.sql"
+)
 
 
 @pytest.fixture
@@ -268,6 +273,7 @@ class TestStartupLogNamesTheStoreItRead:
             tmp_path / "d1.sqlite", isolation_level=None, check_same_thread=False
         )
         conn.executescript(_MIGRATION.read_text(encoding="utf-8"))
+        conn.executescript(_MIGRATION_2.read_text(encoding="utf-8"))
         monkeypatch.setenv("MEMORY_DB_BACKEND", "cf-d1")
         monkeypatch.setattr(
             "mnemo_mcp.db_cf.d1_backend_from_env",

--- a/tests/test_server_setup_actions.py
+++ b/tests/test_server_setup_actions.py
@@ -47,9 +47,15 @@ class TestSetupStatus:
         ctx, _ = ctx_with_db
         set_state(CredentialState.CONFIGURED)
 
-        with patch(
-            "mnemo_mcp.credential_state.get_setup_url",
-            return_value="https://setup.url",
+        with (
+            patch(
+                "mnemo_mcp.credential_state.get_setup_url",
+                return_value="https://setup.url",
+            ),
+            patch(
+                "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+                return_value={"GEMINI_API_KEY": "test-key"},
+            ),
         ):
             result = await config(action="setup_status", ctx=ctx)
 

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -261,6 +261,27 @@ class TestRunWarmup:
         assert len(result["steps"]) == 1
         assert result["steps"][0]["status"] == "ok"
 
+    @patch("mnemo_mcp.setup_tool._download_local_embedding")
+    @patch("mnemo_mcp.setup_tool.settings")
+    async def test_local_embedding_disabled_skips_download(
+        self, mock_settings, mock_download
+    ):
+        from mnemo_mcp.setup_tool import run_warmup
+
+        mock_settings.setup_api_keys.return_value = {}
+        mock_settings.disable_local_embed = True
+
+        result = await run_warmup()
+
+        mock_download.assert_not_called()
+        assert result["status"] == "ok"
+        assert result["mode"] == "unavailable"
+        local_step = next(
+            step for step in result["steps"] if step["step"] == "local_embedding"
+        )
+        assert local_step["status"] == "skipped"
+        assert "disabled" in local_step["message"].lower()
+
     @patch("qwen3_embed.TextEmbedding")
     @patch("mnemo_mcp.embedder.init_backend")
     @patch("mnemo_mcp.setup_tool.settings")


### PR DESCRIPTION
## Description
Repair the Cloudflare-backed Mnemo workflow with per-subject D1 and Vectorize isolation, deploy credential mapping, and authenticated end-to-end harness coverage.

## Changes
- Add additive D1 migration and fail-closed request-sub scoping across memory, graph, temporal, sync, and Vectorize paths.
- Harden the Cloudflare full-flow harness and relay redirect authentication helper.
- Map skret's CF_DEV_TOKEN into Wrangler without leaking the source alias.
- Add regression tests for isolation, auth flow, deployment mapping, and full-flow cleanup.

## Testing
- Local pre-commit hook passed: gitleaks, ruff, ty, pytest.
- Focused isolation and Cloudflare suites passed: 202 tests.
- Full collection passed: 1642/1720 tests collected, 78 deselected.
- Remaining live-only stdio tests are excluded from the default profile.

## Checklist
- [x] Existing tests pass
- [x] Added new tests for the changes
- [x] Tested manually